### PR TITLE
优化VCPTavern嵌入预设排版，保证各块之间有且仅有一个空行

### DIFF
--- a/Plugin/VCPTavern/VCPTavern.js
+++ b/Plugin/VCPTavern/VCPTavern.js
@@ -82,9 +82,10 @@ class VCPTavern {
                 const systemMsg = newMessages.find(m => m.role === 'system');
                 if (systemMsg && typeof systemMsg.content === 'string') {
                     if (rule.position === 'before') {
-                        systemMsg.content = textToEmbed + systemMsg.content;
+                        // 强制在嵌入内容与原有内容之间保持一个空行
+                        systemMsg.content = textToEmbed.trim() + '\n\n' + systemMsg.content.trim();
                     } else { // after
-                        systemMsg.content = systemMsg.content + textToEmbed;
+                        systemMsg.content = systemMsg.content.trim() + '\n\n' + textToEmbed.trim();
                     }
                 }
             } else if (rule.target === 'last_user') {
@@ -97,9 +98,9 @@ class VCPTavern {
                 }
                 if (lastUserIndex !== -1 && typeof newMessages[lastUserIndex].content === 'string') {
                     if (rule.position === 'before') {
-                        newMessages[lastUserIndex].content = textToEmbed + newMessages[lastUserIndex].content;
+                        newMessages[lastUserIndex].content = textToEmbed.trim() + '\n\n' + newMessages[lastUserIndex].content.trim();
                     } else { // after
-                        newMessages[lastUserIndex].content = newMessages[lastUserIndex].content + textToEmbed;
+                        newMessages[lastUserIndex].content = newMessages[lastUserIndex].content.trim() + '\n\n' + textToEmbed.trim();
                     }
                 }
             }


### PR DESCRIPTION
原本的拼接是首尾相接的，嵌入的预设之间，预设和系统提示词之间连换行都没有。