### PR TITLE
Fix: Update FluxGen build script to use correct source file

### DIFF
--- a/Plugin/FluxGen/package.json
+++ b/Plugin/FluxGen/package.json
@@ -22,7 +22,7 @@
   ],
   "author": "Exa Labs",
   "scripts": {
-    "build": "node -e \"const fs = require('fs'); const path = require('path'); const buildDir = './build'; const srcFile = './FluxGen.js'; const targetFile = path.join(buildDir, 'FluxGen.js'); if (!fs.existsSync(buildDir)){ fs.mkdirSync(buildDir, { recursive: true }); } fs.copyFileSync(srcFile, targetFile); try { fs.chmodSync(targetFile, '755'); console.log('FluxGen build: FluxGen.js copied to build directory and chmodded.'); } catch(e) { console.warn('FluxGen build: chmod failed, possibly on Windows. File copied.'); }\"",
+    "build": "node -e \"const fs = require('fs'); const path = require('path'); const buildDir = './build'; const srcFile = './FluxGen.mjs'; const targetFile = path.join(buildDir, 'FluxGen.js'); if (!fs.existsSync(buildDir)){ fs.mkdirSync(buildDir, { recursive: true }); } fs.copyFileSync(srcFile, targetFile); try { fs.chmodSync(targetFile, '755'); console.log('FluxGen build: FluxGen.mjs copied to build directory and renamed to FluxGen.js'); } catch(e) { if (e.code === 'ENOENT') { console.error('Source file not found:', srcFile); process.exit(1); } else { console.warn('FluxGen build:', e.message); } }\"",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/FluxGen.js",


### PR DESCRIPTION
## Summary
- Fix FluxGen plugin build script filename mismatch issue
- Change source file from `FluxGen.js` to `FluxGen.mjs` in build script
- Add error handling for missing source file

## Problem
The FluxGen plugin's package.json build script was trying to copy `FluxGen.js` as the source file, but the actual file was renamed to `FluxGen.mjs`. This caused the build process to fail.

## Solution
- Updated the build script to use the correct source file (`FluxGen.mjs`)
- Added error handling to provide better debugging information
- The target file remains `FluxGen.js` to maintain compatibility with the existing bin configuration

## Test plan
- Run `npm run build` in Plugin/FluxGen directory
- Verify that FluxGen.mjs is successfully copied to build/FluxGen.js
- Check that the build process completes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)