### PR TITLE
build: 添加 Rust 和 Cargo 并更新 pip 工具链

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,10 @@ RUN apk add --no-cache \
   python3-dev \
   linux-headers \
   libffi-dev \
-  openssl-dev \ffmpeg
+  openssl-dev \
+  ffmpeg \
+  rust \
+  cargo
 
 # 在 npm install 之前设置环境变量，跳过 puppeteer 的 chromium 下载
 ARG PUPPETEER_SKIP_DOWNLOAD=true
@@ -46,6 +49,7 @@ RUN npm cache clean --force && npm install --registry=https://registry.npmmirror
 COPY requirements.txt ./
 # 在 Linux 环境下构建时，注释掉仅适用于 Windows 的 win10toast 包
 RUN sed -i '/^win10toast/s/^/#/' requirements.txt
+RUN python3 -m pip install --no-cache-dir --break-system-packages -U pip setuptools wheel -i https://pypi.tuna.tsinghua.edu.cn/simple
 RUN pip3 install --no-cache-dir --break-system-packages --target=/usr/src/app/pydeps -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
 
 # 复制所有源代码


### PR DESCRIPTION

- fix(Dockerfile): 为 Alpine 构建补充 Rust 工具链修复 sudachipy 安装失败，并在安装前升级 pip；修正 openssl-dev/ffmpeg 行续接

**变更概述**
- 在构建阶段安装 rust 和 cargo，解决 sudachipy 在 Alpine/musl 下无预编译轮子时的源码构建失败。
- 在安装 Python 依赖前升级 pip/setuptools/wheel，避免旧版 pip 无法正确选择轮子。
- 修正 openssl-dev 与 ffmpeg 续行问题，避免被解析为一个错误的包名。
- 保持生产阶段镜像不包含 Rust，体积与运行安全性不受影响。

**背景与动机**
- 在构建阶段为插件安装 Python 依赖时，安装 JapaneseHelper 的 sudachipy 失败：
  - 报错：error: can't find Rust compiler
  - Alpine/musl 环境通常没有可用的 sudachipy 预编译轮子，pip 会回退到源码构建，需 Rust 工具链支持。
- 另发现 Dockerfile 中 openssl-dev 与 ffmpeg 行尾续接写法不规范，潜在引发 apk 解析失败。

**问题复现**
- 环境：node:20-alpine（多阶段构建）
- 执行：
  - docker build -t vcptoolbox:test .
- 关键失败日志：
  - Building wheel for sudachipy … error: can't find Rust compiler
  - ERROR: Failed to build installable wheels for some pyproject.toml based projects (sudachipy)

**具体修改**
- 构建阶段系统依赖新增：
  - rust、cargo
- 修正 apk 依赖列表格式：
  - 将 openssl-dev \ffmpeg 调整为独立行续接
- Python 包安装前新增升级步骤：
  - python3 -m pip install -U pip setuptools wheel -i https://pypi.tuna.tsinghua.edu.cn/simple
- 参考代码位置：
  - 新增构建依赖与修正续行：[Dockerfile](file:///d:/project/aiMemery/VCPToolBox/Dockerfile#L12-L33)
  - pip 升级步骤和安装顺序优化：[Dockerfile](file:///d:/project/aiMemery/VCPToolBox/Dockerfile#L45-L50)

**实现细节**
- 仅在构建阶段安装 Rust；生产阶段镜像保持最小化（不含 Rust），不影响运行期体积与安全基线。
- 继续使用清华 PyPI 镜像以加速国内环境构建。
- JapaneseHelper 插件的依赖未改动：
  - [Plugin/JapaneseHelper/requirements.txt](file:///d:/project/aiMemery/VCPToolBox/Plugin/JapaneseHelper/requirements.txt)

**兼容性与风险**
- 兼容性：对 Debian/Ubuntu 或已有 Rust 环境的构建无副作用；对 Alpine 构建修复失败问题。
- 风险：构建阶段安装 Rust 会略微增加构建时间，但生产镜像无增长。
- 运行时：不包含 Rust，运行时行为与体积不变。

**体积与性能影响**
- 构建阶段层包含 Rust，生产阶段镜像不包含 Rust。最终产物镜像体积基本不变。
- 由于避免 sudachipy 源码构建失败，整体构建流程更稳定。

**测试计划与结果**
- 构建阶段目标镜像测试：
  - docker build --target build -t vcptoolbox:build-test .
  - 结果：构建成功，插件 Python 依赖（含 sudachipy）安装完成，无 Rust 缺失错误。
- 完整镜像测试：
  - docker build -t vcptoolbox:fix-sudachi .
  - 结果：构建成功；生产阶段镜像复制 pydeps、Plugin、routes 等目录完成。
- 运行期验证：
  - docker-compose up -d 启动后应用正常拉起。
