### PR TITLE
feat: per-agent semantic group filtering

### DIFF
--- a/Plugin/RAGDiaryPlugin/MetaThinkingManager.js
+++ b/Plugin/RAGDiaryPlugin/MetaThinkingManager.js
@@ -103,7 +103,7 @@ class MetaThinkingManager {
     /**
      * 处理VCP元思考链 - 递归向量增强的多阶段推理
      */
-    async processMetaThinkingChain(chainName, queryVector, userContent, aiContent, combinedQueryForDisplay, kSequence, useGroup, isAutoMode = false, autoThreshold = 0.65) {
+    async processMetaThinkingChain(chainName, queryVector, userContent, aiContent, combinedQueryForDisplay, kSequence, useGroup, isAutoMode = false, autoThreshold = 0.65, agentName = null) {
 
         // 🌟 兜底：如果配置尚未加载，先执行加载
         if (!this.metaThinkingChains.chains || Object.keys(this.metaThinkingChains.chains).length === 0) {
@@ -206,7 +206,7 @@ class MetaThinkingManager {
         // 如果启用语义组，获取激活的组
         let activatedGroups = null;
         if (useGroup) {
-            activatedGroups = this.ragPlugin.semanticGroups.detectAndActivateGroups(userContent);
+            activatedGroups = this.ragPlugin.semanticGroups.detectAndActivateGroups(userContent, agentName);
             if (activatedGroups.size > 0) {
                 const enhancedVector = await this.ragPlugin.semanticGroups.getEnhancedVector(userContent, activatedGroups, currentQueryVector);
                 if (enhancedVector) {

--- a/Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
+++ b/Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
@@ -1311,6 +1311,10 @@ class RAGDiaryPlugin {
         const hybridDeclarations = [...processedContent.matchAll(/《《(.*?)日记本(.*?)》》/g)];
         const metaThinkingDeclarations = [...processedContent.matchAll(/\[\[VCP元思考(.*?)\]\]/g)];
         const directDiariesDeclarations = [...processedContent.matchAll(/\{\{(.*?)日记本(.*?)\}\}/g)];
+
+        // Per-Agent: 从同一 system message 的日记本声明中提取 Agent 标识
+        const agentNameMatch = content.match(/\[\[(\w+?)日记本/);
+        const agentName = agentNameMatch ? agentNameMatch[1] : null;
         console.log(`[RAGDiaryPlugin] Found ${directDiariesDeclarations.length} {{...}} declarations`);
         // --- 1. 处理 [[VCP元思考...]] 元思考链 ---
         for (const match of metaThinkingDeclarations) {
@@ -1372,7 +1376,8 @@ class RAGDiaryPlugin {
                     null, // kSequence现在从JSON配置中获取，不再从占位符传递
                     useGroup,
                     isAutoMode,
-                    autoThreshold
+                    autoThreshold,
+                    agentName // Per-Agent: 传递 Agent 标识用于语义组/思维簇过滤
                 );
 
                 processedContent = processedContent.replace(placeholder, metaResult);
@@ -2316,7 +2321,7 @@ class RAGDiaryPlugin {
         let vcpInfoData = null;
 
         if (useGroup) {
-            activatedGroups = this.semanticGroups.detectAndActivateGroups(userContent);
+            activatedGroups = this.semanticGroups.detectAndActivateGroups(userContent, dbName);
             if (activatedGroups.size > 0) {
                 const enhancedVector = await this.semanticGroups.getEnhancedVector(userContent, activatedGroups, queryVector);
                 if (enhancedVector) finalQueryVector = enhancedVector;

--- a/Plugin/RAGDiaryPlugin/SemanticGroupManager.js
+++ b/Plugin/RAGDiaryPlugin/SemanticGroupManager.js
@@ -271,10 +271,15 @@ class SemanticGroupManager {
     }
 
     // ============ 核心功能：组激活 ============
-    detectAndActivateGroups(text) {
+    detectAndActivateGroups(text, agentName = null) {
         const activatedGroups = new Map();
 
         for (const [groupName, groupData] of Object.entries(this.groups)) {
+            // Per-Agent 过滤：若组配置了 agents 字段且当前 agent 不在其中，跳过
+            if (agentName && groupData.agents && groupData.agents.length > 0 && !groupData.agents.some(a => agentName === a || agentName.startsWith(a))) {
+                console.log(`[SemanticGroup] 组 "${groupName}" 因 agents 过滤跳过 (当前agent: ${agentName}, 允许: ${groupData.agents.join(',')})`);
+                continue;
+            }
             // 如果 auto_learned 不存在，提供一个空数组作为后备
             const autoLearnedWords = groupData.auto_learned || [];
             const allWords = [...groupData.words, ...autoLearnedWords];


### PR DESCRIPTION
- SemanticGroupManager: add agentName param to detectAndActivateGroups, filter groups by optional 'agents' field with prefix matching
- RAGDiaryPlugin: pass dbName to semantic group detection in _processRAGPlaceholder, extract agentName from diary declarations and pass to MetaThinkingManager
- MetaThinkingManager: accept agentName param and forward to semantic group detection

Groups without 'agents' field remain global (backward compatible). Tested: forward match, reverse isolation, backward compat all passed.