### PR TITLE
fix(VSearch): 让 SearchMode 默认值优先读取 config.env 配置

### DIFF
--- a/Plugin/VSearch/VSearch.js
+++ b/Plugin/VSearch/VSearch.js
@@ -509,7 +509,8 @@ const callKimiSearchMode = async (topic, keywordList, apiKey, baseUrl, maxResult
 };
 
 async function main(request) {
-    const { SearchTopic, Keywords, ShowURL, SearchMode = 'kimisearch' } = request;
+    const { SearchTopic, Keywords, ShowURL, 
+        SearchMode = process.env.SearchMode || 'kimisearch' } = request;
     const showURL = ShowURL === true || ShowURL === 'true';
 
     if (!SearchTopic || !Keywords) {


### PR DESCRIPTION
修复 VSearch 插件的 SearchMode 参数未读取 config.env 的问题。

原因：main() 函数的 SearchMode 默认值硬编码为 'kimisearch'，
忽略了 config.env 中用户配置的 SearchMode=grounding。

修复：将默认值改为 process.env.SearchMode || 'kimisearch'，
使优先级变为：调用时传入 > config.env 配置 > 硬编码兜底。