### PR TITLE
维护更新

### DIFF
--- a/Plugin/MCPO/DEPLOYMENT.md
+++ b/Plugin/MCPO/DEPLOYMENT.md
@@ -69,7 +69,7 @@
 
 ```env
 # MCPO 服务器设置
-MCPO_PORT=8000
+MCPO_PORT=9000
 MCPO_API_KEY=your-secret-key
 MCPO_AUTO_START=true
 
@@ -116,7 +116,7 @@ node server.js
 
 | 变量名 | 类型 | 默认值 | 说明 |
 |--------|------|--------|------|
-| `MCPO_PORT` | integer | 8000 | MCPO 服务器端口 |
+| `MCPO_PORT` | integer | 9000 | MCPO 服务器端口 |
 | `MCPO_API_KEY` | string | vcp-mcpo-secret | API 访问密钥 |
 | `MCPO_AUTO_START` | boolean | true | 自动启动服务器 |
 | `PYTHON_EXECUTABLE` | string | python | Python 解释器路径 |
@@ -169,7 +169,7 @@ node server.js
 1. 修改 `config.env` 中的 `MCPO_PORT`
 2. 或终止占用端口的进程：
    ```bash
-   lsof -ti:8000 | xargs kill
+   lsof -ti:9000 | xargs kill
    ```
 
 ### 问题 2: MCP 服务器无法启动
@@ -180,7 +180,7 @@ node server.js
 2. 验证 `mcp-config.json` 配置语法
 3. 查看 MCPO 服务器日志：
    ```bash
