### PR TITLE
fix: 为 PowerShell 命令添加 -NoProfile 参数

### DIFF
--- a/routes/adminPanelRoutes.js
+++ b/routes/adminPanelRoutes.js
@@ -56,7 +56,7 @@ module.exports = function(DEBUG_MODE, dailyNoteRootPath, pluginManager, getCurre
             if (process.platform === 'win32') {
                 // 先尝试现代 PowerShell 命令，失败时回退到 wmic（向下兼容）
                 try {
-                    const { stdout: memInfo } = await execAsync('powershell -Command "Get-CimInstance Win32_OperatingSystem | Select-Object TotalVisibleMemorySize,FreePhysicalMemory | ConvertTo-Json"', execOptions);
+                    const { stdout: memInfo } = await execAsync('powershell -NoProfile -Command "Get-CimInstance Win32_OperatingSystem | Select-Object TotalVisibleMemorySize,FreePhysicalMemory | ConvertTo-Json"', execOptions);
                     const memData = JSON.parse(memInfo);
                     systemInfo.memory = {
                         total: (memData.TotalVisibleMemorySize || 0) * 1024,
@@ -78,7 +78,7 @@ module.exports = function(DEBUG_MODE, dailyNoteRootPath, pluginManager, getCurre
                 }
                 
                 try {
-                    const { stdout: cpuInfo } = await execAsync('powershell -Command "Get-CimInstance Win32_Processor | Measure-Object -Property LoadPercentage -Average | Select-Object Average | ConvertTo-Json"', execOptions);
+                    const { stdout: cpuInfo } = await execAsync('powershell -NoProfile -Command "Get-CimInstance Win32_Processor | Measure-Object -Property LoadPercentage -Average | Select-Object Average | ConvertTo-Json"', execOptions);
                     const cpuData = JSON.parse(cpuInfo);
                     systemInfo.cpu = { usage: Math.round(cpuData.Average || 0) };
                 } catch (powershellError) {


### PR DESCRIPTION
## 问题描述

在 Windows 环境下，SystemMonitor 获取系统资源时报错：

```
[SystemMonitor] Error getting system resources: Error: Command failed: wmic OS get TotalVisibleMemorySize,FreePhysicalMemory /value
'wmic' 不是内部或外部命令
```

## 问题原因

1. PowerShell 命令默认会加载用户 profile 配置文件
2. 如果用户的 profile 有输出内容（例如 `PowerShell UTF-8 encoding configuration loaded successfully`），会导致输出不是纯净 JSON
3. `JSON.parse()` 解析失败，触发 catch 回退到 `wmic` 命令
4. Windows 11 已移除 `wmic` 命令，导致最终报错

## 解决方案

为两处 PowerShell 调用添加 `-NoProfile` 参数：

```diff
- powershell -Command "Get-CimInstance ..."
+ powershell -NoProfile -Command "Get-CimInstance ..."
```

`-NoProfile` 参数会跳过加载用户 profile，确保输出为纯净 JSON。

## 修改文件

- `routes/adminPanelRoutes.js`：第 59 行和第 81 行

## 测试验证

修复后 PowerShell 命令输出纯净 JSON：
```json
{
    "TotalVisibleMemorySize": 66859356,
    "FreePhysicalMemory": 36057796
}
```

## 影响范围

- 仅影响 Windows 平台的系统监控功能
- 向后兼容，不影响其他功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)