### PR TITLE
fix(deps): 统一插件Python依赖并修复Docker卷挂载问题

### DIFF
--- a/Plugin/1PanelInfoProvider/config.env.example
+++ b/Plugin/1PanelInfoProvider/config.env.example
@@ -8,3 +8,6 @@ PanelApiKey=xxxxxxxxxxxxxxxxxxxxxxxx
 
 # 是否为此插件启用调试模式 (True/False)
 DebugMode=False
+
+# 是否启用此插件 (True/False)
+Enabled=True


### PR DESCRIPTION
将SciCalculator等插件的Python依赖统一到根requirements.txt，并修改docker-compose.yml以使用匿名卷保留pydeps目录，确保容器运行时依赖可用。