### PR TITLE
feat: Per-Agent semantic group filtering via processingContext

### DIFF
--- a/Plugin.js
+++ b/Plugin.js
@@ -363,7 +363,7 @@ class PluginManager extends EventEmitter {
         return `[Invalid value format for placeholder ${placeholder}]`;
     }
 
-    async executeMessagePreprocessor(pluginName, messages) {
+    async executeMessagePreprocessor(pluginName, messages, context = {}) {
         const processorModule = this.messagePreprocessors.get(pluginName);
         const pluginManifest = this.plugins.get(pluginName);
         if (!processorModule || !pluginManifest) {
@@ -376,8 +376,9 @@ class PluginManager extends EventEmitter {
         }
         try {
             if (this.debugMode) console.log(`[PluginManager] Executing message preprocessor: ${pluginName}`);
+            console.log(`[PluginManager] Preprocessor context agentName for ${pluginName}: ${context?.agentName || 'null'}`);
             const pluginSpecificConfig = this._getPluginConfig(pluginManifest);
-            const processedMessages = await processorModule.processMessages(messages, pluginSpecificConfig);
+            const processedMessages = await processorModule.processMessages(messages, pluginSpecificConfig, context);
             if (this.debugMode) console.log(`[PluginManager] Message preprocessor ${pluginName} finished.`);
             return processedMessages;
         } catch (error) {

--- a/Plugin/RAGDiaryPlugin/MetaThinkingManager.js
+++ b/Plugin/RAGDiaryPlugin/MetaThinkingManager.js
@@ -103,7 +103,7 @@ class MetaThinkingManager {
     /**
      * 处理VCP元思考链 - 递归向量增强的多阶段推理
      */
-    async processMetaThinkingChain(chainName, queryVector, userContent, aiContent, combinedQueryForDisplay, kSequence, useGroup, isAutoMode = false, autoThreshold = 0.65) {
+    async processMetaThinkingChain(chainName, queryVector, userContent, aiContent, combinedQueryForDisplay, kSequence, useGroup, isAutoMode = false, autoThreshold = 0.65, context = {}) {
 
         // 🌟 兜底：如果配置尚未加载，先执行加载
         if (!this.metaThinkingChains.chains || Object.keys(this.metaThinkingChains.chains).length === 0) {
@@ -206,7 +206,9 @@ class MetaThinkingManager {
         // 如果启用语义组，获取激活的组
         let activatedGroups = null;
         if (useGroup) {
-            activatedGroups = this.ragPlugin.semanticGroups.detectAndActivateGroups(userContent);
+            const agentName = context?.agentName || null;
+            console.log(`[MetaThinkingManager] Semantic group agentName: ${agentName || 'null'}`);
+            activatedGroups = this.ragPlugin.semanticGroups.detectAndActivateGroups(userContent, agentName);
             if (activatedGroups.size > 0) {
                 const enhancedVector = await this.ragPlugin.semanticGroups.getEnhancedVector(userContent, activatedGroups, currentQueryVector);
                 if (enhancedVector) {

--- a/Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
+++ b/Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
@@ -1041,7 +1041,7 @@ class RAGDiaryPlugin {
     }
 
     // processMessages 是 messagePreprocessor 的标准接口
-    async processMessages(messages, pluginConfig) {
+    async processMessages(messages, pluginConfig, context = {}) {
         try {
             // ✅ 新增：更新上下文向量映射（为后续衰减聚合做准备）
             // 🌟 修复：传递 allowApi 配置，控制是否允许向量化历史消息
@@ -1247,7 +1247,8 @@ class RAGDiaryPlugin {
                     contextDiaryPrefixes, // 🌟 V4.1: 传递上下文日记去重前缀
                     messages, // 🌟 V4.2: 传递完整消息用于 RoleValve
                     ghostTags, // 🌟 V6: 传递幽灵节点
-                    collectedAttachments // 🌟 V7: 传递附件收集器
+                    collectedAttachments, // 🌟 V7: 传递附件收集器
+                    context // 🌟 Per-Agent Semantic Group: 透传当前 Agent 上下文
                 );
 
                 newMessages[index].content = processedContent;
@@ -1323,7 +1324,7 @@ class RAGDiaryPlugin {
     }
 
     // V3.0 新增: 处理单条 system 消息内容的辅助函数
-    async _processSingleSystemMessage(content, queryVector, userContent, aiContent, combinedQueryForDisplay, dynamicK, timeRanges, processedDiaries, isAIMemoLicensed, dynamicTagWeight = 0.15, tagTruncationRatio = 0.5, metrics = {}, historySegments = [], contextDiaryPrefixes = new Set(), messages = [], ghostTags = [], collectedAttachments = []) {
+    async _processSingleSystemMessage(content, queryVector, userContent, aiContent, combinedQueryForDisplay, dynamicK, timeRanges, processedDiaries, isAIMemoLicensed, dynamicTagWeight = 0.15, tagTruncationRatio = 0.5, metrics = {}, historySegments = [], contextDiaryPrefixes = new Set(), messages = [], ghostTags = [], collectedAttachments = [], context = {}) {
         if (!this.pushVcpInfo) {
             console.warn('[RAGDiaryPlugin] _processSingleSystemMessage: pushVcpInfo is null. Cannot broadcast RAG details.');
         }
@@ -1398,7 +1399,8 @@ class RAGDiaryPlugin {
                     null, // kSequence现在从JSON配置中获取，不再从占位符传递
                     useGroup,
                     isAutoMode,
-                    autoThreshold
+                    autoThreshold,
+                    context // 🌟 Per-Agent Semantic Group: 透传当前 Agent 上下文到元思考链
                 );
 
                 processedContent = processedContent.replace(placeholder, metaResult);
@@ -1513,7 +1515,8 @@ class RAGDiaryPlugin {
                             historySegments: historySegments, // 🌟 传入历史分段
                             contextDiaryPrefixes, // 🌟 V4.1: 传入上下文日记去重前缀
                             ghostTags, // 🌟 V6: 传入幽灵节点
-                            collectedAttachments // 🌟 V7
+                            collectedAttachments, // 🌟 V7
+                            context // 🌟 Per-Agent Semantic Group: 透传当前 Agent 上下文
                         });
                         return { placeholder, content: retrievedContent };
                     } catch (error) {
@@ -2157,7 +2160,7 @@ class RAGDiaryPlugin {
      * @param {string} originalUserQuery - 从 chatCompletionHandler 回溯找到的真实用户查询
      * @returns {Promise<string>} 返回完整的、带有新元数据的新区块文本
      */
-    async refreshRagBlock(metadata, contextData, originalUserQuery) {
+    async refreshRagBlock(metadata, contextData, originalUserQuery, context = {}) {
         console.log(`[VCP Refresh] 正在刷新 "${metadata.dbName}" 的记忆区块 (U:0.5, A:0.35, T:0.15 权重)...`);
         const { lastAiMessage, toolResultsText } = contextData;
 
@@ -2226,6 +2229,7 @@ class RAGDiaryPlugin {
             combinedQueryForDisplay: combinedSanitizedContext, // ✅ 使用组合后的上下文进行显示
             dynamicK: metadata.k || 5,
             timeRanges: this.timeParser.parse(combinedSanitizedContext), // ✅ 基于组合后的上下文重新解析时间
+            context // 🌟 Per-Agent Semantic Group: 透传当前 Agent 上下文到 refresh 路径
         });
 
         // 6. 返回完整的、带有新元数据的新区块文本
@@ -2249,7 +2253,8 @@ class RAGDiaryPlugin {
             historySegments = [], // 🌟 Tagmemo V4
             contextDiaryPrefixes = new Set(), // 🌟 V4.1: 上下文日记去重前缀
             ghostTags = [], // 🌟 V6: 幽灵节点
-            collectedAttachments = [] // 🌟 V7
+            collectedAttachments = [], // 🌟 V7
+            context = {} // 🌟 Per-Agent Semantic Group: 当前 Agent 上下文
         } = options;
 
         // 1️⃣ 生成缓存键
@@ -2284,6 +2289,7 @@ class RAGDiaryPlugin {
         const kMultiplier = this._extractKMultiplier(modifiers);
         const useTime = allowTimeAndGroup && modifiers.includes('::Time');
         const useGroup = allowTimeAndGroup && modifiers.includes('::Group');
+        
         // 🌟 Rerank+ (RRF): 解析 ::Rerank+ 修饰符
         // 语法: ::Rerank+ (默认α=0.5) 或 ::Rerank+0.7 (α=0.7, Reranker占70%权重)
         const rerankPlusMatch = modifiers.match(/::Rerank\+(\d+\.?\d*)?/);
@@ -2342,7 +2348,9 @@ class RAGDiaryPlugin {
         let vcpInfoData = null;
 
         if (useGroup) {
-            activatedGroups = this.semanticGroups.detectAndActivateGroups(userContent);
+            const agentName = context?.agentName || null;
+            
+            activatedGroups = this.semanticGroups.detectAndActivateGroups(userContent, agentName);
             if (activatedGroups.size > 0) {
                 const enhancedVector = await this.semanticGroups.getEnhancedVector(userContent, activatedGroups, queryVector);
                 if (enhancedVector) finalQueryVector = enhancedVector;

--- a/Plugin/RAGDiaryPlugin/SemanticGroupManager.js
+++ b/Plugin/RAGDiaryPlugin/SemanticGroupManager.js
@@ -271,13 +271,36 @@ class SemanticGroupManager {
     }
 
     // ============ 核心功能：组激活 ============
-    detectAndActivateGroups(text) {
+    isGroupAllowedForAgent(groupData, agentName = null) {
+        const allowedAgents = groupData?.agents;
+
+        // 向后兼容：未配置 agents 或配置为空 = 全局生效
+        if (!Array.isArray(allowedAgents) || allowedAgents.length === 0) {
+            return true;
+        }
+
+        // 向后兼容：上游尚未透传 agentName 时，不做拦截
+        if (!agentName) {
+            return true;
+        }
+
+        return allowedAgents.includes(agentName);
+    }
+
+    detectAndActivateGroups(text, agentName = null) {
         const activatedGroups = new Map();
 
         for (const [groupName, groupData] of Object.entries(this.groups)) {
+            if (!this.isGroupAllowedForAgent(groupData, agentName)) {
+                const allowedAgents = Array.isArray(groupData?.agents) ? groupData.agents.join(', ') : 'GLOBAL';
+                console.log(`[SemanticGroup] Skip Group "${groupName}" for agent "${agentName}" (allowed: ${allowedAgents})`);
+                continue;
+            }
+
             // 如果 auto_learned 不存在，提供一个空数组作为后备
             const autoLearnedWords = groupData.auto_learned || [];
-            const allWords = [...groupData.words, ...autoLearnedWords];
+            const baseWords = groupData.words || [];
+            const allWords = [...baseWords, ...autoLearnedWords];
 
             const matchedWords = allWords.filter(word => this.flexibleMatch(text, word));
 

--- a/modules/chatCompletionHandler.js
+++ b/modules/chatCompletionHandler.js
@@ -30,6 +30,8 @@ const ToolExecutor = require('./vcpLoop/toolExecutor');
 const StreamHandler = require('./handlers/streamHandler');
 const NonStreamHandler = require('./handlers/nonStreamHandler');
 
+
+
 /**
  * 检测工具返回结果是否为错误
  * @param {any} result - 工具返回的结果
@@ -213,7 +215,7 @@ async function fetchWithRetry(
   throw new Error('Fetch failed after all retries.');
 }
 // 辅助函数：根据新上下文刷新对话历史中的RAG区块
-async function _refreshRagBlocksIfNeeded(messages, newContext, pluginManager, debugMode = false) {
+async function _refreshRagBlocksIfNeeded(messages, newContext, pluginManager, debugMode = false, processingContext = {}) {
   const ragPlugin = pluginManager.messagePreprocessors?.get('RAGDiaryPlugin');
   // 检查插件是否存在且是否实现了refreshRagBlock方法
   if (!ragPlugin || typeof ragPlugin.refreshRagBlock !== 'function') {
@@ -283,7 +285,7 @@ async function _refreshRagBlocksIfNeeded(messages, newContext, pluginManager, de
             }
 
             // 调用 RAG 插件的刷新接口, now with originalUserQuery
-            const newBlock = await ragPlugin.refreshRagBlock(metadata, newContext, originalUserQuery);
+            const newBlock = await ragPlugin.refreshRagBlock(metadata, newContext, originalUserQuery, processingContext);
 
             // 🟢 改进点4：关键修复！使用回调函数进行替换，防止 newBlock 中的 "$" 符号被解析为正则特殊字符
             // 这是一个极其常见的 Bug，导致包含 $ 的内容（如公式、代码）替换失败或乱码
@@ -480,21 +482,17 @@ class ChatCompletionHandler {
       }
 
       // --- VCPTavern 优先处理 ---
-      // 在任何变量替换之前，首先运行 VCPTavern 来注入预设内容
+      // 在任何变量替换之前，首先准备一个可用的初始上下文，再运行 VCPTavern 注入预设内容
       let tavernProcessedMessages = originalBody.messages;
-      if (pluginManager.messagePreprocessors.has('VCPTavern')) {
-        if (DEBUG_MODE) console.log(`[Server] Calling priority message preprocessor: VCPTavern`);
-        try {
-          tavernProcessedMessages = await pluginManager.executeMessagePreprocessor('VCPTavern', originalBody.messages);
-        } catch (pluginError) {
-          console.error(`[Server] Error in priority preprocessor VCPTavern:`, pluginError);
-        }
-      }
 
       // --- 统一处理所有变量替换 ---
+      // Identity is carried by processingContext and provided explicitly by the request layer.
+      const agentName = originalBody.agentName || originalBody.context?.agentName || null;
+
       // 创建一个包含所有所需依赖的统一上下文
       const processingContext = {
         pluginManager,
+        agentName,
         cachedEmojiLists: this.config.cachedEmojiLists,
         detectors: this.config.detectors,
         superDetectors: this.config.superDetectors,
@@ -506,6 +504,16 @@ class ChatCompletionHandler {
         expandedAgentName: null,    // string | null - 已展开的唯一 Agent 别名
         expandedToolboxes: new Set() // Set<string> - 已展开的 Toolbox 别名集合
       };
+
+      if (pluginManager.messagePreprocessors.has('VCPTavern')) {
+        if (DEBUG_MODE) console.log(`[Server] Calling priority message preprocessor: VCPTavern`);
+        try {
+          tavernProcessedMessages = await pluginManager.executeMessagePreprocessor('VCPTavern', originalBody.messages, processingContext);
+          processingContext.messages = tavernProcessedMessages;
+        } catch (pluginError) {
+          console.error(`[Server] Error in priority preprocessor VCPTavern:`, pluginError);
+        }
+      }
 
       // 🔒 顺序处理消息（非并发），确保 agent/toolbox 的"首次展开"语义正确
       // 如果使用 Promise.all 并发，多条消息可能同时展开同一个 agent，违反"只展开一个"的约束
@@ -560,7 +568,7 @@ class ChatCompletionHandler {
         if (pluginManager.messagePreprocessors.has(processorName)) {
           if (DEBUG_MODE) console.log(`[Server] Calling message preprocessor: ${processorName}`);
           try {
-            processedMessages = await pluginManager.executeMessagePreprocessor(processorName, processedMessages);
+            processedMessages = await pluginManager.executeMessagePreprocessor(processorName, processedMessages, processingContext);
           } catch (pluginError) {
             console.error(`[Server] Error in preprocessor ${processorName}:`, pluginError);
           }
@@ -574,7 +582,7 @@ class ChatCompletionHandler {
 
         if (DEBUG_MODE) console.log(`[Server] Calling message preprocessor: ${name}`);
         try {
-          processedMessages = await pluginManager.executeMessagePreprocessor(name, processedMessages);
+          processedMessages = await pluginManager.executeMessagePreprocessor(name, processedMessages, processingContext);
         } catch (pluginError) {
           console.error(`[Server] Error in preprocessor ${name}:`, pluginError);
         }


### PR DESCRIPTION
## 概述`n`n为语义组增加 Per-Agent 过滤能力：当 semantic_groups.json 中的组配置了 allowedAgents 字段时，仅对指定 Agent 生效。`n`n## 改动文件`n`n- **chatCompletionHandler.js**：将 agentName 写入 processingContext，并在 _refreshRagBlocksIfNeeded 和 executeMessagePreprocessor 中透传。`n- **Plugin.js**：将 processingContext 转发给消息预处理器。`n- **RAGDiaryPlugin.js**：processMessages / refreshRagBlock / _processRAGPlaceholder 接收 context 参数，将 agentName 传递给 detectAndActivateGroups。`n- **SemanticGroupManager.js**：新增 isGroupAllowedForAgent 辅助方法；detectAndActivateGroups 在 allowedAgents 存在时按 Agent 过滤。`n- **MetaThinkingManager.js**：接收并转发 processingContext。`n`n## 行为说明`n`n- 未配置 allowedAgents 的组保持全局生效（向后兼容）。`n- 配置了 allowedAgents: [name1, name2] 的组仅对列出的 Agent 激活。`n- identity 通过 processingContext 在主处理链和 refresh/placeholder 旁路中统一继承。`n`n## 后续计划`n`n前端侧 identity 输入源的规范化（稳定提供 agentId + agentName）将作为单独的 follow-up PR 提交到 VCPChat 仓库。