### PR TITLE
fix: rescan agent directory on admin panel list request

### DIFF
--- a/modules/agentManager.js
+++ b/modules/agentManager.js
@@ -256,7 +256,8 @@ class AgentManager {
      * 获取所有Agent文件和文件夹结构
      * @returns {Object} 包含文件列表和文件夹结构的对象
      */
-    getAllAgentFiles() {
+    async getAllAgentFiles() {
+        await this.scanAgentFiles();
         return {
             files: this.agentFiles,
             folderStructure: this.folderStructure

--- a/routes/admin/agents.js
+++ b/routes/admin/agents.js
@@ -51,7 +51,7 @@ module.exports = function(options) {
     router.get('/agents', async (req, res) => {
         try {
             await _agentScanReady; // 确保初始扫描已完成
-            const agentFilesData = agentManager.getAllAgentFiles();
+            const agentFilesData = await agentManager.getAllAgentFiles();
             res.json(agentFilesData);
         } catch (error) {
             res.status(500).json({ error: 'Failed to list agent files', details: error.message });


### PR DESCRIPTION
## Problem
After the admin panel (6006) restarts, newly added Agent files
in the `Agent/` directory are not detected until a full PM2
restart of both processes.

## Root Cause
`getAllAgentFiles()` returns a cached in-memory snapshot.
The chokidar watcher uses `ignoreInitial: true`, so if the
watcher misses an `add` event (e.g. during process restart),
the cache becomes stale.

## Fix
- Make `getAllAgentFiles()` async
- Call `await this.scanAgentFiles()` before returning
- Update the route handler to `await` the call

This ensures the filesystem is always the source of truth
when the admin panel requests the agent list.

## Files Changed
- `modules/agentManager.js` (1 method signature + 1 line)
- `routes/admin/agents.js` (1 line)