### PR TITLE
修改后端控制台插件配置文件修改后点击保存配置报错

### DIFF
--- a/AdminPanel/script.js
+++ b/AdminPanel/script.js
@@ -711,7 +711,7 @@ Description Length: ${newDescription.length}`);
         
         // Rebuild the .env string from the form, preserving comments and order
         const currentPluginEntries = originalPluginConfigs[pluginName] || [];
-        const newConfigString = buildEnvStringForPlugin(form, currentPluginEntries);
+        const newConfigString = buildEnvStringForPlugin(form, currentPluginEntries, pluginName);
 
         try {
             await apiFetch(`${API_BASE_URL}/plugins/${pluginName}/config`, {
@@ -723,7 +723,7 @@ Description Length: ${newDescription.length}`);
         } catch (error) { /* Error handled by apiFetch */ }
     }
 
-    function buildEnvStringForPlugin(formElement, originalParsedEntries) {
+    function buildEnvStringForPlugin(formElement, originalParsedEntries, pluginName) {
         const finalLines = [];
         const editedKeysInForm = new Set();
 


### PR DESCRIPTION
原先点击保存后会报错
script.js:739  Uncaught (in promise) ReferenceError: pluginName is not defined
    at script.js:739:62
    at Array.forEach (<anonymous>)
    at buildEnvStringForPlugin (script.js:735:31)
    at HTMLFormElement.handlePluginFormSubmit (script.js:714:33)