-   curl http://localhost:8000/docs
+   curl http://localhost:9000/docs
    ```
 
 ### 问题 3: 权限错误

--- a/Plugin/MCPO/config.env
+++ b/Plugin/MCPO/config.env
@@ -4,8 +4,9 @@ MCPO_API_KEY=vcp-mcpo-secret
 MCPO_AUTO_START=true
 PYTHON_EXECUTABLE=python
 
-MCP_CONFIG_PATH=./Plugin/MCPO/custom-mcp-config/example-config.json
+MCP_CONFIG_PATH=./Plugin/MCPO/custom-mcp-config/mcp-config.json
 # 注意此处相对路径是以 VCPToolBox 作为根目录
+# 配置文件必须以 -config.json 结尾
 
 
 MCPO_HOT_RELOAD=true

--- a/Plugin/MCPO/mcpo_plugin.py
+++ b/Plugin/MCPO/mcpo_plugin.py
@@ -76,7 +76,7 @@ class MCPOPlugin:
                 default_config_path = os.path.join(project_root, env_config_path)
         
         config = {
-            'MCPO_PORT': int(os.getenv('MCPO_PORT', '8000')),
+            'MCPO_PORT': int(os.getenv('MCPO_PORT', '9000')),
             'MCPO_API_KEY': os.getenv('MCPO_API_KEY', 'vcp-mcpo-secret'),
             'MCPO_AUTO_START': os.getenv('MCPO_AUTO_START', 'true').lower() == 'true',
             'PYTHON_EXECUTABLE': os.getenv('PYTHON_EXECUTABLE', 'python'),

--- a/Plugin/MCPO/plugin-manifest.json
+++ b/Plugin/MCPO/plugin-manifest.json
@@ -18,7 +18,7 @@
     "MCPO_PORT": {
       "type": "integer",
       "description": "MCPO 服务器端口号",
-      "default": 8000
+      "default": 9000
     },
     "MCPO_API_KEY": {
       "type": "string",

--- a/Plugin/MCPO/requirements.txt
+++ b/Plugin/MCPO/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.28.0
 psutil>=5.9.0
-mcpo>=0.1.0
+mcpo

--- a/Plugin/MCPOMonitor/README.md
+++ b/Plugin/MCPOMonitor/README.md
@@ -23,14 +23,14 @@ MCPOMonitor 是一个静态插件，用于监控 MCPO 服务器状态并提供�
 # MCPO 服务器连接配置
 # 支持多种端口配置方式：
 # 方式1: 仅设置端口号（推荐，与MCPO插件共享配置）
-MCPO_PORT=8000
+MCPO_PORT=9000
 
 # 方式2: 设置完整URL（优先级较低）
-MCPO_HOST=http://0.0.0.0:8000
+MCPO_HOST=http://0.0.0.0:9000
 
 # 方式3: 同时设置时，MCPO_PORT优先级更高
 # MCPO_PORT=9000
-# MCPO_HOST=http://localhost:8000  # 实际会使用 http://localhost:9000
+# MCPO_HOST=http://localhost:9000
 
 # API密钥（与MCPO插件共享）
 MCPO_API_KEY=vcp-mcpo-secret
@@ -52,7 +52,7 @@ HEALTH_CHECK_TIMEOUT=5000
 1. MCPOMonitor插件自己的 `MCPO_PORT` 配置
 2. MCPO插件的 `MCPO_PORT` 配置（自动共享）
 3. MCPOMonitor插件的 `MCPO_HOST` 完整URL配置  
-4. 默认值 `8000`
+4. 默认值 `9000`
 
 **自动配置共享**：
 - 插件会自动读取 `Plugin/MCPO/config.env` 中的端口配置

--- a/Plugin/MCPOMonitor/mcpo_monitor.js
+++ b/Plugin/MCPOMonitor/mcpo_monitor.js
@@ -54,7 +54,7 @@ class MCPOMonitor {
         }
         
         // 获取端口配置（优先级：MCPOMonitor具体配置 > MCPO插件配置 > 默认值）
-        const mcpoPort = process.env.MCPO_PORT || '8000';
+        const mcpoPort = process.env.MCPO_PORT || '9000';
         const mcpoHost = process.env.MCPO_HOST;
         
         // 如果指定了完整的HOST URL，解析并更新端口；否则根据端口构造
@@ -65,7 +65,7 @@ class MCPOMonitor {
             try {
                 const url = new URL(mcpoHost);
                 // 如果环境变量MCPO_PORT被单独设置，优先使用它
-                if (process.env.MCPO_PORT && process.env.MCPO_PORT !== '8000') {
+                if (process.env.MCPO_PORT && process.env.MCPO_PORT !== '9000') {
                     actualPort = parseInt(process.env.MCPO_PORT, 10);
                     finalMcpoHost = `${url.protocol}//${url.hostname}:${actualPort}`;
                 } else {

--- a/Plugin/MCPOMonitor/plugin-manifest.json
+++ b/Plugin/MCPOMonitor/plugin-manifest.json
@@ -27,12 +27,12 @@
     "MCPO_HOST": {
       "type": "string",
       "description": "MCPO 服务器完整地址（如果指定则优先使用）",
-      "default": "http://0.0.0.0:8000"
+      "default": "http://0.0.0.0:9000"
     },
     "MCPO_PORT": {
       "type": "integer",
       "description": "MCPO 服务器端口号（与MCPO插件共享配置）",
-      "default": 8000
+      "default": 9000
     },
     "MCPO_API_KEY": {
       "type": "string", 

--- a/Plugin/NanoBananaGenOR/NanoBananaGenOR.mjs
+++ b/Plugin/NanoBananaGenOR/NanoBananaGenOR.mjs
@@ -43,7 +43,7 @@ const {
 })();
 
 const API_BASE_URL = 'https://openrouter.ai/api/v1/chat/completions';
-const MODEL_NAME = 'google/gemini-2.5-flash-image-preview:free';
+const MODEL_NAME = 'google/gemini-2.5-flash-image-preview';
 
 function getRandomApiKey() {
     if (OPENROUTER_API_KEYS.length === 0) {

--- a/config.env.example
+++ b/config.env.example
@@ -32,9 +32,9 @@ ApiRetryDelay=200
 # [调试与开发]
 # -------------------------------------------------------------------
 # DebugMode: 设置为 "True" 会在控制台输出详细的调试信息，方便开发和排错。
-DebugMode=False
+DebugMode=false
 # ShowVCP: 在非流式输出时，是否在返回结果中包含VCP的调用信息。
-ShowVCP=False
+ShowVCP=false
  
 # -------------------------------------------------------------------
 # [管理面板]
@@ -86,6 +86,7 @@ AgentNova=Nova.txt
 AgentCoco=ThemeMaidCoco.txt
 # AgentMemoriaSorter=MemoriaSorter.txt # 不推荐在此处注册 MemoriaSorter。建议在 VCPChat 前端动态编码，或在需要时由用户直接编辑 Agent/MemoriaSorter.txt 文件。
 
+
 # -------------------------------------------------------------------
 # [系统提示词] 定制AI的核心行为
 # -------------------------------------------------------------------
@@ -95,7 +96,9 @@ AgentCoco=ThemeMaidCoco.txt
 # TarSysPrompt: 这是最核心的系统提示词之一，它会在每次对话开始时告诉AI一些基本信息。
 TarSysPrompt="{{VarTimeNow}}当前地址是{{VarCity}},当前天气是{{VCPWeatherInfo}}。"
 # TarEmojiPrompt: 注入到系统提示词中，指导AI如何使用表情包。
-TarEmojiPrompt='本服务器支持表情包功能，通用表情包图床路径为{{VarHttpUrl}}:{{Port}}/pw={{Image_Key}}/images/通用表情包，注意[/通用表情包]路径指代，表情包列表为{{通用表情包}}，你可以灵活的在你的输出中插入表情包，调用方式为<img src="{{VarHttpUrl}}:{{Port}}/pw={{Image_Key}}/images/通用表情包/阿库娅-一脸智障.jpg" width="150">,使用Width参数来控制表情包尺寸（50-200）。'
+TarEmojiPrompt='本服务器支持表情包功能，通用表情包图床路径为{{VarHttpUrl}}:{{Port}}/pw={{Image_Key}}/images/通用表情包，注意[/通用表情包]路径指代，表情包列表为{{通用表情包}}，你可以灵活的在你的输出中插入表情包，调用方式为<img src="{{VarHttpUrl}}:{{Port}}/pw={{Image_Key}}/images/通用表情包/阿库娅-一脸智障.jpg" width="150">,使用Width参数来控制表情包尺寸（50-200）。
+'
+
 # TarEmojiList: VCPToolbox会自动根据"image/通用表情包"文件夹定义一个或多个表情包列表文件（.txt格式），AI会从中获取到可用的表情包。
 TarEmojiList=通用表情包.txt
 # 你可以在 "image/" 目录下创建新的表情包文件夹，并在这里放入图片文件。
@@ -155,8 +158,10 @@ tool_name:「始」tool「末」
 <<<[END_TOOL_REQUEST]>>>
 '
 
+
+
 # VarDailyNoteGuide: 指导AI如何使用日记功能来记录长期记忆。
-VarDailyNoteGuide="本客户端已经搭载长期记忆功能。要创建日记，请在回复末尾添加如下结构化内容。`Maid`字段通过特定格式控制日记的【写入位置】。
+VarDailyNoteGuide='本客户端已经搭载长期记忆功能。要创建日记，请在回复末尾添加如下结构化内容。`Maid`字段通过特定格式控制日记的【写入位置】。
 
 **1. 写入个人日记:**
 直接使用你的名字作为`Maid`的值，日记将保存在你的个人文件夹下。
@@ -168,7 +173,7 @@ Content: 这是写入我个人日记的内容。
 
 
 **2. 写入指定日记本:**
-使用 `[Tag]你的名字` 的格式，其中 `[Tag]` 是目标文件夹名称 (例如：`[公共]`是公共日记本的储存目录)。署名相对的变成Maid: [公共]Nova "
+使用 `[Tag]你的名字` 的格式，其中 `[Tag]` 是目标文件夹名称 (例如：`[公共]`是公共日记本的储存目录)。署名相对的变成Maid: [公共]Nova '
 
 # VarFileTool: 专门为文件操作工具提供的说明。
 VarFileTool=filetool.txt
@@ -193,16 +198,55 @@ VarVchatPath="YOUR_VCHAT_PATH_SUCH_AS_D:\\VCPChat"
 
 # Vchat客户端专用提示词。
 # 用于教导Vchat中的agent输出规范和行为。
-VarDivRender=""将你的每一次回复都视为一次创意设计的机会。利用 Vchat 强大的渲染能力，将你的回复封装在一个单一、完整且设计精良的多层 `<div>` 容器中。你可以自由挥洒 HTML、内联 CSS 甚至内联 SVG 的全部力量，div渲染器支持简单的Anime.js语法，来构建不仅仅是文本，还包括定制表格、数据图表（如条形图、饼图）和矢量图标的丰富内容，使用css来替代mermaid输出更美观高级的流程图。尽情展现你的个性和创意。个性产生优雅/美观/酷炫/搞怪…的属于你期望的风格的输出气泡主题吧。支持渲染 <button onclick=></button>,用户可以直接点击按钮来输入选择内容。
-【补充核心原则】：注意MD渲染和DIV渲染冲突(在div模式下可以不输出md格式的文档)，因此你如果试图在div中演示代码，推荐自定义代码块背景色，将所有代码单独用<pre style=><code> 你的代码展示内容 </code></pre>元素包裹起来；其次，当你需要在Div元素里插入日记写入/VCP调用时，注意维持调用格式的完整性(Vchat会自动为日记,VCP工具添加div样式，无需你添加)，不要被多余标签元素破坏原始调用结构。根据各种情景来设计不同风格的div气泡主题吧！""
-VarRendering="当前Vchat客户端支持HTML/Div元素/CSS/JS/MD/PY/Latex/Mermaid渲染。可用于输出图表，数据图，数学公式，函数图，网页渲染模块，脚本执行。简单表格可以通过MD,Mermaid输出，复杂表格可以通过Html，Css输出，div/Script类直接发送会在气泡内渲染。Py脚本需要添加```python头，来构建CodeBlock来让脚本可以在气泡内运行。
+VarDivRender='将你的每一次回复都视为一次创意设计的机会。利用 Vchat 强大的渲染能力，将你的回复封装在一个单一、完整且设计精良的多层 `<div>` 容器中。你可以自由挥洒 HTML、内联 CSS 甚至内联 SVG 的全部力量，div渲染器支持简单的Anime.js语法，来构建不仅仅是文本，还包括定制表格、数据图表（如条形图、饼图）和矢量图标的丰富内容，使用css来替代mermaid输出更美观高级的流程图。尽情展现你的个性和创意。个性产生优雅/美观/酷炫/搞怪…的属于你期望的风格的输出气泡主题吧。支持渲染 <button onclick=></button>,用户可以直接点击按钮来输入选择内容。
+【补充核心原则】：注意MD渲染和DIV渲染冲突(在div模式下可以不输出md格式的文档)，因此你如果试图在div中演示代码，推荐自定义代码块背景色，将所有代码单独用<pre style=><code> 你的代码展示内容 </code></pre>元素包裹起来；其次，当你需要在Div元素里插入日记写入/VCP调用时，注意维持调用格式的完整性(Vchat会自动为日记,VCP工具添加div样式，无需你添加)，不要被多余标签元素破坏原始调用结构。根据各种情景来设计不同风格的div气泡主题吧！
+'
+VarRendering='当前Vchat客户端支持HTML/Div元素/CSS/JS/MD/PY/Latex/Mermaid渲染。可用于输出图表，数据图，数学公式，函数图，网页渲染模块，脚本执行。简单表格可以通过MD,Mermaid输出，复杂表格可以通过Html，Css输出，div/Script类直接发送会在气泡内渲染。Py脚本需要添加```python头，来构建CodeBlock来让脚本可以在气泡内运行。
 Vchat支持渲染完整Html页面，对于完整Html网页内容，输出格式为
 ```html
 <!DOCTYPE html>
 </html>
 ```
 代码块包裹(这是为了避免Html元素溢出直接导致Electron程序异常)，当MD渲染器识别到这是一个完整html页面时，将会将之以独立窗口渲染，此时的渲染器更加高级，支持更多渲染模式和语法嵌套规则，Html渲染器支持完整的anmie.js与three.js语法。
-"
+'
+
+# 当前客户端写出和谐聊天气泡的指导方法：
+VarAdaptiveBubbleTip='主题模式自适应气泡实现指南：
+
+使用CSS变量实现亮暗模式自动切换的关键要素：
+
+1. 基础结构：
+<div style="
+    background-color: var(--primary-bg);
+    color: var(--primary-text);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 20px;
+">
+
+2. 核心变量：
+- var(--primary-bg) : 主背景色
+- var(--secondary-bg) : 次要背景色
+- var(--primary-text) : 主文字颜色
+- var(--highlight-text) : 高亮文字颜色
+- var(--border-color) : 边框颜色
+
+3. 增强效果：
+    backdrop-filter: blur(10px) saturate(120%);
+    transition: all 0.3s ease-in-out;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+
+4. 示例应用：
+<h2 style="color: var(--highlight-text); border-bottom: 1px solid var(--border-color);">
+    标题文字
+</h2>
+<p style="color: var(--primary-text);">内容文字</p>
+
+关键优势：
+- 自动适配亮色/暗色主题
+- 无需JavaScript干预
+- 平滑过渡动画
+- 磨砂玻璃效果'
 
 
 


### PR DESCRIPTION
1. 修改 NanoBananaGenOR 插件中的模型名称
2. 修复 MCPO 插件中错误的依赖版本号，以及相关功能默认端口号修改为 9000
3. 在 config.env.example 中增加一个用于指导 VCPChat 中 Agent 写出能够随该前端壁纸主题、亮暗色模式改变而自适应发生变化的聊天气泡的提示词。
4. 修复 config.env.example 中部分引号包裹的条目。