### PR TITLE
feat(docker): 增强 Docker 镜像健壮性并修复启动问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,18 @@ COPY --from=build /usr/src/app/Agent ./Agent
 COPY --from=build /usr/src/app/routes ./routes
 COPY --from=build /usr/src/app/requirements.txt ./
 
+# 创建所有应用可能需要写入的持久化目录，以增强镜像的健壮性
+# 这样即使用户的宿主机目录不完整，容器也能正常启动。
+# 卷挂载会覆盖这些空目录。
+RUN mkdir -p /usr/src/app/VCPTimedContacts \
+             /usr/src/app/dailynote \
+             /usr/src/app/image \
+             /usr/src/app/file \
+             /usr/src/app/TVStxt \
+             /usr/src/app/VCPAsyncResults \
+             /usr/src/app/Plugin/VCPLog/log \
+             /usr/src/app/Plugin/EmojiListGenerator/generated_lists
+
 
 # --- 安全性说明：关于以 root 用户运行 ---
 #


### PR DESCRIPTION
本次提交解决了一系列与 Docker 卷挂载和容器启动稳定性相关的问题。

- **修复 TaskScheduler ENOENT 错误**: 此前，如果宿主机在 `docker-compose up` 之前不存在 `VCPTimedContacts` 目录，应用会因 TaskScheduler 尝试监视一个不存在的目录而启动失败。

- **确保所有持久化目录存在**: 通过深入分析 `README.md` 和应用日志，识别了所有需要持久化存储数据的目录 (例如 `dailynote`, `image`, `file`, `TVStxt`, `VCPAsyncResults`, `Plugin/VCPLog/log`, `Plugin/EmojiListGenerator/generated_lists`)。

- **加固 Dockerfile**: 修改了 `Dockerfile`，使用 `RUN mkdir -p` 命令在镜像构建过程中创建所有必要的持久化目录。这使得 Docker 镜像更加自包含且富有弹性，能确保无论宿主机在挂载卷之前的目录状态如何，应用都能正确启动。此项更改可以有效防止多个组件因“文件或目录不存在 (ENOENT)”而引发的潜在错误，全面提升了 Docker 部署的可靠性。