### PR TITLE
feat(WeatherReporter): 优化天气插件并更新ignore文件

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,3 +40,4 @@ logs/
 
 # Test files if not needed in production
 example.test.js
+VCPChrome/

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,7 @@ Plugin/ImageProcessor/image_cache.json
 Plugin/WeatherReporter/weather_cache.txt
 DebugLog/
 dailynote/
+
+# WeatherReporter cache files
+Plugin/WeatherReporter/city_cache.txt
+Plugin/WeatherReporter/weather_cache.txt

--- a/Plugin/WeatherReporter/config.env.example
+++ b/Plugin/WeatherReporter/config.env.example
@@ -1,0 +1,10 @@
+# 设置获取未来天气预报的天数。
+# 范围: 1-30, 默认值: 7
+forecastDays=7
+
+# 设置24小时天气预报的更新频率。
+# hourlyForecastInterval: 每隔多少小时获取一次。默认值: 2
+# hourlyForecastCount: 总共获取多少次。默认值: 12
+# 示例: interval=2, count=12 将会获取未来24小时内、每2小时一次的天气数据。
+hourlyForecastInterval=2
+hourlyForecastCount=12

--- a/Plugin/WeatherReporter/plugin-manifest.json
+++ b/Plugin/WeatherReporter/plugin-manifest.json
@@ -30,6 +30,18 @@
       "type": "integer",
       "default": 7,
       "description": "获取未来天气预报的天数 (范围: 1-30)。"
+    },
+    "hourlyForecastInterval": {
+      "type": "number",
+      "description": "24小时天气预报的显示间隔（小时）",
+      "default": 2,
+      "min": 1
+    },
+    "hourlyForecastCount": {
+      "type": "number",
+      "description": "24小时天气预报总共显示的条目数。",
+      "default": 12,
+      "min": 1
     }
   },
   "refreshIntervalCron": "0 */8 * * *"


### PR DESCRIPTION
- 新增 hourlyForecastInterval 和 hourlyForecastCount 配置项，允许用户自定义24小时天气预报的显示频率和数量，以节约Token。
- 为 WeatherReporter 插件添加了 config.env.example 文件，并提供了清晰的配置注释。
- 将插件的缓存文件 (city_cache.txt, weather_cache.txt) 添加到 .gitignore。
- 将 VCPChrome/ 目录添加到 .dockerignore，以减小镜像体积。