### PR TITLE
Fix: 修复agent文件中表情包占位符正则匹配问题

### DIFF
--- a/modules/messageProcessor.js
+++ b/modules/messageProcessor.js
@@ -249,7 +249,7 @@ async function replacePriorityVariables(text, context, role) {
     }
 
     // --- 表情包处理 ---
-    const emojiPlaceholderRegex = /\{\{(.+?表情包)\}\}/g;
+    const emojiPlaceholderRegex = /\{\{([^{}]+?表情包)\}\}/g;
     let emojiMatch;
     while ((emojiMatch = emojiPlaceholderRegex.exec(processedText)) !== null) {
         const placeholder = emojiMatch[0];
@@ -259,7 +259,7 @@ async function replacePriorityVariables(text, context, role) {
     }
 
     // --- 日记本处理 (已修复循环风险) ---
-    const diaryPlaceholderRegex = /\{\{(.+?)日记本\}\}/g;
+    const diaryPlaceholderRegex = /\{\{([^{}]+?)日记本\}\}/g;
     let allDiariesData = {};
     const allDiariesDataString = pluginManager.getPlaceholderValue("{{AllCharacterDiariesData}}");
 
@@ -280,7 +280,7 @@ async function replacePriorityVariables(text, context, role) {
     // Step 2: Iterate through the unique placeholders and replace them.
     for (const placeholder of uniquePlaceholders) {
         // Extract character name from placeholder like "{{小雨日记本}}" -> "小雨"
-        const characterNameMatch = placeholder.match(/\{\{(.+?)日记本\}\}/);
+        const characterNameMatch = placeholder.match(/\{\{([^{}]+?)日记本\}\}/);
         if (characterNameMatch && characterNameMatch[1]) {
             const characterName = characterNameMatch[1];
             let diaryContent = `[${characterName}日记本内容为空或未从插件获取]`;


### PR DESCRIPTION
优化表情包正则、日记本正则。
解决agent文件里跨越占位符匹配问题。原来的正则逻辑例如：
{{VarHttpUrl}}:{{Port}}/pw={{Image_Key}}/images/{{Nova表情包}} 
会被错误地匹配为
VarHttpUrl}}:{{Port}}/pw={{Image_Key}}/images/{{Nova表情包

新的正则从`.+?`改成`[^{}]+?`，解决了问题