### PR TITLE
feat(DeepWikiVCP): v2.1.0 — Deep Research +多仓库查询 + 智能代理

### DIFF
--- a/Plugin/DeepWikiVCP/DeepWikiVCP.js
+++ b/Plugin/DeepWikiVCP/DeepWikiVCP.js
@@ -1,385 +1,339 @@
 /**
- * DeepWikiVCP v2.0 - VCP 同步插件
- * 通过 DeepWiki 官方 MCP API 获取 GitHub 仓库的 AI 生成文档
+ * DeepWikiVCP v2.1.0 - VCP同步插件
+ * 通过DeepWiki 官方 MCP API 获取任意GitHub公开仓库的 AI 生成文档
+ *
+ * 支持功能:
+ * - wiki_structure: 获取文档目录结构
+ * - wiki_content: 读取完整文档内容
+ * - wiki_ask: AI 智能问答 (支持 Deep Research /多仓库查询)
  *
  * API 端点: https://mcp.deepwiki.com/mcp
  * 协议: MCP over Streamable HTTP (JSON-RPC 2.0)
  * 认证: 公开仓库无需认证
- * 零外部依赖 - 仅使用 Node.js 18+ 内置 fetch()
+ * 零外部依赖 -仅使用 Node.js 18+ 内置 fetch()
+ *
+ * === MCP 参数限制 ===
+ * ask_question schema: { repoName: string|string[], question: string }
+ * 不接受其他参数。Deep Research 通过 [DEEP RESEARCH] 前缀实现。
+ *
+ * === 代理策略 ===
+ * 仅当 config.env中显式配置 DEEPWIKI_PROXY 时才启用代理。
+ * 不读取系统级HTTP_PROXY，避免劫持系统代理导致不稳定。
+ * 代理请求使用15秒快速超时，失败后自动回退直连(180秒超时)。
  *
  * @author infinite-vector
- * @version 2.0.0
+ * @version 2.1.0
  */
 
-// ============================================================
+//============================================================
 // 1. 配置与常量
 // ============================================================
-
 const MCP_ENDPOINT = 'https://mcp.deepwiki.com/mcp';
-const REQUEST_TIMEOUT = 120000; // 120秒超时
-const MAX_CONTENT_LENGTH = 80000; // 内容截断阈值（字符数），防止 token 爆炸
+const REQUEST_TIMEOUT = 180000;
+const PROXY_TIMEOUT = 15000;
+const MAX_CONTENT_LENGTH = 80000;
+
+//============================================================
+// 2. 代理支持
+// ============================================================
+let proxyDispatcher = null;
+
+function setupProxy() {
+  const explicitProxy = process.env.DEEPWIKI_PROXY;
+  if (!explicitProxy) {
+    log('未配置 DEEPWIKI_PROXY，使用默认网络（与v2.0行为一致）');
+    return;
+  }
+  log(`检测到显式代理: ${explicitProxy}`);
+  try {
+    const { ProxyAgent } = require('undici');
+    proxyDispatcher = new ProxyAgent({ uri: explicitProxy, allowH2: false });
+    log(`ProxyAgent 已创建 (H2禁用): ${explicitProxy}`);
+  } catch (e) {
+    log(`ProxyAgent 创建失败 (${e.message})，使用默认网络`);
+    proxyDispatcher = null;
+  }
+}
 
 // ============================================================
-// 2. 日志与响应工具
+// 3. 日志与响应
 // ============================================================
-
-const log = (msg) => {
-    console.error(`[DeepWikiVCP] ${new Date().toISOString()}: ${msg}`);
-};
-
-const sendResponse = (data) => {
-    console.log(JSON.stringify(data));
-    process.exit(0);
-};
-
-const sendError = (message) => {
-    sendResponse({ status: 'error', error: `DeepWiki Error: ${message}` });
-};
+const log = (msg) => console.error(`[DeepWikiVCP] ${new Date().toISOString()}: ${msg}`);
+const sendResponse = (data) => { console.log(JSON.stringify(data)); process.exit(0); };
+const sendError = (message) => sendResponse({ status: 'error', error: `DeepWiki Error: ${message}` });
 
 // ============================================================
-// 3. MCP 通信核心
+// 4. MCP 通信核心
 // ============================================================
+async function mcpCallOnce(toolName, args, dispatcher, timeout) {
+  const payload = {
+    jsonrpc: '2.0',
+    method: 'tools/call',
+    params: { name: toolName, arguments: args },
+    id: Date.now(),
+  };
 
-/**
- * 向 DeepWiki MCP 服务器发送 JSON-RPC 请求
- * MCP 协议使用 Streamable HTTP：
- *   - POST JSON-RPC 到 /mcp 端点
- *   - 响应可能是标准 JSON 或 SSE 流
- */
+  const controller = new AbortController();
+  const tid = setTimeout(() => controller.abort(), timeout);
+
+  const fetchOptions = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+    },
+    body: JSON.stringify(payload),
+    signal: controller.signal,
+  };
+  if (dispatcher) fetchOptions.dispatcher = dispatcher;
+
+  try {
+    const res = await fetch(MCP_ENDPOINT, fetchOptions);
+    clearTimeout(tid);
+
+    if (!res.ok) {
+      const errText = await res.text().catch(() => 'Unknown');
+      throw new Error(`HTTP ${res.status}: ${errText.substring(0, 500)}`);
+    }
+
+    const ct = res.headers.get('content-type') || '';
+    if (ct.includes('application/json')) {
+      const r = await res.json();
+      if (r.error) throw new Error(`MCP Error: ${JSON.stringify(r.error)}`);
+      return r.result || r;
+    }
+    if (ct.includes('text/event-stream')) {
+      return await parseSSE(res);
+    }
+    const body = await res.text();
+    try {
+      const p = JSON.parse(body);
+      if (p.error) throw new Error(`MCP Error: ${JSON.stringify(p.error)}`);
+      return p.result || p;
+    } catch {
+      return { content: [{ type: 'text', text: body }] };
+    }
+  } catch (e) {
+    clearTimeout(tid);
+    if (e.name === 'AbortError') {
+      throw new Error(`请求超时 (${timeout / 1000}秒)`);
+    }
+    throw e;
+  }
+}
+
 async function mcpCall(toolName, args) {
-    const payload = {
-        jsonrpc: '2.0',
-        method: 'tools/call',
-        params: { name: toolName, arguments: args },
-        id: Date.now(),
-    };
+  log(`调用 MCP: ${toolName}, 参数: ${JSON.stringify(args)}`);
 
-    log(`调用 MCP: ${toolName}, 参数: ${JSON.stringify(args)}`);
-
-    const controller = new AbortController();
-    const tid = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
-
+  if (proxyDispatcher) {
     try {
-        const res = await fetch(MCP_ENDPOINT, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Accept': 'application/json, text/event-stream',
-            },
-            body: JSON.stringify(payload),
-            signal: controller.signal,
-        });
-        clearTimeout(tid);
-
-        if (!res.ok) {
-            const errText = await res.text().catch(() => 'Unknown');
-            throw new Error(`HTTP ${res.status}: ${errText.substring(0, 500)}`);
-        }
-
-        const ct = res.headers.get('content-type') || '';
-
-        // 情况1: 标准 JSON 响应
-        if (ct.includes('application/json')) {
-            const r = await res.json();
-            if (r.error) throw new Error(`MCP Error: ${JSON.stringify(r.error)}`);
-            return r.result || r;
-        }
-
-        // 情况2: SSE 流式响应 (MCP Streamable HTTP)
-        if (ct.includes('text/event-stream')) {
-            return await parseSSE(res);
-        }
-
-        // 情况3: 纯文本回退
-        const body = await res.text();
-        try {
-            const p = JSON.parse(body);
-            if (p.error) throw new Error(`MCP Error: ${JSON.stringify(p.error)}`);
-            return p.result || p;
-        } catch {
-            return { content: [{ type: 'text', text: body }] };
-        }
+      return await mcpCallOnce(toolName, args, proxyDispatcher, PROXY_TIMEOUT);
     } catch (e) {
-        clearTimeout(tid);
-        if (e.name === 'AbortError') {
-            throw new Error(`请求超时 (${REQUEST_TIMEOUT / 1000}秒)`);
-        }
-        throw e;
+      log(`代理请求失败 (${e.message})，回退直连...`);
+      try {
+        return await mcpCallOnce(toolName, args, null, REQUEST_TIMEOUT);
+      } catch (e2) {
+        throw new Error(`代理和直连均失败。代理: ${e.message} | 直连: ${e2.message}`);
+      }
     }
