### PR TITLE
fix: _truncateCoreTags .toFixed() 崩溃导致 TagBoost 标签感应静默失效

### DIFF
--- a/Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
+++ b/Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
@@ -510,11 +510,11 @@ class RAGDiaryPlugin {
 
         // 2. 获取 EPA 指标 (L, R)
         const epa = await this.vectorDBManager.getEPAAnalysis(queryVector);
-        const L = epa.logicDepth;
-        const R = epa.resonance;
+        const L = epa?.logicDepth ?? 0.5;
+        const R = epa?.resonance ?? 0;
 
         // 3. 获取语义宽度 (S)
-        const S = this.contextVectorManager.computeSemanticWidth(queryVector);
+        const S = this.contextVectorManager?.computeSemanticWidth?.(queryVector) ?? 0.5;
 
         // 4. 计算动态 Beta (TagWeight)
         // β = σ(L · log(1 + R) - S · noise_penalty)
@@ -577,7 +577,7 @@ class RAGDiaryPlugin {
         const truncated = tags.slice(0, targetCount);
 
         if (truncated.length < tags.length) {
-            console.log(`[RAGDiaryPlugin][Truncation] ${tags.length} -> ${truncated.length} tags (Ratio: ${ratio.toFixed(2)}, L:${metrics.L.toFixed(2)}, S:${metrics.S.toFixed(2)})`);
+            console.log(`[RAGDiaryPlugin][Truncation] ${tags.length} -> ${truncated.length} tags (Ratio: ${ratio.toFixed(2)}, L:${(metrics?.L ?? 0).toFixed(2)}, S:${(metrics?.S ?? 0).toFixed(2)})`);
         }
         return truncated;
     }


### PR DESCRIPTION
## 问题

`_truncateCoreTags` 方法中一行日志代码缺少防御性检查，导致每次 RAG 检索时 `applyTagBoost` 的完整结果被静默丢弃，TagBoost 标签感应能力完全失效，检索退化为纯向量 KNN。

**报错日志：**
`[RAGDiaryPlugin] Failed to sense tags via applyTagBoost: Cannot read properties of undefined (reading 'toFixed')`

**复现率：** 100%，只要标签数 > 5 触发截断逻辑即崩溃。

## 根因

**RAGDiaryPlugin.js `_truncateCoreTags` 方法（约第578行）：**

`metrics.L.toFixed(2)` 和 `metrics.S.toFixed(2)` 直接访问，无防御性检查。

`metrics` 参数通过多层位置参数传递（`_processSingleSystemMessage` 有 17 个位置参数），签名默认值为 `metrics = {}`。当默认值生效时 `{}.L = undefined`，触发 TypeError。

该异常被上层 try-catch 捕获后，`applyTagBoost` 返回的完整 TagBoost 结果（Spike Propagation + 残差金字塔 + EPA 投影）被丢弃，`coreTagsForSearch` 退化为空数组。

## 修复内容

1. **`_truncateCoreTags`（根因修复）：** `metrics.L.toFixed(2)` → `(metrics?.L ?? 0).toFixed(2)`，`metrics.S` 同理
2. **`_calculateDynamicParams`（防御性加固）：** L/R/S 赋值加 `?.` 和 `??` 兜底

## 影响评估

- **严重度：高** — 标签增强是浪潮 RAG 引擎的核心能力，此 bug 导致其完全静默失效
- **修复成本：极低** — 4行代码加可选链和空值合并
- **已验证：** 修复后 pm2 重启，error log 无新增报错，TagBoost 恢复正常