### PR TITLE
feat(docker): 优化 Dockerfile 以适应国内网络环境并同步 upstream 策略

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ FROM node:20-alpine AS build
 # 设置工作目录
 WORKDIR /usr/src/app
 
+# 更换为国内镜像源以加速
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
+
 # 安装所有运行时和编译时依赖
 RUN apk add --no-cache \
     tzdata \
@@ -29,11 +32,11 @@ COPY package*.json ./
 # --registry=https://mirrors.huaweicloud.com/repository/npm/ (华为云)
 # 国际通用 (如果服务器在海外):
 # (默认，无需指定)
-RUN npm install
+RUN npm install --registry=https://registry.npm.taobao.org
 
 # 复制 Python 依赖定义文件并安装
 COPY requirements.txt ./
-RUN pip3 install --no-cache-dir --break-system-packages --target=/usr/src/app/pydeps -r requirements.txt
+RUN pip3 install --no-cache-dir --break-system-packages --target=/usr/src/app/pydeps -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
 
 # 复制所有源代码
 COPY . .
@@ -47,7 +50,8 @@ FROM node:20-alpine
 WORKDIR /usr/src/app
 
 # 仅安装运行时的系统依赖
-RUN apk add --no-cache \
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories && \
+    apk add --no-cache \
     tzdata \
     python3 \
     openblas \


### PR DESCRIPTION
本次提交对 Dockerfile 进行了两项关键优化：

1.  **国内网络加速**: 为了解决在国内构建 Docker 镜像时因网络问题导致的超时，为 apk, npm, 和 pip 分别配置了阿里云、淘宝和清华大学的镜像源。

2.  **同步 Upstream 文件复制策略**: 采用了官方 upstream 仓库中更规范、更精确的文件复制策略，在生产阶段仅复制必需的文件和目录。

这些更改在保留了 upstream 仓库最佳实践的同时，显著提升了国内用户的构建体验。