### PR TITLE
插件调用审核添加静默拒绝功能

### DIFF
--- a/AdminPanel-Vue/public/index.html
+++ b/AdminPanel-Vue/public/index.html
@@ -834,7 +834,7 @@
                         </div>
                         <div class="config-item">
                             <label for="tool-approval-list">被审核工具名单 (每行一个工具名称)</label>
-                            <textarea id="tool-approval-list" rows="8" placeholder="例如：\nSciCalculator\nPowerShellExecutor"></textarea>
+                            <textarea id="tool-approval-list" rows="8" placeholder="例如：\nSciCalculator\nPowerShellExecutor:Get-ChildItem\nPowerShellExecutor::SilentReject\nPowerShellExecutor:Remove-Item::SilentReject"></textarea>
                             <p class="aa-hint">当“开启所有工具调用审核”关闭时，仅对此名单中的工具进行审核。</p>
                         </div>
                         <div class="config-footer">

--- a/AdminPanel-Vue/src/views/ToolApprovalManager.vue
+++ b/AdminPanel-Vue/src/views/ToolApprovalManager.vue
@@ -27,9 +27,9 @@
           <p class="aa-hint">超时后，该审核请求将自动拒绝。</p>
         </div>
         <div class="config-item">
-          <label for="tool-approval-list">被审核工具名单 (每行一个工具名称)</label>
-          <textarea id="tool-approval-list" v-model="config.approvalListText" rows="8" placeholder="例如：&#10;SciCalculator&#10;PowerShellExecutor"></textarea>
-          <p class="aa-hint">当"开启所有工具调用审核"关闭时，仅对此名单中的工具进行审核。</p>
+          <label for="tool-approval-list">被审核规则名单 (每行一条规则)</label>
+          <textarea id="tool-approval-list" v-model="config.approvalListText" rows="8" placeholder="例如：&#10;SciCalculator&#10;PowerShellExecutor:Get-ChildItem&#10;PowerShellExecutor::SilentReject&#10;PowerShellExecutor:Remove-Item::SilentReject"></textarea>
+          <p class="aa-hint">支持四种格式：ToolName、ToolName:Command、ToolName::SilentReject、ToolName:Command::SilentReject。带“::SilentReject”的规则在用户拒绝时不会向 AI 返回拒绝提示。</p>
         </div>
         <div class="config-footer">
           <button type="submit" class="btn-primary">保存审核配置</button>

