### PR TITLE
 fix(DailyNote): 修复 update 命令因 HTML 实体转义导致的匹配失效问题

### DIFF
--- a/Plugin/DailyNote/dailynote.js
+++ b/Plugin/DailyNote/dailynote.js
@@ -231,14 +231,41 @@ async function handleCreateCommand(args) {
 
 
 // --- 'update' Command Logic ---
+
+/**
+ * 反转义 HTML 实体，解决 LLM 输出转义导致的匹配失败问题
+ * @param {string} str
+ * @returns {string}
+ */
+function unescapeHtml(str) {
+    if (!str || typeof str !== 'string') return str;
+    return str
+        .replace(/"/g, '"')
+        .replace(/&/g, '&')
+        .replace(/</g, '<')
+        .replace(/>/g, '>')
+        .replace(/'/g, "'")
+        .replace(/'/g, "'")
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&copy;/g, '©')
+        .replace(/&reg;/g, '®')
+        .replace(/&trade;/g, '™')
+        .replace(/&times;/g, '×')
+        .replace(/&divide;/g, '÷');
+}
+
 async function handleUpdateCommand(args) {
     debugLog("Processing 'update' command with args:", args);
 
-    const { target, replace, maid } = args;
+    let { target, replace, maid } = args;
 
     if (typeof target !== 'string' || typeof replace !== 'string') {
         return { status: "error", error: "Invalid arguments for update: 'target' and 'replace' must be strings." };
     }
+
+    // 在安全校验前进行反转义，确保长度校验和后续匹配使用的是原始字符
+    target = unescapeHtml(target);
+    replace = unescapeHtml(replace);
 
     if (target.length < 15) {
         return { status: "error", error: `Security check failed: 'target' must be at least 15 characters long. Provided length: ${target.length}` };


### PR DESCRIPTION
📝 概述 (Description)
修复了 DailyNote 插件在执行 update 操作时，由于 LLM输出内容被 HTML 转义（例如 " 变为 &quot;）而导致无法在日记文件中匹配到原始字符的问题。

🔍 问题背景 (Background)
现象：当 LLM 尝试更新包含引号、和号等特殊字符的内容时，其 API 输出层常会自动进行 HTML 实体转义。 根源：dailynote.js 中的 handleUpdateCommand 直接使用 target 原文进行 indexOf 匹配。由于日记文件内存储的是原始字符（如 "），而传入的 target 是转义字符（如 &quot;），导致匹配永远返回 -1，更新失败。 🛠️ 解决方案 (Solution)
在 handleUpdateCommand 逻辑中引入了 HTML 实体反转义 (Unescape) 机制：

新增辅助函数：unescapeHtml(str)，支持对 &quot;, &amp;, &lt;, &gt;, &#39;, &apos;, &nbsp; 以及常见的数学/版权符号进行还原。 参数预处理：在执行任何匹配逻辑前，先对 target 和 replace 参数进行反转义。
安全校验对齐：确保在 target.length < 15 的安全校验之前完成反转义，使得长度检查基于真实字符数而非转义后的字符串长度。