### PR TITLE
npm warn deprecated crypto@1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "chinese-lunar-calendar": "^1.0.1",
     "chokidar": "^3.5.3",
     "cors": "^2.8.5",
-    "crypto": "^1.0.1",
     "dotenv": "^16.5.0",
     "eslint": "^9.39.1",
     "exceljs": "^4.4.0",
@@ -58,3 +57,4 @@
     "ws": "^8.17.0"
   }
 }
+


### PR DESCRIPTION
package.json 中显式安装了 crypto 这个包。然而，crypto 是 Node.js 的内置核心模块，不需要也不应该作为 npm 包单独安装。npm 上的这个 crypto 包是一个非常古老且不再维护的包装器。 影响：可能会导致安全问题或与 Node.js 内置功能冲突。
建议：直接卸载它。您的代码中使用的 require('crypto') 会自动调用 Node.js 自带的模块。