--- a/Plugin.js
+++ b/Plugin.js
@@ -774,9 +774,14 @@ class PluginManager extends EventEmitter {
         // --- 透明化处理结束 ---
 
         // --- 人工审核逻辑 (新增) ---
-        if (this.toolApprovalManager.shouldApprove(toolName, pluginSpecificArgs)) {
+        const approvalDecision = this.toolApprovalManager.getApprovalDecision(toolName, pluginSpecificArgs);
+        if (approvalDecision.requiresApproval) {
             const requestId = `approve-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
-            if (this.debugMode) console.log(`[PluginManager] Tool call for "${toolName}" requires manual approval. Request ID: ${requestId}`);
+            if (this.debugMode) {
+                console.log(
+                    `[PluginManager] Tool call for "${toolName}" requires manual approval. Request ID: ${requestId}. notifyAiOnReject=${approvalDecision.notifyAiOnReject !== false}`
+                );
+            }
 
             const approvalPromise = new Promise((resolve, reject) => {
                 const timeoutDuration = this.toolApprovalManager.getTimeoutMs();
@@ -787,7 +792,12 @@ class PluginManager extends EventEmitter {
                     }
                 }, timeoutDuration);
 
-                this.pendingApprovals.set(requestId, { resolve, reject, timeoutId });
+                this.pendingApprovals.set(requestId, {
+                    resolve,
+                    reject,
+                    timeoutId,
+                    notifyAiOnReject: approvalDecision.notifyAiOnReject !== false
+                });
             });
 
             // 发送审核请求到管理面板
@@ -810,7 +820,13 @@ class PluginManager extends EventEmitter {
             }
 
             try {
-                await approvalPromise;
+                const approvalResult = await approvalPromise;
+                if (approvalResult && approvalResult.silentRejected === true) {
+                    if (this.debugMode) {
+                        console.log(`[PluginManager] Tool call for "${toolName}" (ID: ${requestId}) was rejected silently. Returning empty result to AI.`);
+                    }
+                    return undefined;
+                }
                 if (this.debugMode) console.log(`[PluginManager] Tool call for "${toolName}" (ID: ${requestId}) approved.`);
             } catch (error) {
                 if (this.debugMode) console.warn(`[PluginManager] Tool call for "${toolName}" (ID: ${requestId}) rejected: ${error.message}`);
@@ -1153,6 +1169,8 @@ class PluginManager extends EventEmitter {
             clearTimeout(approval.timeoutId);
             if (approved) {
                 approval.resolve();
+            } else if (approval.notifyAiOnReject === false) {
+                approval.resolve({ silentRejected: true });
             } else {
                 approval.reject(new Error(JSON.stringify({ plugin_error: 'Manual approval was REJECTED by user.' })));
             }

--- a/modules/toolApprovalManager.js
+++ b/modules/toolApprovalManager.js
@@ -84,37 +84,118 @@ class ToolApprovalManager {
         return commands;
     }
 
-    shouldApprove(toolName, toolArgs = {}) {
+    parseApprovalRule(entry) {
+        if (typeof entry !== 'string') {
+            return null;
+        }
+
+        const trimmed = entry.trim();
+        if (!trimmed) {
+            return null;
+        }
+
+        const silentSuffix = '::SilentReject';
+        const isSilentRule = trimmed.endsWith(silentSuffix);
+        const baseRule = isSilentRule
+            ? trimmed.slice(0, -silentSuffix.length).trim()
+            : trimmed;
+
+        if (!baseRule) {
+            return null;
+        }
+
+        return {
+            rawRule: trimmed,
+            baseRule,
+            notifyAiOnReject: !isSilentRule
+        };
+    }
+
+    getApprovalDecision(toolName, toolArgs = {}) {
+        const defaultDecision = {
+            requiresApproval: false,
+            notifyAiOnReject: true,
+            matchedRule: null,
+            matchedCommand: null
+        };
+
         if (!this.config.enabled) {
-            return false;
+            return defaultDecision;
         }
 
         if (this.config.approveAll) {
             console.log(`[ToolApprovalManager] 🛡️ [${toolName}] 所有工具均需审核 (approveAll=true)`);
-            return true;
+            return {
+                requiresApproval: true,
+                notifyAiOnReject: true,
+                matchedRule: '__APPROVE_ALL__',
+                matchedCommand: null
+            };
         }
 
         const approvalList = Array.isArray(this.config.approvalList) ? this.config.approvalList : [];
-        const matchedToolRule = approvalList.includes(toolName);
-        if (matchedToolRule) {
-            console.log(`[ToolApprovalManager] 🛡️ [${toolName}] 命中工具级审核规则，准备发送请求`);
-            return true;
-        }
+        const parsedRules = approvalList
+            .map(entry => this.parseApprovalRule(entry))
+            .filter(Boolean);
 
         const commands = this.extractCommands(toolArgs);
-        for (const command of commands) {
-            const commandRule = `${toolName}:${command}`;
-            if (approvalList.includes(commandRule)) {
-                console.log(`[ToolApprovalManager] 🛡️ [${toolName}] 命中命令级审核规则 [${commandRule}]，准备发送请求`);
-                return true;
+        let bestMatch = null;
+
+        const considerMatch = (rule, specificity, matchedCommand = null) => {
+            if (!bestMatch) {
+                bestMatch = { ...rule, specificity, matchedCommand };
+                return;
             }
+
+            if (specificity > bestMatch.specificity) {
+                bestMatch = { ...rule, specificity, matchedCommand };
+                return;
+            }
+
+            if (
+                specificity === bestMatch.specificity &&
+                rule.notifyAiOnReject === false &&
+                bestMatch.notifyAiOnReject !== false
+            ) {
+                bestMatch = { ...rule, specificity, matchedCommand };
+            }
+        };
+
+        for (const rule of parsedRules) {
+            if (rule.baseRule === toolName) {
+                considerMatch(rule, 1, null);
+            }
+
+            for (const command of commands) {
+                const commandRule = `${toolName}:${command}`;
+                if (rule.baseRule === commandRule) {
+                    considerMatch(rule, 2, command);
+                }
+            }
+        }
+
+        if (bestMatch) {
+            const scope = bestMatch.specificity === 2 ? '命令级' : '工具级';
+            const silentTag = bestMatch.notifyAiOnReject === false ? '，拒绝时不提示AI' : '';
+            console.log(`[ToolApprovalManager] 🛡️ [${toolName}] 命中${scope}审核规则 [${bestMatch.rawRule}]，准备发送请求${silentTag}`);
+            return {
+                requiresApproval: true,
+                notifyAiOnReject: bestMatch.notifyAiOnReject,
+                matchedRule: bestMatch.rawRule,
+                matchedCommand: bestMatch.matchedCommand || null
+            };
         }
 
         if (this.config.debugMode) {
             const commandInfo = commands.length > 0 ? `，commands=${JSON.stringify(commands)}` : '';
             console.log(`[ToolApprovalManager] [${toolName}] 不需要审核${commandInfo}`);
         }
-        return false;
+
+        return defaultDecision;
+    }
+
+    shouldApprove(toolName, toolArgs = {}) {
+        return this.getApprovalDecision(toolName, toolArgs).requiresApproval;
     }
 
     getTimeoutMs() {

--- a/审核系统开发文档和适配说明.md
+++ b/审核系统开发文档和适配说明.md
@@ -66,7 +66,9 @@ The logic is controlled by [toolApprovalConfig.json](file:///h:/VCP/VCPToolBox/t
   "approvalList": [
     "TestTool1",
     "PowerShellExecutor:Get-ChildItem",
-    "ChromeBridge:open_url"
+    "ChromeBridge:open_url",
+    "PowerShellExecutor::SilentReject",
+    "PowerShellExecutor:Remove-Item::SilentReject"
   ]
 }
 ```
@@ -74,11 +76,15 @@ The logic is controlled by [toolApprovalConfig.json](file:///h:/VCP/VCPToolBox/t
 - `enabled`: Global switch for the feature.
 - `timeoutMinutes`: Automatic rejection if no response is received within this time.
 - `approveAll`: If `true`, all tool calls will require manual approval (ignoring `approvalList`).
-- `approvalList`: when `approveAll` is `false`, each entry supports two exact-match formats:
-  - `ToolName`: approve all calls for that tool.
-  - `ToolName:Command`: approve only calls whose `command` matches exactly.
+- `approvalList`: when `approveAll` is `false`, each entry supports four exact-match formats:
+  - `ToolName`: require approval for all calls of that tool; notify AI on rejection.
+  - `ToolName:Command`: require approval only when `command` matches exactly; notify AI on rejection.
+  - `ToolName::SilentReject`: require approval for all calls of that tool; do not notify AI on rejection.
+  - `ToolName:Command::SilentReject`: require approval only when `command` matches exactly; do not notify AI on rejection.
 - If a tool call carries `command1`, `command2`, ... then matching any one of them will trigger approval.
-- If a tool call has no `command` / `commandN`, then only the plain `ToolName` rule can match.
+- If both tool-level and command-level rules match, command-level rule wins.
+- If a same-scope rule exists with and without `::SilentReject`, the `::SilentReject` rule takes precedence.
+- If a tool call has no `command` / `commandN`, then only tool-level rules can match.
 
 ---
 


### PR DESCRIPTION
现在支持四种格式：ToolName、ToolName:Command、ToolName::SilentReject、ToolName:Command::SilentReject
带 ::SilentReject 的规则，在用户拒绝时不会向 AI 返回拒绝提示，主要是为了解决 AI 乱写日记的问题。

但是对配置页面说明的改动，却不起作用，也不知道为什么。