### PR TITLE
Feat ( VCPTavern )：添加" first _ user "目标进行嵌入和相关注入

### DIFF
--- a/AdminPanel-Vue/src/api/vcptavern.ts
+++ b/AdminPanel-Vue/src/api/vcptavern.ts
@@ -8,7 +8,7 @@ const DEFAULT_READ_UI_OPTIONS: RequestUiOptions = { showLoader: false };
 
 export type RuleType = "relative" | "depth" | "embed";
 export type RulePosition = "before" | "after";
-export type RuleTarget = "system" | "last_user";
+export type RuleTarget = "system" | "last_user" | "first_user";
 export type RuleRole = "system" | "user" | "assistant";
 
 export interface RuleContent {
@@ -44,8 +44,7 @@ export const vcptavernApi = {
   ): Promise<string[]> {
     const response = await requestWithUi<unknown>(
       {
-        url: `${API_BASE_URL}/presets`,
-      },
+        url: `${API_BASE_URL}/presets`,},
       uiOptions
     );
     return Array.isArray(response)
@@ -93,4 +92,3 @@ export const vcptavernApi = {
     );
   },
 };
-

--- a/AdminPanel-Vue/src/views/VcptavernEditor.vue
+++ b/AdminPanel-Vue/src/views/VcptavernEditor.vue
@@ -5,8 +5,7 @@
         <p class="description">
           管理上下文注入预设与规则。按住规则左侧手柄可像仪表盘一样实时预览排序位置，
           并在释放时提交最终顺序。
-        </p>
-      </div>
+        </p></div>
       <div class="header-actions">
         <button
           class="btn-secondary"
@@ -15,8 +14,7 @@
           @click="fetchPresets"
         >
           刷新
-        </button>
-      </div>
+        </button></div>
     </div>
 
     <div class="preset-toolbar card">
@@ -59,7 +57,7 @@
     </div>
 
     <div v-if="!isEditorVisible" class="empty-tip card">
-      <p>请选择一个预设进行编辑，或点击“新建”创建预设。</p>
+      <p>请选择一个预设进行编辑，或点击"新建"创建预设。</p>
     </div>
 
     <div v-else class="editor card">
@@ -92,8 +90,7 @@
         </button>
       </div>
 
-      <div v-if="editorState.rules.length === 0" class="empty-rules">
-        暂无规则，点击“添加规则”创建。
+      <div v-if="editorState.rules.length === 0" class="empty-rules">暂无规则，点击"添加规则"创建。
       </div>
 
       <TransitionGroup
@@ -179,6 +176,7 @@
               <select v-model="rule.target">
                 <option value="system">系统提示</option>
                 <option value="last_user">最后的用户消息</option>
+                <option value="first_user">第一个用户消息</option>
               </select>
             </div>
 
@@ -216,16 +214,14 @@
           @click="savePreset"
         >
           {{ isSaving ? "保存中…" : "保存预设" }}
-        </button>
-      </div>
+        </button></div>
     </div>
 
     <div v-if="dragGhost" ref="dragGhostElement" class="rule-drag-ghost">
       <div class="rule-drag-ghost-shell">
         <div class="rule-drag-ghost-title">{{ dragGhost.label }}</div>
         <div class="rule-drag-ghost-meta">{{ dragGhost.meta }}</div>
-      </div>
-    </div>
+      </div></div>
   </section>
 </template>
 
@@ -306,7 +302,7 @@ void dragGhostElement
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap:6px;
 }
 
 .form-group.full-width {
@@ -423,8 +419,7 @@ button:focus-visible {
   padding: 0;
   cursor: grab;
   font-size: var(--font-size-body);
-  flex-shrink: 0;
-  user-select: none;
+  flex-shrink: 0;user-select: none;
   touch-action: none;
 }
 
@@ -487,8 +482,7 @@ button:focus-visible {
 
 .rule-drag-ghost-meta {
   margin-top: 6px;
-  color: var(--secondary-text);
-  font-size: var(--font-size-helper);
+  color: var(--secondary-text);font-size: var(--font-size-helper);
   line-height: 1.45;
   text-transform: capitalize;
 }

--- a/Plugin/VCPTavern/VCPTavern.js
+++ b/Plugin/VCPTavern/VCPTavern.js
@@ -315,6 +315,16 @@ class VCPTavern {
                         newMessages[lastUserIndex].content = newMessages[lastUserIndex].content.trim() + '\n\n' + textToEmbed.trim();
                     }
                 }
+            } else if (rule.target === 'first_user') {
+                // [PR] 新增：定位第一条user 消息进行嵌入
+                const firstUserIndex = newMessages.findIndex(m => m.role === 'user');
+                if (firstUserIndex !== -1 && typeof newMessages[firstUserIndex].content === 'string') {
+                    if (rule.position === 'before') {
+                        newMessages[firstUserIndex].content = textToEmbed.trim() + '\n\n' + newMessages[firstUserIndex].content.trim();
+                    } else { // after
+                        newMessages[firstUserIndex].content = newMessages[firstUserIndex].content.trim() + '\n\n' + textToEmbed.trim();
+                    }
+                }
             }
         }
 
@@ -356,6 +366,16 @@ class VCPTavern {
                         newMessages.splice(lastUserIndex + 1, 0, msgObj);
                     } else { // before
                         newMessages.splice(lastUserIndex, 0, msgObj);
+                    }
+                }
+            } else if (rule.target === 'first_user') {
+                // [PR] 新增：定位第一条 user 消息进行相对注入
+                const firstUserIndex = newMessages.findIndex(m => m.role === 'user');
+                if (firstUserIndex !== -1) {
+                    if (rule.position === 'after') {
+                        newMessages.splice(firstUserIndex + 1, 0, msgObj);
+                    } else { // before
+                        newMessages.splice(firstUserIndex, 0, msgObj);
                     }
                 }
             } else if (rule.target === 'all_user') {


### PR DESCRIPTION
加入" first _ user "作为VCPTavern嵌入和相对注入规则的新目标。

用户需要注入相对于第一个用户消息(例如,会话语境应该在会话的早期出现)的内容。目前仅支持系统、Last _ User和All _ User。
变化

Plugin/VCPTavern/VCPTavern.js (+20 lines)Add first_user branch in embed loop and relative loop,symmetric with existing last_user logic.
AdminPanel-Vue/src/api/vcptavern.ts (+1 line)Add "first_user" to RuleTarget union type.
AdminPanel-Vue/src/views/VcptavernEditor.vue (+1 line)Add "第一个用户消息" option to target dropdown.

Risk
Minimal — pure additive else if branches.No existing code paths modified.