### PR TITLE
RAG算法调参页——适配移动端

### DIFF
--- a/AdminPanel/style.css
+++ b/AdminPanel/style.css
@@ -3110,7 +3110,7 @@ html[data-theme='light'] .delete-theme-btn {
 
 .param-group > div:not(h3) {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
     gap: 25px;
     width: 100%;
     margin-bottom: 20px;
@@ -3222,11 +3222,16 @@ html[data-theme='light'] .delete-theme-btn {
     width: 100%;
 }
 
-@media (max-width: 900px) {
-    .param-item {
+@media (max-width: 768px) {
+    .param-group > div:not(h3) {
         grid-template-columns: 1fr;
         gap: 15px;
     }
+
+    .param-item {
+        padding: 15px;
+    }
+
     .param-input-row {
         justify-content: stretch;
     }

--- a/AdminPanel/tool_list_editor_new.css
+++ b/AdminPanel/tool_list_editor_new.css
@@ -1246,6 +1246,53 @@ body {
     .config-actions button {
         flex: 1;
     }
+
+    /* 插件分组头部移动端适配 - 分为上下两层，左对齐 */
+    .plugin-group-header {
+        display: flex;
+        flex-wrap: wrap;
+        padding: 8px 12px;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 0;
+    }
+
+    .plugin-group-icon {
+        width: 18px;
+        height: 18px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1em;
+        margin-right: 4px; /* 紧挨着名称 */
+        flex: 0 0 auto;
+    }
+
+    .plugin-group-name {
+        flex: 1;
+        min-width: calc(100% - 22px); /* 18px + 4px = 22px, 强制换行形成第一层 */
+        font-size: 0.9em;
+        font-weight: 600;
+        text-align: left;
+    }
+
+    .plugin-group-original-name {
+        display: none; /* 移动端隐藏原始名称 */
+    }
+
+    .plugin-group-count {
+        flex: 0 0 auto; /* 左对齐 */
+        font-size: 0.75em;
+        margin-top: 4px;
+        margin-right: 12px;
+    }
+
+    .btn-select-all-plugin {
+        flex: 0 0 auto;
+        margin-top: 4px;
+        padding: 4px 10px;
+        font-size: 0.7em;
+    }
 }
 
 /* ==================== 无效工具样式 ==================== */


### PR DESCRIPTION
1.修复移动端下”RAG算法调参页“部分UI超出屏幕的的问题
2.修改了移动端“工具列表配置编辑器”下plugin-group-header控件的布局。