+  }
+
+  return await mcpCallOnce(toolName, args, null, REQUEST_TIMEOUT);
 }
 
-/**
- * 解析 SSE (Server-Sent Events) 流式响应
- */
 async function parseSSE(response) {
-    const text = await response.text();
-    const lines = text.split('\n');
-    let lastData = null;
-
-    for (const line of lines) {
-        if (line.startsWith('data: ')) {
-            const dataStr = line.slice(6).trim();
-            if (dataStr && dataStr !== '[DONE]') {
-                try {
-                    lastData = JSON.parse(dataStr);
-                } catch {
-                    // 非 JSON 数据行，跳过
-                }
-            }
-        }
+  const text = await response.text();
+  const lines = text.split('\n');
+  let lastData = null;
+  for (const line of lines) {
+    if (line.startsWith('data: ')) {
+      const dataStr = line.slice(6).trim();
+      if (dataStr && dataStr !== '[DONE]') {
+        try { lastData = JSON.parse(dataStr); } catch { /* skip */ }
+      }
     }
-
-    if (lastData) {
-        if (lastData.error) {
-            throw new Error(`MCP SSE Error: ${JSON.stringify(lastData.error)}`);
-        }
-        return lastData.result || lastData;
-    }
-
-    // 没有解析到有效 JSON-RPC 结果，把整个文本作为内容返回
-    return { content: [{ type: 'text', text }] };
+  }
+  if (lastData) {
+    if (lastData.error) throw new Error(`MCP SSE Error: ${JSON.stringify(lastData.error)}`);
+    return lastData.result || lastData;
+  }
+  return { content: [{ type: 'text', text }] };
 }
 
 // ============================================================
-// 4. 结果提取与格式化
+// 5. 结果提取与格式化
 // ============================================================
-
-/**
- * 从 MCP 响应中提取文本内容
- * MCP 工具返回格式: { content: [{ type: 'text', text: '...' }] }
- */
 function extractText(result) {
-    if (!result) return '(无返回内容)';
-
-    // 标准 MCP 工具返回格式
-    if (result.content && Array.isArray(result.content)) {
-        return result.content
-            .filter(item => item.type === 'text')
-            .map(item => item.text)
-            .join('\n\n');
-    }
-
-    // 直接文本
-    if (typeof result === 'string') return result;
-
-    // 嵌套结果
-    if (result.result) return extractText(result.result);
-
-    // 兜底：JSON 序列化
-    return JSON.stringify(result, null, 2);
+  if (!result) return '(无返回内容)';
+  if (result.content && Array.isArray(result.content)) {
+    return result.content.filter(i => i.type === 'text').map(i => i.text).join('\n\n');
+  }
+  if (typeof result === 'string') return result;
+  if (result.result) return extractText(result.result);
+  return JSON.stringify(result, null, 2);
 }
 
-/**
- * 智能截断内容，防止 token 爆炸
- * 优先在换行符处截断，保持内容完整性
- */
 function truncate(text, maxLen = MAX_CONTENT_LENGTH) {
-    if (!text || text.length <= maxLen) return text;
-
-    const truncated = text.substring(0, maxLen);
-    const lastNewline = truncated.lastIndexOf('\n');
-    const cutPoint = lastNewline > maxLen * 0.8 ? lastNewline : maxLen;
-
-    return truncated.substring(0, cutPoint) +
-        `\n\n---\n⚠️ [内容已截断] 原始 ${text.length} 字符，截断至 ${cutPoint} 字符。可用 wiki_ask 针对具体主题提问。`;
+  if (!text || text.length <= maxLen) return text;
+  const truncated = text.substring(0, maxLen);
+  const lastNL = truncated.lastIndexOf('\n');
+  const cutPoint = lastNL > maxLen * 0.8 ? lastNL : maxLen;
+  return truncated.substring(0, cutPoint) +`\n\n---\n⚠️ [内容已截断] 原始${text.length}字符，截断至${cutPoint}字符。可用wiki_ask针对具体主题提问。`;
 }
 
 // ============================================================
-// 5. 仓库标识解析
+// 6. 仓库标识解析
 // ============================================================
-
-/**
- * 将各种输入格式标准化为 owner/repo
- * 支持:
- *   - "owner/repo"
- *   - "https://github.com/owner/repo"
- *   - "https://deepwiki.com/owner/repo"
- *   - "https://deepwiki.com/owner/repo/some/page"
- *   - 带尾部斜杠的各种格式
- */
 function parseRepo(input) {
-    if (!input || typeof input !== 'string') return null;
+  if (!input || typeof input !== 'string') return null;
+  let cleaned = input.trim();
+  cleaned = cleaned.replace(/^https?:\/\/(www\.)?(github\.com|gitlab\.com|bitbucket\.org|deepwiki\.com)\//, '');
+  cleaned = cleaned.replace(/\/+$/, '');
+  const parts = cleaned.split('/').filter(Boolean);
+  return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null;
+}
 
-    let cleaned = input.trim();
-
-    // 去除 URL 前缀
-    cleaned = cleaned.replace(/^https?:\/\/(www\.)?(github\.com|deepwiki\.com)\//, '');
-
-    // 去除尾部斜杠
-    cleaned = cleaned.replace(/\/+$/, '');
-
-    // 提取 owner/repo (前两段路径)
-    const parts = cleaned.split('/').filter(Boolean);
-    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null;
+/** 支持逗号分隔的多仓库，最多10个 */
+function parseRepoInput(input) {
+  if (!input || typeof input !== 'string') return null;
+  if (input.includes(',')) {
+    const repos = input.split(',').map(s => parseRepo(s.trim())).filter(Boolean);
+    if (repos.length === 0) return null;
+    if (repos.length === 1) return repos[0];
+    if (repos.length > 10) {
+      log(`警告: 提供了${repos.length}个仓库，最多支持10个，已截断至前10个`);
+      return repos.slice(0, 10);
+    }
+    return repos;
+  }
+  return parseRepo(input);
 }
 
 // ============================================================
-// 6. 指令处理器
+// 7. 高级参数收集器(预留)
 // ============================================================
+function collectAdvancedParams(args) {
+  const adv = {};
+  const token = args.token || process.env.DEEPWIKI_GITHUB_TOKEN || process.env.DEEPWIKI_GITLAB_TOKEN;
+  if (token) adv.token = token;
+  if (args.type) adv.type = args.type;
+  if (args.provider) adv.provider = args.provider;
+  if (args.model) adv.model = args.model;
+  if (args.language) adv.language = args.language;
+  const fp = args.filepath || args.filePath || args.file_path;
+  if (fp) adv.filePath = fp;
+  if (args.excluded_dirs || args.excludedDirs) adv.excluded_dirs = args.excluded_dirs || args.excludedDirs;
+  if (args.included_dirs || args.includedDirs) adv.included_dirs = args.included_dirs || args.includedDirs;
+  return adv;
+}
 
-/**
- * wiki_structure: 获取仓库的 wiki 目录结构
- */
+// ============================================================
+// 8. 指令处理器
+// ============================================================
 async function handleStructure(args) {
-    const repo = parseRepo(args.url || args.repo || args.reponame || args.repoName);
-    if (!repo) {
-        return sendError('无法解析仓库标识。请提供 owner/repo 格式，例如: lioensky/VCPToolBox');
-    }
-
-    log(`获取 wiki 结构: ${repo}`);
-
-    try {
-        const result = await mcpCall('read_wiki_structure', { repoName: repo });
-        const text = truncate(extractText(result));
-
-        sendResponse({
-            status: 'success',
-            result: `## 📚 DeepWiki 文档结构: ${repo}\n\n${text}`,
-            messageForAI: `已获取 ${repo} 的 DeepWiki 文档目录结构。可用 wiki_content 读取完整文档，或用 wiki_ask 针对特定主题提问。`,
-        });
-    } catch (e) {
-        sendError(`获取 ${repo} 的文档结构失败: ${e.message}`);
-    }
+  const repo = parseRepo(args.url || args.repo || args.reponame || args.repoName);
+  if (!repo) return sendError('无法解析仓库标识。请提供 owner/repo 格式');
+  log(`获取 wiki结构: ${repo}`);
+  try {
+    const result = await mcpCall('read_wiki_structure', { repoName: repo });
+    sendResponse({
+      status: 'success',
+      result: `##📚 DeepWiki 文档结构: ${repo}\n\n${truncate(extractText(result))}`,
+      messageForAI: `已获取 ${repo} 的文档目录。可用 wiki_content 读取完整文档，或 wiki_ask 提问。`,
+    });
+  } catch (e) { sendError(`获取 ${repo} 文档结构失败: ${e.message}`); }
 }
 
-/**
- * wiki_content: 读取仓库的完整 wiki 文档
- * 注意: DeepWiki MCP 的 read_wiki_contents 只接受 repoName 参数，
- * 返回整个仓库的文档内容，不支持指定单个页面。
- */
 async function handleContent(args) {
-    const repo = parseRepo(args.url || args.repo || args.reponame || args.repoName);
-    if (!repo) {
-        return sendError('无法解析仓库标识。请提供 owner/repo 格式。');
-    }
-
-    log(`获取 wiki 完整文档: ${repo}`);
-
-    try {
-        const result = await mcpCall('read_wiki_contents', { repoName: repo });
-        const text = truncate(extractText(result));
-
-        sendResponse({
-            status: 'success',
-            result: `## 📖 DeepWiki 完整文档: ${repo}\n\n${text}`,
-            messageForAI: `已获取 ${repo} 的完整 DeepWiki 文档。如内容被截断，可用 wiki_ask 针对具体主题提问。`,
-        });
-    } catch (e) {
-        sendError(`获取 ${repo} 的文档内容失败: ${e.message}`);
-    }
+  const repo = parseRepo(args.url || args.repo || args.reponame || args.repoName);
+  if (!repo) return sendError('无法解析仓库标识。请提供 owner/repo 格式');
+  log(`获取 wiki 完整文档: ${repo}`);
+  try {
+    const result = await mcpCall('read_wiki_contents', { repoName: repo });
+    sendResponse({
+      status: 'success',
+      result: `## 📖 DeepWiki 完整文档: ${repo}\n\n${truncate(extractText(result))}`,
+      messageForAI: `已获取 ${repo} 的完整文档。如被截断，可用 wiki_ask 针对具体主题提问。`,
+    });
+  } catch (e) { sendError(`获取 ${repo} 文档内容失败: ${e.message}`); }
 }
 
-/**
- * wiki_ask: 向 DeepWiki AI 提问
- */
 async function handleAsk(args) {
-    const repo = parseRepo(args.url || args.repo || args.reponame || args.repoName);
-    const question = args.question || args.query || args.q;
+  const repoInput = parseRepoInput(args.url || args.repo || args.reponame || args.repoName);
+  let question = args.question || args.query || args.q;
+  if (!repoInput) return sendError('无法解析仓库标识。owner/repo 格式，多仓库逗号分隔(最多10个)');
+  if (!question) return sendError('缺少 question 参数');
 
-    if (!repo) {
-        return sendError('无法解析仓库标识。请提供 owner/repo 格式。');
-    }
-    if (!question) {
-        return sendError('缺少必需参数: question。请提供你想问的问题。');
-    }
+  // 检测多仓库截断
+  const rawUrl = args.url || args.repo || args.reponame || args.repoName || '';
+  const originalCount = rawUrl.includes(',') ? rawUrl.split(',').filter(s => s.trim()).length : 0;
+  const wasTruncated = originalCount > 10;
 
-    log(`向 DeepWiki 提问: ${repo}, 问题: ${question}`);
+  const deepResearch = args.deep_research === true || args.deep_research === 'true'
+    || args.deepresearch === true || args.deepresearch === 'true'
+    || args.deepResearch === true || args.deepResearch === 'true';
+  if (deepResearch) { question = `[DEEP RESEARCH] ${question}`; log('Deep Research 已激活'); }
 
-    try {
-        const result = await mcpCall('ask_question', { repoName: repo, question: question });
-        const text = truncate(extractText(result));
+  const isMulti = Array.isArray(repoInput);
+  const label = isMulti ? repoInput.join(' + ') : repoInput;
+  if (isMulti) log(`多仓库查询: ${repoInput.length}个`);
 
-        sendResponse({
-            status: 'success',
-            result: `## 🤖 DeepWiki AI 回答: ${repo}\n\n**问题**: ${question}\n\n---\n\n${text}`,
-            messageForAI: `DeepWiki AI 已回答关于 ${repo} 的问题。`,
-        });
-    } catch (e) {
-        sendError(`向 DeepWiki 提问失败: ${e.message}`);
-    }
+  const adv = collectAdvancedParams(args);
+  if (Object.keys(adv).length > 0) log(`高级参数(预留): ${JSON.stringify(adv)}`);
+
+  log(`提问: ${label}, 问题: ${question}`);
+  try {
+    const result = await mcpCall('ask_question', { repoName: repoInput, question });
+    const mode = deepResearch ? '🔬 Deep Research' : '🤖 AI 回答';
+    const multi = isMulti ? ` (跨${repoInput.length}个仓库)` : '';
+    const truncNote = wasTruncated ? ` ⚠️ 原始提供了${originalCount}个仓库，已截断至前10个。` : '';
+    sendResponse({
+      status: 'success',
+      result: `## ${mode}: ${label}${multi}\n\n**问题**: ${question}\n\n---\n\n${truncate(extractText(result))}`,
+      messageForAI: `DeepWiki 已回答 ${label} 的问题。${deepResearch ? '(Deep Research)' : ''}${multi}${truncNote}`,
+    });
+  } catch (e) { sendError(`提问失败: ${e.message}`); }
 }
 
 // ============================================================
-// 7. 指令分发器
+// 9. 指令分发器
 // ============================================================
-
-/**
- * 根据 command 字段路由到对应的处理器
- * 支持同义词和大小写容错
- * 智能猜测：无 command 但有 question 时自动走 ask
- */
 async function processRequest(req) {
-    let cmd = (req.command || '').toLowerCase().trim();
+  let cmd = (req.command || '').toLowerCase().trim();
+  const args = {};
+  for (const [k, v] of Object.entries(req)) { args[k.toLowerCase()] = v; }
+  Object.assign(args, req);
 
-    // 参数容错：统一处理大小写和同义词
-    const args = {};
-    for (const [k, v] of Object.entries(req)) {
-        args[k.toLowerCase()] = v;
-    }
-    // 保持原始大小写的参数也能被识别
-    Object.assign(args, req);
+  const hasQ = args.question || args.query || args.q;
+  if (!cmd && hasQ) cmd = 'wiki_ask';
+  if (!cmd) cmd = 'wiki_structure';
 
-    // 智能猜测：如果没有显式 command 但有 question，优先走 ask
-    const hasQuestion = args.question || args.query || args.q;
-    if (!cmd && hasQuestion) {
-        cmd = 'wiki_ask';
-    }
-    if (!cmd) {
-        cmd = 'wiki_structure';
-    }
-
-    switch (cmd) {
-        case 'wiki_structure':
-        case 'structure':
-        case 'list':
-        case 'list_pages':
-            return handleStructure(args);
-
-        case 'wiki_content':
-        case 'content':
-        case 'read':
-        case 'read_page':
-        case 'fetch':
-            return handleContent(args);
-
-        case 'wiki_ask':
-        case 'ask':
-        case 'question':
-        case 'search':
-            return handleAsk(args);
-
-        default:
-            // 兜底：未知 command 时，有 question 走 ask，否则走 structure
-            if (hasQuestion) return handleAsk(args);
-            return handleStructure(args);
-    }
+  switch (cmd) {
+    case 'wiki_structure': case 'structure': case 'list': case 'list_pages':
+      return handleStructure(args);
+    case 'wiki_content': case 'content': case 'read': case 'read_page': case 'fetch':
+      return handleContent(args);
+    case 'wiki_ask': case 'ask': case 'question': case 'search':
+      return handleAsk(args);
+    default:
+      if (hasQ) return handleAsk(args);
+      return handleStructure(args);
+  }
 }
 
 // ============================================================
-// 8. 插件入口 (stdio)
+// 10. 入口
 // ============================================================
-
+setupProxy();
 let inputData = '';
 process.stdin.setEncoding('utf8');
-
-process.stdin.on('data', (chunk) => {
-    inputData += chunk;
-});
-
+process.stdin.on('data', (chunk) => { inputData += chunk; });
 process.stdin.on('end', async () => {
-    try {
-        if (!inputData.trim()) {
-            return sendError('未从 stdin 接收到任何数据。');
-        }
-
-        const request = JSON.parse(inputData);
-        await processRequest(request);
-    } catch (e) {
-        if (e instanceof SyntaxError) {
-            sendError('无法解析输入的 JSON 数据。');
-        } else {
-            log(`未捕获错误: ${e.message}`);
-            sendError(`插件执行出错: ${e.message}`);
-        }
-    }
+  try {
+    if (!inputData.trim()) return sendError('未从stdin接收到数据');
+    await processRequest(JSON.parse(inputData));
+  } catch (e) {
+    if (e instanceof SyntaxError) sendError('无法解析JSON数据');
+    else { log(`未捕获错误: ${e.message}`); sendError(`插件出错: ${e.message}`); }
+  }
 });

--- a/Plugin/DeepWikiVCP/README.md
+++ b/Plugin/DeepWikiVCP/README.md
@@ -1,37 +1,45 @@
 # DeepWikiVCP
 
-> 通过 DeepWiki 官方 MCP API，为 VCP 伙伴提供 GitHub 仓库的 AI 生成文档检索与智能问答能力。
+通过DeepWiki 官方 MCP API，为 VCP 伙伴提供 GitHub 仓库的 AI 生成文档检索与智能问答能力。
 
 ## 概述
 
-DeepWikiVCP 是一个 VCP 同步插件，通过调用 [DeepWiki](https://deepwiki.com) 的官方 MCP (Model Context Protocol) 服务器，让 AI伙伴能够：
+DeepWikiVCP 是一个 VCP 同步插件，通过调用 DeepWiki 的官方 MCP (Model Context Protocol) 服务器，让 AI伙伴能够：
 
-- **📚 浏览文档结构** — 获取任意 GitHub 公开仓库的 AI 生成文档目录
-- **📖 阅读完整文档** — 获取仓库的完整 wiki 文档内容
-- **🤖 智能问答** — 向 DeepWiki AI 提问，获取基于仓库代码的深度回答
+-📚 **浏览文档结构** — 获取任意GitHub 公开仓库的 AI 生成文档目录
+- 📖 **阅读完整文档** — 获取仓库的完整 wiki 文档内容
+- 🤖 **智能问答** — 向 DeepWiki AI 提问，获取基于仓库代码的深度回答
+- 🔬 **深度研究** — 多轮迭代检索（最多5轮），适合复杂架构分析
+- 🌐 **多仓库联合查询** — 一次查询最多10个仓库，AI 综合多个代码库回答
 
 ## 特性
 
-- ✅ **零依赖** — 仅使用 Node.js 18+ 内置 `fetch()`，无需 `npm install`
-- ✅ **零配置** — 无需 API Key，DeepWiki 对公开仓库完全免费
-- ✅ **智能解析** — 支持 `owner/repo`、GitHub URL、DeepWiki URL 等多种输入格式
-- ✅ **内容截断** — 自动将超长文档截断至80K 字符，防止 token爆炸
-- ✅ **参数容错** — command 大小写不敏感，支持多种同义词和参数名
-- ✅ **优雅降级** — 不存在的仓库、空输入等边界情况均有友好错误提示
+✅ **零依赖** — 仅使用 Node.js 18+ 内置 `fetch()` 和 `undici`，无需 npm install
+✅ **零配置** — 无需 API Key，DeepWiki 对公开仓库完全免费
+✅ **智能解析** — 支持 `owner/repo`、GitHub/GitLab/DeepWiki URL 等多种输入格式
+✅ **内容截断** — 自动将超长文档截断至80K 字符，防止 token爆炸
+✅ **参数容错** — command 大小写不敏感，支持多种同义词和参数名
+✅ **智能代理** — 仅读显式配置的 `DEEPWIKI_PROXY`，不劫持系统代理
+✅ **代理回退** — 代理请求 15秒快速失败，自动回退直连（180 秒超时）
+✅ **优雅降级** — 不存在的仓库、空输入等边界情况均有友好错误提示
 
 ## 技术架构
 
 ```
-┌─────────────┐    JSON-RPC 2.0     ┌──────────────────────┐
-│  VCP Server  │ ──── stdin/stdout ──→ │  DeepWikiVCP.js      │
-│  (Plugin.js) │ ←── JSON result ──── │  (零依赖 Node.js)    │
-└─────────────┘                └──────────┬───────────┘
-                                                │ fetch()
+┌─────────────┐    JSON-RPC 2.0     ┌──────────────────────────┐
+│  VCP Server  │ ──── stdin/stdout ──→ │  DeepWikiVCP.js│
+│  (Plugin.js) │ ←── JSON result ──── │  (零依赖 Node.js 18+)     │
+└─────────────┘                └──────────┬───────────────┘
+                                │ fetch()
+                                                  │ + undici.ProxyAgent
                                                   ▼
                                        ┌──────────────────────┐
                                        │ mcp.deepwiki.com/mcp │
-                                       │ (MCP over HTTP)      │
+                                       │ (MCP over HTTP+SSE)  │
                                        └──────────────────────┘
+
+代理策略:DEEPWIKI_PROXY 已配置 → ProxyAgent(15秒超时) → 失败回退直连(180秒)
+  DEEPWIKI_PROXY 未配置 → 直连(与v2.0 行为一致)
 ```
 
 ## 使用方法
@@ -56,6 +64,10 @@ command: wiki_content
 url: facebook/react
 ```
 
+>⚠️ **注意**: `wiki_content` 返回整个仓库文档，数据量可能非常大（数万字符）。
+> 大量内容可能导致上下文 token 溢出或流式渲染不稳定。
+> **建议优先使用 `wiki_ask` 针对具体主题提问。**
+
 ### 3. 智能问答
 
 向 DeepWiki AI 提问关于仓库的具体问题：
@@ -67,6 +79,39 @@ url: lioensky/VCPToolBox
 question: 插件系统是如何工作的？
 ```
 
+### 4. 深度研究模式
+
+AI 进行多轮迭代检索（最多5轮），从核心逻辑、依赖关系、交互流等多维度深入分析：
+
+```
+tool_name: DeepWikiVCP
+command: wiki_ask
+url: lioensky/VCPToolBox
+question: 详细分析 RAG 记忆系统的完整架构
+deep_research: true
+```
+
+### 5. 多仓库联合查询
+
+同时查询多个仓库（最多10个），AI 综合多个代码库的上下文回答。适合分析前后端协作、微服务架构等跨仓库场景。超过10个显示被截断的个数：
+
+```
+tool_name: DeepWikiVCP
+command: wiki_ask
+url: lioensky/VCPToolBox, lioensky/VCPChat
+question: 前后端是如何通过 WebSocket 通信的？
+```
+
+### 6. 深度研究 + 多仓库（组合使用）
+
+```
+tool_name: DeepWikiVCP
+command: wiki_ask
+url: owner1/repo1, owner2/repo2
+question: 详细分析这两个项目的完整通信架构
+deep_research: true
+```
+
 ## URL 格式支持
 
 以下格式均可被正确解析：
@@ -75,9 +120,12 @@ question: 插件系统是如何工作的？
 |---------|------|
 | owner/repo | `lioensky/VCPToolBox` |
 | GitHub URL | `https://github.com/lioensky/VCPToolBox` |
+| GitLab URL | `https://gitlab.com/owner/repo` |
+| Bitbucket URL | `https://bitbucket.org/owner/repo` |
 | DeepWiki URL | `https://deepwiki.com/lioensky/VCPToolBox` |
 | 带尾部斜杠 | `lioensky/VCPToolBox/` |
 | 带额外路径 | `https://deepwiki.com/lioensky/VCPToolBox/some/page` |
+| 多仓库（逗号分隔） | `owner1/repo1, owner2/repo2` |
 
 ## Command 同义词
 
@@ -87,26 +135,115 @@ question: 插件系统是如何工作的？
 | wiki_content | content, read, read_page, fetch |
 | wiki_ask | ask, question, search |
 
+## wiki_ask 参数表
+
+| 参数 | 类型 | 必需 | 说明 |
+|------|------|:---:|------|
+| `url` | 字符串 | ✅ | 仓库标识。单仓库: `owner/repo`。多仓库: 逗号分隔，最多10个 |
+| `question` | 字符串 | ✅ | 你想问的问题，支持自然语言 |
+| `deep_research` | 布尔| ❌ | 设为 `true` 启用深度研究模式（多轮迭代，耗时较长） |
+
+## 配置指南
+
+>公开仓库无需任何配置即可使用。以下配置均为可选。
+
+### 代理配置
+
+如果你的网络无法直连 `mcp.deepwiki.com`（例如被防火墙阻断），复制`config.env.example` 为 `config.env`，配置代理：
+
+```env
+DEEPWIKI_PROXY=http://127.0.0.1:7890
+```
+
+**代理策略说明**:
+
+- **仅读取`DEEPWIKI_PROXY`**: 不会自动读取系统级`HTTP_PROXY` 环境变量，避免劫持系统代理导致不稳定
+- **15秒快速失败**: 代理请求使用 15 秒超时，无响应则自动回退直连（180 秒超时）
+- **未配置时**: 与 v2.0.0 行为完全一致 — 直接使用默认网络
+- **HTTP/2 已禁用**: 通过 `allowH2: false` 避免部分代理的 HTTP/2 兼容性问题
+
+### GitHub 令牌获取
+
+如需查询私有仓库（预留功能，当前 MCP 协议暂不支持透传），在 `config.env` 中配置令牌：
+
+1. 打开 [GitHub Token 设置页](https://github.com/settings/tokens)
+2. 点击 **"Generate new token"** →选择 **"Fine-grained, repo-scoped"**（推荐）
+3. **Permissions**: Contents: Read-only ✅ + Metadata: Read-only ✅（其他保持默认）
+4. 复制令牌填入 `config.env` 的 `DEEPWIKI_GITHUB_TOKEN=`
+
+>⚠️ 安全提示: 只需Contents和 Metadata 只读权限。令牌泄露时权限越小越安全。
+
+### GitLab 令牌获取
+
+1. 打开 [GitLab Token 设置页](https://gitlab.com/-/user_settings/personal_access_tokens)
+2.勾选 **read_api** ✅ 和 **read_repository** ✅
+3. 复制令牌填入 `config.env` 的 `DEEPWIKI_GITLAB_TOKEN=`
+
+> 💡 **什么是 GitLab？** 类似 GitHub 的代码托管平台，核心优势是 CI/CD 流水线和免费自托管。很多企业和学术机构使用自建GitLab 实例。
+
+## 当前限制与未来计划
+
+### MCP 协议参数限制
+
+DeepWiki 官方 MCP 的`ask_question` 工具仅接受 `repoName`（string或 string[]）和 `question`（string）。以下高级参数**当前无法通过 MCP 使用**：
+
+| 参数 | 说明 | 状态 |
+|------|------|:---:|
+| `language` | 语言选择 (zh/en/ja/es/kr/vi) | 🔒 代码已预留 |
+| `filePath` | 文件聚焦 | 🔒 代码已预留 |
+| `token` | 私有仓库令牌 | 🔒 config.env 已支持存储 |
+| `type` | 多平台 (gitlab/bitbucket) | 🔒 代码已预留 |
+| `provider` / `model` | 模型选择 | 🔒 代码已预留 |
+| `excluded_dirs` | 目录过滤 | 🔒 代码已预留 |
+
+这些参数已在代码中预留了完整的收集器（`collectAdvancedParams`），待以下任一条件满足时可快速启用：
+
+### 未来扩展路线
+
+1. **DeepWiki 官方扩展 MCP 参数白名单** — 最理想，零改动启用
+2. **集成 DeepWiki REST API** — 自部署 `deepwiki-open` 后使用全部参数
+3. **VCP 异步插件模式** — 利用 VCP 的 requestId + 占位符机制解决 Deep Research 超时
+
 ## ToolBox 折叠配置
 
-在 `TVStxt/SearchToolBox.txt` 中添加以下段落即可启用上下文折叠：
+在系统提示词的工具箱折叠区域添加以下段落：
 
 ```
-[===vcp_fold:0.45::desc:DeepWiki仓库文档检索===]
-## 7. DeepWiki 仓库文档检索 (DeepWikiVCP)
-通过 DeepWiki 官方 API 获取 GitHub 仓库的 AI 生成文档。
-tool_name: DeepWikiVCP
-command: wiki_structure / wiki_content / wiki_ask
-url: owner/repo 格式
-question: (仅 wiki_ask) 你的问题
+## 7. DeepWiki仓库文档检索 (DeepWikiVCP)
+通过 DeepWiki 官方 MCP API 获取任意 GitHub 公开仓库的 AI 生成文档。支持查看文档结构、阅读完整文档、以及基于仓库代码的AI智能问答。零配置，无需 API Key。
+### 查看文档目录
+tool_name:「始」DeepWikiVCP「末」,
+command:「始」wiki_structure「末」,
+url:「始」owner/repo 格式，如lioensky/VCPToolBox「末」
+### 阅读完整文档
+tool_name:「始」DeepWikiVCP「末」,
+command:「始」wiki_content「末」,
+url:「始」owner/repo「末」
+### 智能问答
+tool_name:「始」DeepWikiVCP「末」,
+command:「始」wiki_ask「末」,
+url:「始」owner/repo「末」,
+question:「始」你想问的问题「末」
+### 深度研究模式
+tool_name:「始」DeepWikiVCP「末」,
+command:「始」wiki_ask「末」,
+url:「始」owner/repo「末」,
+question:「始」详细分析项目架构「末」,
+deep_research:「始」true「末」
+### 多仓库联合查询（最多10个，逗号分隔）
+tool_name:「始」DeepWikiVCP「末」,
+command:「始」wiki_ask「末」,
+url:「始」owner1/repo1, owner2/repo2「末」,
+question:「始」这两个项目如何协作？「末」
 ```
 
 ## 文件结构
 
 ```
 Plugin/DeepWikiVCP/
-├── DeepWikiVCP.js          # 插件主体(~9KB, 零依赖)
-├── plugin-manifest.json    # VCP 插件描述
+├── DeepWikiVCP.js          # 插件主体(~14KB, 零依赖)
+├── plugin-manifest.json# VCP 插件清单
+├── config.env.example      # 配置模板 (复制为 config.env 使用)
 ├── package.json            # 极简 package (无依赖)
 └── README.md               # 本文件
 ```
@@ -116,7 +253,7 @@ Plugin/DeepWikiVCP/
 ### MCP 端点
 
 - **URL**: `https://mcp.deepwiki.com/mcp`
-- **协议**: JSON-RPC 2.0 over Streamable HTTP
+- **协议**: JSON-RPC 2.0 over Streamable HTTP (支持 JSON 和 SSE 响应)
 - **认证**: 公开仓库无需认证
 
 ### MCP 工具
@@ -125,17 +262,49 @@ Plugin/DeepWikiVCP/
 |--------|------|------|
 | read_wiki_structure | repoName | 获取文档目录 |
 | read_wiki_contents | repoName | 获取完整文档 |
-| ask_question | repoName, question | AI 问答 |
+| ask_question | repoName (string\|string[]), question | AI 问答（支持多仓库） |
+
+### 超时与截断
+
+| 配置项 | 值 | 说明 |
+|--------|------|------|
+| 直连超时 | 180 秒 | Deep Research 需要更长时间 |
+| 代理超时 | 15 秒 | 快速失败后回退直连 |
+| 内容截断 | 80000 字符 | 优先在换行符处截断 |
 
 ## 测试记录
 
-两轮 16 项测试全部通过（2026-04-19）：
+v2.1.0 共20 项测试全部通过（2026-04-20）：
+
+**v2.0继承功能（12项）**:
 - 3 个核心指令功能验证 ✅
-- 5 种 URL 格式解析 ✅
+- 5 种 URL 格式解析（GitHub/GitLab/DeepWiki/owner-repo/带路径）✅
 - command 大小写/同义词/参数名容错 ✅
+- 智能猜测（无command 有 question时自动路由）✅
+- SSE 流式响应解析 ✅
+- 80000 字符智能截断验证 ✅
 - 空输入/缺参数/不存在仓库/未知指令边界测试 ✅
-- 8 发并发压力测试 ✅
-- 353K 字符内容截断验证 ✅
+- JSON解析容错 ✅
+
+**v2.1 新增功能（8项）**:
+- Deep Research 深度研究模式 ✅
+- 多仓库联合查询（string[]）✅
+- 代理配置（config.env DEEPWIKI_PROXY）✅
+- 代理回退直连 ✅
+- 15秒代理快速失败 ✅
+- 令牌持久化（GitHub/GitLab PAT）✅
+- 高级参数预留（collectAdvancedParams）✅
+- GitLab/Bitbucket URL 解析 ✅
+
+## 版本历史
+
+- **v2.1.0** (2026-04-20): Deep Research 深度研究 / 多仓库联合查询 / 智能代理配置+回退 / 令牌持久化 / 高级参数预留
+- **v2.0.0** (2026-04-19): 零依赖重写，MCP 协议，SSE 流式支持，16 项测试全通过
+- **v1.0.0**: 初始版本 (Lionsky)
+
+## 作者
+
+**infinite-vector** — 基于 Lionsky 的初始版本重写
 
 ## License
 

--- a/Plugin/DeepWikiVCP/config.env.example
+++ b/Plugin/DeepWikiVCP/config.env.example
@@ -1,0 +1,32 @@
+#============================================================
+# DeepWikiVCP v2.1.0 配置文件
+# ============================================================
+# 使用方法: 将此文件复制为 config.env 并填写所需配置。
+# VCP 的 PluginManager 会自动加载此文件中的环境变量。
+#
+#⚠️ 不知道怎么配置？请阅读 README.md 中的详细指引！
+#
+# 所有配置项均为可选。公开仓库无需任何配置即可使用。
+# ============================================================
+
+# --- 代理配置 ---
+# 如果 DeepWiki (mcp.deepwiki.com) 无法直连，请配置 HTTP 代理。
+# 留空则继承 VCP 主进程 (pm2) 的代理设置。
+# 如果你的 VCP 启动脚本已配置了HTTP_PROXY 环境变量，通常无需再配置此项。
+# 示例: http://127.0.0.1:7890
+DEEPWIKI_PROXY=
+
+# --- 私有仓库令牌 ---
+# 查询私有仓库时需要提供对应平台的访问令牌。
+# 也可以在调用时通过 token 参数临时传入（不会被持久化）。
+# 详细的令牌获取步骤请参阅 README.md 的"令牌配置指南"章节。
+
+# GitHub Personal Access Token
+# 获取地址: https://github.com/settings/tokens
+# 推荐使用 Fine-grained token，权限选择 Contents: Read-only 即可
+DEEPWIKI_GITHUB_TOKEN=
+
+# GitLab Personal Access Token
+# 获取地址: https://gitlab.com/-/user_settings/personal_access_tokens
+# 需要勾选 read_api 和 read_repository 权限
+DEEPWIKI_GITLAB_TOKEN=

--- a/Plugin/DeepWikiVCP/plugin-manifest.json
+++ b/Plugin/DeepWikiVCP/plugin-manifest.json
@@ -1,10 +1,10 @@
 {
   "manifestVersion": "1.0.0",
   "name": "DeepWikiVCP",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "displayName": "DeepWiki仓库文档检索",
-  "description": "通过 DeepWiki 官方 MCP API 获取 GitHub 仓库的 AI 生成文档、目录结构和智能问答。零依赖，无需配置。",
-  "author": "CodeCC & ZhaoFeng",
+  "description": "通过 DeepWiki 官方 MCP API 获取任意 GitHub 公开仓库的 AI 生成文档。支持文档结构、完整内容、AI 智能问答、Deep Research 深度研究和多仓库联合查询。",
+  "author": "infinite-vector",
   "pluginType": "synchronous",
   "entryPoint": {
     "type": "nodejs",
@@ -12,21 +12,37 @@
   },
   "communication": {
     "protocol": "stdio",
-    "timeout": 120000
+    "timeout": 180000
   },
-  "configSchema": {},
+  "configSchema": {
+    "DEEPWIKI_PROXY": {
+      "type": "string",
+      "description": "HTTP 代理地址，留空则继承系统代理。注意: Node.js 内置 fetch 不自动读取环境变量代理，本插件通过 undici.ProxyAgent 显式设置。",
+      "required": false
+    },
+    "DEEPWIKI_GITHUB_TOKEN": {
+      "type": "string",
+      "description": "GitHub PAT，用于查询私有仓库（预留，当前 MCP 不支持透传）",
+      "required": false
+    },
+    "DEEPWIKI_GITLAB_TOKEN": {
+      "type": "string",
+      "description": "GitLab PAT，用于查询私有仓库（预留，当前 MCP 不支持透传）",
+      "required": false
+    }
+  },
   "capabilities": {
     "invocationCommands": [
       {
         "commandIdentifier": "wiki_structure",
-        "description": "获取 GitHub 仓库在DeepWiki 上的文档目录结构。\n参数:\n- url (字符串, 必需): 仓库标识，支持 owner/repo 格式、GitHub URL 或 DeepWiki URL。\n调用格式:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」DeepWikiVCP「末」,\ncommand:「始」wiki_structure「末」,\nurl:「始」lioensky/VCPToolBox「末」\n<<<[END_TOOL_REQUEST]>>>"},
+        "description": "获取 GitHub仓库在 DeepWiki 上的文档目录结构。\n参数:\n- url (字符串, 必需): 仓库标识，支持 owner/repo 格式、GitHub URL 或 DeepWiki URL。\n调用格式:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」DeepWikiVCP「末」,\ncommand:「始」wiki_structure「末」,\nurl:「始」lioensky/VCPToolBox「末」\n<<<[END_TOOL_REQUEST]>>>"},
       {
         "commandIdentifier": "wiki_content",
-        "description": "读取 DeepWiki 上指定仓库的完整文档内容。返回整个仓库的文档，内容较长时会自动截断。\n参数:\n- url (字符串, 必需): 仓库标识 (owner/repo 格式)。\n调用格式:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」DeepWikiVCP「末」,\ncommand:「始」wiki_content「末」,\nurl:「始」lioensky/VCPToolBox「末」\n<<<[END_TOOL_REQUEST]>>>"
+        "description": "读取 DeepWiki 上指定仓库的完整文档内容。返回整个仓库的文档，内容较长时会自动截断。注意：返回数据量可能很大，建议优先使用 wiki_ask。\n参数:\n- url (字符串, 必需): 仓库标识 (owner/repo 格式)。\n调用格式:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」DeepWikiVCP「末」,\ncommand:「始」wiki_content「末」,\nurl:「始」lioensky/VCPToolBox「末」\n<<<[END_TOOL_REQUEST]>>>"
       },
       {
         "commandIdentifier": "wiki_ask",
-        "description": "向 DeepWiki AI 提出关于某个 GitHub 仓库的问题，获取基于仓库代码的 AI 回答。\n参数:\n- url (字符串, 必需): 仓库标识 (owner/repo 格式)。\n- question (字符串, 必需): 你想问的问题。\n调用格式:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」DeepWikiVCP「末」,\ncommand:「始」wiki_ask「末」,\nurl:「始」lioensky/VCPToolBox「末」,\nquestion:「始」这个项目的插件系统是如何工作的？「末」\n<<<[END_TOOL_REQUEST]>>>"
+        "description": "向 DeepWiki AI 提出关于 GitHub 仓库的问题。支持单仓库或多仓库联合查询（最多10个）。\n参数:\n- url (字符串, 必需): 仓库标识。单仓库: owner/repo 格式。多仓库: 用逗号分隔，如 'owner1/repo1, owner2/repo2'（最多10个）。\n- question (字符串, 必需): 你想问的问题。\n- deep_research (布尔, 可选): 设为 true 启用深度研究模式，AI 将进行多轮迭代检索（最多5轮），适合复杂架构分析。\n调用示例:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」DeepWikiVCP「末」,\ncommand:「始」wiki_ask「末」,\nurl:「始」lioensky/VCPToolBox「末」,\nquestion:「始」插件系统是如何工作的？「末」\n<<<[END_TOOL_REQUEST]>>>\n深度研究:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」DeepWikiVCP「末」,\ncommand:「始」wiki_ask「末」,\nurl:「始」lioensky/VCPToolBox「末」,\nquestion:「始」详细分析 RAG 记忆系统的完整架构「末」,\ndeep_research:「始」true「末」\n<<<[END_TOOL_REQUEST]>>>\n多仓库联合查询:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」DeepWikiVCP「末」,\ncommand:「始」wiki_ask「末」,\nurl:「始」lioensky/VCPToolBox, lioensky/VCPChat「末」,\nquestion:「始」前后端是如何通信的？「末」\n<<<[END_TOOL_REQUEST]>>>"
       }
     ]
   }


### PR DESCRIPTION
## DeepWikiVCP v2.1.0

基于 v2.0.0 (#294) 的增量升级，新增 Deep Research 深度研究、多仓库联合查询和智能代理配置。

### ✨ 新增功能

**🔬 Deep Research 深度研究模式**
- `wiki_ask` 新增 `deep_research` 参数
- 通过在 question 前添加 `[DEEP RESEARCH]` 前缀触发 DeepWiki 多轮迭代检索（最多5轮）
- 适合复杂架构分析，回答深度显著提升

**🌐 多仓库联合查询**
- `wiki_ask` 的 `url` 参数支持逗号分隔的多个仓库（最多10个）
- 内部传递 `repoName` 为 `string[]`，符合 DeepWiki MCP schema
- 适合分析前后端协作、微服务架构等跨仓库场景

**🔧 智能代理配置(config.env)**
- 新增 `config.env.example` 配置模板
- 仅读取显式配置的 `DEEPWIKI_PROXY`，不劫持系统级`HTTP_PROXY`
- 通过 `undici.ProxyAgent` 显式设置代理（`allowH2: false` 避免 HTTP/2 兼容性问题）
- 代理请求 15 秒快速超时，失败自动回退直连（180秒超时）
- 未配置代理时与v2.0.0 行为完全一致

**🔒 令牌持久化**
- config.env 支持 `DEEPWIKI_GITHUB_TOKEN` 和 `DEEPWIKI_GITLAB_TOKEN`
- 附带详细的令牌获取指南（GitHub Fine-grained + GitLab Legacy）

**📐 高级参数预留**
- 保留 `collectAdvancedParams()` 函数
- 支持 language/filePath/token/type/provider/model/excluded_dirs 等参数收集
- 当前MCP 协议不支持透传，参数收集后记录到日志，待未来扩展

### 🔧 技术改进

- 超时: 直连 180s / 代理 15s（快速失败回退）
- URL 解析: 新增 gitlab.com / bitbucket.org 支持
- 代理架构: 不劫持系统代理，按请求注入 dispatcher
- configSchema: manifest中声明三个配置项
- 文档: 完整的令牌配置指南 + MCP 限制说明 + 未来路线图

### 📁 改动文件

| 文件 | 改动 |
|------|------|
| `DeepWikiVCP.js` | 重构代理架构 + Deep Research + 多仓库 + 参数预留 |
| `plugin-manifest.json` | 版本号+ configSchema + 提示词更新 |
| `config.env.example` | 新文件：配置模板 |
| `README.md` | 完整重写：新功能文档 + 配置指南 + 测试记录 |

### ✅ 测试验证 (20项全通过)

**v2.0继承 (12项)**:
- [x] 3 个核心指令
- [x] 5 种 URL 格式解析
- [x] 命令同义词/大小写容错
- [x] 智能猜测/SSE解析/智能截断/边界测试

**v2.1 新增 (8项)**:
- [x] Deep Research 深度研究
- [x] 多仓库联合查询 (string[])
- [x] 代理配置 + 回退直连
- [x] 令牌持久化
- [x] 高级参数预留

### 📋 关于 Lionsky 提出的"多个ask模式"

1. **深度询问 (Deep Research)**: ✅ 已实现。`deep_research: true` 触发 `[DEEP RESEARCH]` 前缀
2. **多仓库查询**: ✅ 已实现。`url` 逗号分隔多个仓库，插件解析为 `string[]` 传给 MCP
3. **代码地图检索**:
   - 静态地图：`wiki_structure` 返回文档目录树 ✅
   - 动态逻辑地图：`wiki_ask` 提问时 DeepWiki 会根据问题自动生成 Mermaid 架构图 ✅
   - *若需专门的逻辑拓扑命令（如独立的 `wiki_map`），请在评论区补充具体需求*

### 📋 关于 MCP 参数限制

经实测，DeepWiki MCP 的 `ask_question` schema 仅接受 `repoName`（string|string[]）和 `question`（string）。language/filePath/token 等高级参数无法透传。本版本已预留完整参数收集器，待 DeepWiki 扩展 MCP 参数或集成 REST API 时可快速启用。