### PR TITLE
控制中心添加插件分组(已启用/已禁用)

### DIFF
--- a/AdminPanel/index.html
+++ b/AdminPanel/index.html
@@ -258,7 +258,7 @@
             <nav id="plugin-nav">
                 <ul>
                     <li><a href="#" data-target="dashboard" class="active"><span class="material-symbols-outlined">dashboard</span>仪表盘</a></li>
-                    <li class="nav-category">核心功能</li>
+                    <li class="nav-category">———— 核 心 功 能 ————</li>
                     <li><a href="#" data-target="base-config"><span class="material-symbols-outlined">settings</span>全局基础配置</a></li>
                     <li><a href="#" data-target="daily-notes-manager"><span class="material-symbols-outlined">description</span>日记知识库管理</a></li>
                     <li><a href="#" data-target="image-cache-editor"><span class="material-symbols-outlined">photo_library</span>多媒体Base64编辑器</a></li>
@@ -269,7 +269,7 @@
                     <li><a href="#" data-target="preprocessor-order-manager"><span class="material-symbols-outlined">sort</span>预处理器顺序管理</a></li>
                     <li><a href="#" data-target="thinking-chains-editor"><span class="material-symbols-outlined">psychology</span>思维链编辑器</a></li>
                     <li><a href="#" data-target="server-log-viewer"><span class="material-symbols-outlined">terminal</span>服务器日志</a></li>
-                    <li class="nav-category" id="plugins-category">插件管理</li>
+                    <li class="nav-category" id="plugins-category">———— 插 件 管 理 ————</li>
                     <!-- 插件列表将动态生成在这里 -->
                 </ul>
             </nav>

--- a/AdminPanel/style.css
+++ b/AdminPanel/style.css
@@ -196,8 +196,8 @@ body {
 
 .sidebar nav li.nav-category {
     padding: 15px 15px 5px;
-    font-size: 0.8em;
-    color: var(--secondary-text);
+    font-size: 1em;
+    color: var(--primary-text);
     text-transform: uppercase;
     font-weight: 600;
     letter-spacing: 0.5px;


### PR DESCRIPTION
将插件分为”已启用“和“已禁用”两个分组，同时修改了一下”核心功能“和“插件管理”的字体，使界面看起来更分明。