### PR TITLE
优化 Dockerfile：使用清华 PyPI 镜像源以加速构建

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY . .
 # 使用 --no-cache-dir 避免缓存，可以减小镜像体积
 # 使用 --break-system-packages 解决 "externally-managed-environment" 错误
 # 注：docker的环境中，在系统级安装，是可以接受的
-RUN pip3 install --no-cache-dir --break-system-packages -r requirements.txt
+RUN pip3 install --no-cache-dir --break-system-packages -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
 
 # 暴露应用程序使用的端口 (从 config.env 获取)
 EXPOSE 6005


### PR DESCRIPTION
此 PR 旨在优化 Docker 构建流程，特别针对在中国大陆等可能遇到网络访问 `files.pythonhosted.org` 较慢或不稳定的地区用户。

**问题背景：**

在尝试构建 Docker 镜像时，`RUN pip3 install -r requirements.txt` 步骤可能会因为连接默认 PyPI 源（`files.pythonhosted.org`）发生网络超时（ReadTimeoutError）而导致构建失败。

**解决方案：**

本 PR 修改了 `Dockerfile` 中的 `pip3 install` 命令，通过添加 `-i https://pypi.tuna.tsinghua.edu.cn/simple` 参数，将其指向清华大学的 PyPI 镜像源。

**带来的改进：**

*   **提高下载速度：** 国内镜像源通常能提供更快的 Python 包下载速度。
*   **增强稳定性：** 减少因网络波动连接到官方源失败的可能性。
*   **改善用户体验：** 使得 Docker 镜像的构建过程更加顺畅，减少不必要的构建失败和等待时间。

这个改动有助于提升项目在不同网络环境下的可用性和构建效率。