### PR TITLE
feat(rag): 新增基于时间衰减的RAG结果重排功能

### DIFF
--- a/AdminPanel/js/rag-tuning.js
+++ b/AdminPanel/js/rag-tuning.js
@@ -28,6 +28,12 @@ const PARAM_METADATA = {
             "meaning": "标签截断的上下限范围。",
             "logic": "用于控制标签截断的动态调整空间。",
             "range": "建议区间: 0.5 ~ 0.9"
+        },
+        "timeDecay": {
+            "name": "时间衰减控制",
+            "meaning": "实现“近因效应”，让越久的记忆权重衰减越快。",
+            "logic": "halfLifeDays (半衰期)：记忆分数减半的天数。支持精准衰减：::TimeDecay[天数]:[最小分数]:[目标Tags]，仅包含目标标签的内容（如Box）才会衰减，其余（如Wiki）保持原分。",
+            "range": "建议区间: 半衰期 15~90 天；最小分数 0.5。此处仅作为全局回退值。"
         }
     },
     "KnowledgeBaseManager": {

--- a/Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
+++ b/Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
@@ -1898,6 +1898,11 @@ class RAGDiaryPlugin {
         const useTime = allowTimeAndGroup && modifiers.includes('::Time');
         const useGroup = allowTimeAndGroup && modifiers.includes('::Group');
         const useRerank = modifiers.includes('::Rerank');
+        
+        // ✅ 解析 TimeDecay 参数：::TimeDecay[halfLife]:[minScore]:[whitelistTags]
+        // 示例：::TimeDecay30:0.5:Wiki,技巧
+        const timeDecayMatch = modifiers.match(/::TimeDecay(\d+)?(?::(\d+\.?\d*))?(?::([\w,]+))?/);
+        const useTimeDecay = !!timeDecayMatch;
 
         // ✅ 新增：解析TagMemo修饰符和权重
         const tagMemoMatch = modifiers.match(/::TagMemo([\d.]+)/);
@@ -2109,6 +2114,83 @@ class RAGDiaryPlugin {
 
             // ✅ 统一添加 source 标识，防止 VCP Info 显示 unknown
             finalResultsForBroadcast = finalResultsForBroadcast.map(r => ({ ...r, source: 'rag' }));
+
+            // 🌟 V5.2: 时间衰减重排 (Time Decay Reranking)
+            if (useTimeDecay && finalResultsForBroadcast.length > 0) {
+                // 优先从修饰符解析局部参数，格式：::TimeDecay[halfLife]:[minScore]:[targetTags]
+                const localHalfLife = timeDecayMatch[1] ? parseInt(timeDecayMatch[1]) : null;
+                const localMinScore = timeDecayMatch[2] ? parseFloat(timeDecayMatch[2]) : null;
+                const localTargets = timeDecayMatch[3] ? timeDecayMatch[3].split(',') : [];
+
+                const globalDecayConfig = this.ragParams?.RAGDiaryPlugin?.timeDecay || { halfLifeDays: 30, minScore: 0.5 };
+                const halfLife = localHalfLife ?? globalDecayConfig.halfLifeDays ?? 30;
+                const minScore = localMinScore ?? globalDecayConfig.minScore ?? 0.5;
+                
+                const now = dayjs();
+
+                console.log(`[RAGDiaryPlugin] ⏳ Applying Time Decay (Half-life: ${halfLife} days, MinScore: ${minScore}, Targets: ${localTargets.length > 0 ? localTargets.join(',') : 'ALL'})...`);
+
+                finalResultsForBroadcast = finalResultsForBroadcast.map(result => {
+                    // 0. 检查精准打击目标：如果指定了目标标签，则只有包含目标标签的条目才执行衰减
+                    if (localTargets.length > 0) {
+                        const isTarget = localTargets.some(tag => {
+                            // 1. 匹配向量库结构化标签
+                            if (result.matchedTags && result.matchedTags.includes(tag)) return true;
+                            
+                            // 2. 匹配文本中的标签格式 (支持 #Tag, 【Tag】, 以及姐姐文件里的 Tag: ..., Tag, ...)
+                            const text = result.text;
+                            const tagPattern = new RegExp(`(?:#|【|Tag:.*\\b|\\b)${tag}(?:\\b|】|,)`, 'i');
+                            return tagPattern.test(text);
+                        });
+
+                        if (!isTarget) {
+                            // 不在衰减名单内，保持原分
+                            return result;
+                        }
+                    }
+
+                    // 1. 尝试从文本中提取日期 [YYYY-MM-DD]
+                    let dateStr = null;
+                    const textDateMatch = result.text.match(/\[(\d{4}-\d{2}-\d{2})\]/);
+                    if (textDateMatch) {
+                        dateStr = textDateMatch[1];
+                    } else {
+                        // 2. 回退：尝试从文件名或路径中提取日期
+                        const pathSource = result.sourceFile || result.fullPath || '';
+                        const pathDateMatch = pathSource.match(/(\d{4}[-.]\d{2}[-.]\d{2})/);
+                        if (pathDateMatch) {
+                            dateStr = pathDateMatch[1].replace(/\./g, '-');
+                        }
+                    }
+
+                    if (!dateStr) return result;
+
+                    const entryDate = dayjs(dateStr);
+                    if (!entryDate.isValid()) return result;
+
+                    const diffDays = Math.max(0, now.diff(entryDate, 'day'));
+                    // Score = Score * 0.5 ^ (days / halfLife)
+                    const decayFactor = Math.pow(0.5, diffDays / halfLife);
+                    const originalScore = result.rerank_score ?? result.score ?? 0;
+                    const newScore = originalScore * decayFactor;
+
+                    return {
+                        ...result,
+                        score: newScore,
+                        original_score: originalScore,
+                        decay_factor: decayFactor,
+                        diff_days: diffDays
+                    };
+                });
+
+                // 重新按衰减后的分数排序
+                finalResultsForBroadcast.sort((a, b) => (b.score || 0) - (a.score || 0));
+                
+                // 过滤掉分数过低的结果
+                if (minScore > 0) {
+                    finalResultsForBroadcast = finalResultsForBroadcast.filter(r => (r.score || 0) >= minScore);
+                }
+            }
 
             if (useGroup) {
                 retrievedContent = this.formatGroupRAGResults(finalResultsForBroadcast, displayName, activatedGroups, metadata);

--- a/rag_params.json
+++ b/rag_params.json
@@ -3,7 +3,11 @@
     "noise_penalty": 0.05,
     "tagWeightRange": [0.05, 0.45],
     "tagTruncationBase": 0.6,
-    "tagTruncationRange": [0.5, 0.9]
+    "tagTruncationRange": [0.5, 0.9],
+    "timeDecay": {
+      "halfLifeDays": 30,
+      "minScore": 0.5
+    }
   },
   "KnowledgeBaseManager": {
     "activationMultiplier": [0.5, 1.5],


### PR DESCRIPTION
为RAG系统引入“近因效应”，使检索结果能根据内容的新旧程度进行动态调整，提升记忆管理的智能性。

- 新增 `::TimeDecay` 修饰符，支持半衰期、最低分数和目标标签的精准控制
- 在管理面板和配置文件中添加时间衰减的全局参数配置
- 实现基于日期提取的分数衰减算法，并支持按标签进行选择性衰减

针对一些经常更新的归档目录设计的，比如游戏box的更新，召回到旧的记录就不太好