### PR TITLE
feat(WeatherReporter): 增加可配置的预报天数

### DIFF
--- a/Plugin/WeatherReporter/plugin-manifest.json
+++ b/Plugin/WeatherReporter/plugin-manifest.json
@@ -25,7 +25,12 @@
   "configSchema": {
     "VarCity": "string",
     "WeatherKey": "string",
-    "WeatherUrl": "string"
+    "WeatherUrl": "string",
+    "forecastDays": {
+      "type": "integer",
+      "default": 7,
+      "description": "获取未来天气预报的天数 (范围: 1-30)。"
+    }
   },
   "refreshIntervalCron": "0 */8 * * *"
 }

--- a/Plugin/WeatherReporter/weather-reporter.js
+++ b/Plugin/WeatherReporter/weather-reporter.js
@@ -122,35 +122,45 @@ async function getCurrentWeather(cityId, weatherKey, weatherUrl) {
     }
 }
 
-// Function to get 7-day Forecast from City ID
-async function get7DayForecast(cityId, weatherKey, weatherUrl) {
+// Function to get N-day Forecast from City ID
+async function getForecast(cityId, weatherKey, weatherUrl, days) {
     const { default: fetch } = await import('node-fetch'); // Dynamic import
-     if (!cityId || !weatherKey || !weatherUrl) {
-        console.error('[WeatherReporter] City ID, Weather Key or Weather URL is missing for get7DayForecast.');
-        return { success: false, data: null, error: new Error('Missing parameters for get7DayForecast.') };
+    if (!cityId || !weatherKey || !weatherUrl || !days) {
+        console.error('[WeatherReporter] City ID, Weather Key, Weather URL, or days is missing for getForecast.');
+        return { success: false, data: null, error: new Error('Missing parameters for getForecast.') };
     }
 
-    const forecastUrlEndpoint = `https://${weatherUrl}/v7/weather/7d?location=${cityId}&key=${weatherKey}`;
+    // Determine the correct API endpoint based on the number of days
+    let apiDays;
+    if (days <= 3) apiDays = '3d';
+    else if (days <= 7) apiDays = '7d';
+    else if (days <= 10) apiDays = '10d';
+    else if (days <= 15) apiDays = '15d';
+    else apiDays = '30d'; // Default to 30d for anything larger than 15
+
+    const forecastUrlEndpoint = `https://${weatherUrl}/v7/weather/${apiDays}?location=${cityId}&key=${weatherKey}`;
 
     try {
-        console.error(`[WeatherReporter] Fetching 7-day forecast for city ID: ${cityId}`);
+        console.error(`[WeatherReporter] Fetching ${days}-day forecast for city ID: ${cityId} using ${apiDays} endpoint.`);
         const response = await fetch(forecastUrlEndpoint, { timeout: 10000 }); // 10s timeout
 
         if (!response.ok) {
             const errorText = await response.text();
-            throw new Error(`QWeather 7-day Forecast API failed: ${response.status} ${errorText.substring(0, 200)}`);
+            throw new Error(`QWeather ${apiDays} Forecast API failed: ${response.status} ${errorText.substring(0, 200)}`);
         }
 
         const data = await response.json();
-         if (data.code === '200' && data.daily) {
-            console.error(`[WeatherReporter] Successfully fetched 7-day forecast for ${cityId}.`);
-            return { success: true, data: data.daily, error: null };
+        if (data.code === '200' && data.daily) {
+            // Slice the array to return only the number of days requested
+            const slicedForecast = data.daily.slice(0, days);
+            console.error(`[WeatherReporter] Successfully fetched and sliced ${days}-day forecast for ${cityId}.`);
+            return { success: true, data: slicedForecast, error: null };
         } else {
-             throw new Error(`Failed to get 7-day forecast for ${cityId}. API returned code ${data.code}`);
+            throw new Error(`Failed to get forecast for ${cityId}. API returned code ${data.code}`);
         }
 
     } catch (error) {
-        console.error(`[WeatherReporter] Error fetching 7-day forecast: ${error.message}`);
+        console.error(`[WeatherReporter] Error fetching ${days}-day forecast: ${error.message}`);
         return { success: false, data: null, error: error };
     }
 }
@@ -223,7 +233,7 @@ async function getWeatherWarning(cityId, weatherKey, weatherUrl) {
 }
 
 // Helper to format weather data into a readable string
-function formatWeatherInfo(hourlyForecast, weatherWarning, forecast) {
+function formatWeatherInfo(hourlyForecast, weatherWarning, forecast, days) {
     if (!hourlyForecast && (!weatherWarning || weatherWarning.length === 0) && (!forecast || forecast.length === 0)) {
         return "[天气信息获取失败]";
     }
@@ -266,9 +276,9 @@ function formatWeatherInfo(hourlyForecast, weatherWarning, forecast) {
         result += "未来24小时天气预报获取失败。\n";
     }
 
-    // Keep 7-day Forecast section
+    // Keep N-day Forecast section
     if (forecast && forecast.length > 0) {
-        result += "\n【未来7日天气预报】\n";
+        result += `\n【未来${days}日天气预报】\n`;
         forecast.forEach(day => {
             result += `\n日期: ${day.fxDate}\n`;
             result += `白天: ${day.textDay} (图标: ${day.iconDay}), 最高温: ${day.tempMax}℃, 风向: ${day.windDirDay}, 风力: ${day.windScaleDay}级\n`;
@@ -278,7 +288,7 @@ function formatWeatherInfo(hourlyForecast, weatherWarning, forecast) {
             result += `紫外线指数: ${day.uvIndex}\n`;
         });
     } else {
-         result += "\n未来7日天气预报获取失败。\n";
+         result += `\n未来${days}日天气预报获取失败。\n`;
     }
 
 
@@ -309,6 +319,13 @@ async function fetchAndCacheWeather() {
     const varCity = process.env.VarCity;
     const weatherKey = process.env.WeatherKey;
     const weatherUrl = process.env.WeatherUrl;
+    let forecastDays = parseInt(process.env.forecastDays, 10);
+
+    // Validate forecastDays
+    if (isNaN(forecastDays) || forecastDays < 1 || forecastDays > 30) {
+        console.warn(`[WeatherReporter] Invalid or missing 'forecastDays' in config. Defaulting to 7. Value was: ${process.env.forecastDays}`);
+        forecastDays = 7;
+    }
 
 
     if (!varCity || !weatherKey || !weatherUrl) {
@@ -320,7 +337,7 @@ async function fetchAndCacheWeather() {
     let cityId = null;
     let hourlyForecast = null; // New variable for 24-hour forecast
     let weatherWarning = null; // New variable for weather warning
-    let forecast = null; // Keep 7-day forecast
+    let forecast = null; // Keep N-day forecast
 
     // 1. Get City ID
     const cityResult = await getCityId(varCity, weatherKey, weatherUrl);
@@ -356,14 +373,14 @@ async function fetchAndCacheWeather() {
     }
 
 
-    // 4. Get 7-day Forecast (if cityId is available) - Keep this
+    // 4. Get N-day Forecast (if cityId is available)
     if (cityId) {
-        const forecastResult = await get7DayForecast(cityId, weatherKey, weatherUrl);
+        const forecastResult = await getForecast(cityId, weatherKey, weatherUrl, forecastDays);
         if (forecastResult.success) {
             forecast = forecastResult.data;
         } else {
             lastError = forecastResult.error;
-            console.error(`[WeatherReporter] Failed to get 7-day forecast: ${lastError.message}`);
+            console.error(`[WeatherReporter] Failed to get ${forecastDays}-day forecast: ${lastError.message}`);
         }
     }
 
@@ -371,7 +388,7 @@ async function fetchAndCacheWeather() {
     // Update condition to check for any data
     if (hourlyForecast || weatherWarning || (forecast && forecast.length > 0)) {
         // Update function call
-        const formattedWeather = formatWeatherInfo(hourlyForecast, weatherWarning, forecast);
+        const formattedWeather = formatWeatherInfo(hourlyForecast, weatherWarning, forecast, forecastDays);
         try {
             await fs.writeFile(CACHE_FILE_PATH, formattedWeather, 'utf-8');
             console.error(`[WeatherReporter] Successfully fetched, formatted, and cached new weather info.`);
@@ -383,7 +400,7 @@ async function fetchAndCacheWeather() {
         }
     } else {
         // If all fetches failed
-        lastError = lastError || new Error("未能获取天气信息 (24小时预报, 预警, 7日预报)。");
+        lastError = lastError || new Error(`未能获取天气信息 (24小时预报, 预警, ${forecastDays}日预报)。`);
         console.error(`[WeatherReporter] ${lastError.message}`);
         return { success: false, data: null, error: lastError };
     }


### PR DESCRIPTION
- 在 plugin-manifest.json 中添加 forecastDays 配置项，默认为 7。
- weather-reporter.js 现在会读取 forecastDays 配置，并根据其值（1-30）获取相应天数的预报。
- 增加了对 forecastDays 的输入验证。
- 更新了 API 调用逻辑以支持不同的预报天数 (3d, 7d, 10d, 15d, 30d)。