### PR TITLE
Pillow的版本得更新

### DIFF
--- a/Plugin/VideoGenerator/requirements.txt
+++ b/Plugin/VideoGenerator/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.31.0
 python-dotenv==1.0.0
-Pillow==10.3.0
+
+Pillow==11.0.0


### PR DESCRIPTION
Python3.13不兼容11之前的版本，根目录之前我们已经改成11了，同步一下