### PR TITLE
修复docker部署的 Python 依赖缺失、统一时区并改进 Docker Compose 挂载

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # 使用官方 Node.js 18 Alpine 镜像作为基础镜像
 FROM node:18-alpine
+# FROM docker.mirrors.tuna.tsinghua.edu.cn/library/node:18-alpine
 
 # 设置工作目录
 WORKDIR /usr/src/app
@@ -10,8 +11,34 @@ COPY package*.json ./
 # 安装项目依赖
 RUN npm install
 
+# 安装 Python、pip、时区数据以及 Python 依赖所需的系统构建依赖
+# tzdata 用于时区设置
+# python3 和 py3-pip 用于运行 Python 脚本和安装 Python 包
+# build-base, gfortran, musl-dev, lapack-dev, openblas-dev 是编译 numpy, scipy, Pillow 等库可能需要的依赖
+RUN apk add --no-cache \
+    tzdata \
+    python3 \
+    py3-pip \
+    build-base \
+    gfortran \
+    musl-dev \
+    lapack-dev \
+    openblas-dev \
+    jpeg-dev \
+    zlib-dev \
+    freetype-dev && \
+    ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone
+
 # 复制项目中的所有文件到工作目录
 COPY . .
+
+# 安装根目录下 requirements.txt 中列出的所有 Python 依赖
+# requirements.txt 文件已通过上面的 "COPY . ." 指令复制到镜像中
+# 使用 --no-cache-dir 避免缓存，可以减小镜像体积
+# 使用 --break-system-packages 解决 "externally-managed-environment" 错误
+# 注：docker的环境中，在系统级安装，是可以接受的
+RUN pip3 install --no-cache-dir --break-system-packages -r requirements.txt
 
 # 暴露应用程序使用的端口 (从 config.env 获取)
 EXPOSE 6005

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,31 @@
-version: '3.8'
-
 services:
   app:
     build: .
+    container_name: vcptoolbox
     ports:
       - "6005:6005"
+    environment:
+      TZ: Asia/Shanghai        # 环境变量
     volumes:
-      # 将本地的 config.env 映射到容器中
-      - ./config.env:/usr/src/app/config.env
+      #1 将本地的 config.env 映射到容器中
+      #1- ./config.env:/usr/src/app/config.env
       # 将插件的配置文件和数据目录映射进去
       # 注意: 如果插件的 config.env 文件不存在于宿主机，Docker 卷映射可能会创建目录而不是文件。
       # 确保这些文件在启动容器前在宿主机上存在，或者调整为映射整个插件目录（如果插件设计允许）。
       # 为了简单起见，这里假设目标是映射特定文件和已知数据目录。
+#######
+#
+#为了docker desktop用户不用频繁构建镜像，依然推荐采取全挂载的方式
+#
+#######
+      #0 插件特定配置和数据示例 (根据 .dockerignore 和已知插件调整)
+      #0- ./Plugin/WeatherReporter/city_cache.txt:/usr/src/app/Plugin/WeatherReporter/city_cache.txt
+      #0- ./Plugin/VCPLog/log:/usr/src/app/Plugin/VCPLog/log
+      #0 - ./Plugin/ImageProcessor/cache:/usr/src/app/Plugin/ImageProcessor/cache # 假设的缓存目录
+      #0- ./dailynote:/usr/src/app/dailynote
+      #0- ./image:/usr/src/app/image # 映射整个 image 目录，包括 fluxgen 等子目录
 
-      # 插件特定配置和数据示例 (根据 .dockerignore 和已知插件调整)
-      - ./Plugin/WeatherReporter/city_cache.txt:/usr/src/app/Plugin/WeatherReporter/city_cache.txt
-      - ./Plugin/VCPLog/log:/usr/src/app/Plugin/VCPLog/log
-      # - ./Plugin/ImageProcessor/cache:/usr/src/app/Plugin/ImageProcessor/cache # 假设的缓存目录
-      - ./dailynote:/usr/src/app/dailynote
-      - ./image:/usr/src/app/image # 映射整个 image 目录，包括 fluxgen 等子目录
-
+      - .:/usr/src/app
       # 保持 node_modules 独立于容器，避免本地开发环境的 node_modules 覆盖容器内的
       - /usr/src/app/node_modules
     command: node server.js


### PR DESCRIPTION
本次 Pull Request 主要包含以下三方面的改进和修复：

1.  **完善 `Dockerfile`，确保 Python 依赖正确安装：**
    *   **问题描述：** 原 `Dockerfile` 未包含通过 `pip install` 安装 Python 依赖的步骤，导致依赖 Python 的插件（例如科学计算器插件、Wan2.1 视频生成插件等）在 Docker 环境下无法正常工作。
    *   **解决方案：** 在 `Dockerfile` 中增加了相应的 `pip install -r requirements.txt`指令，确保所有必要的 Python 包在构建镜像时被正确安装。这恢复了相关插件的功能，提升了应用的完整性和用户体验。

2.  **修正日记时间戳问题，统一时区为北京时间 (Asia/Shanghai)：**
    *   **问题描述：** 由于应用通过硬编码方式获取时间，且部分用户（如使用代理的用户）的服务器环境可能并非东八区，导致日记记录的时间与用户本地时间不一致，造成混淆。
    *   **解决方案：**
        *   在 `Dockerfile` (或相关构建脚本) 中安装了必要的时区数据包 (例如 `tzdata` for Alpine/Debian)。
        *   在 `docker-compose.yml` 文件中，为相关服务明确增加了环境变量 `TZ: Asia/Shanghai`，强制容器内部使用东八区（北京时间）作为标准时间。
    *   **效果：** 此更改确保了所有日记记录的时间戳统一为北京时间，解决了因时区差异导致的时间错乱问题。

3.  **优化 `docker-compose.yml`，重新采用全量挂载以方便 Docker Desktop 用户：**
    *   **问题描述：** 对于频繁修改代码或配置的 Docker Desktop 用户，若不采用卷挂载或者只挂载部分数据，可能需要频繁重构镜像以使更改生效，这既耗时又不方便。
    *   **解决方案：** 本次提交的 `docker-compose.yml` 文件默认采用了更全面的卷挂载方式 (例如将应用的主要代码目录、配置文件目录等都映射到宿主机)。
    *   **用户须知：**
        *   这种方式极大地便利了本地开发和调试，修改宿主机上的对应文件后，容器内应用通常可以即时反映变化（取决于应用本身的热重载能力），无需重新构建镜像。
        *   如果用户不需要此种全量挂载行为（例如在生产环境或不希望本地文件直接影响容器内部），可以在 `docker-compose.yml` 文件中自行注释掉相应的 `volumes` 配置行，恢复到更少的挂载或无挂载状态。PR 中的文件提供了注释示例或说明。

**贡献说明：**

这些更改旨在提升应用的易用性、稳定性和开发便利性。希望这些改进能够帮助到更多的用户。
