### PR TITLE
feat(ObsidianBridge): v1.2.0 CLI路径配置化

### DIFF
--- a/Plugin/ObsidianBridge/README.md
+++ b/Plugin/ObsidianBridge/README.md
@@ -1,0 +1,284 @@
+# ObsidianBridge
+
+通过 Obsidian 官方 CLI (v1.12+) 桥接 VCP 与 Obsidian 笔记库，让 AI 伙伴直接读写、搜索、管理你的 Obsidian 知识库。
+
+## 概述
+
+ObsidianBridge 是一个 VCP 同步插件，通过调用 Obsidian 官方命令行接口（CLI），让 AI 伙伴能够：
+
+- 📖 **读写笔记** — 读取、创建、追加、前插笔记内容
+- 🔍 **全文搜索** — 支持普通搜索和带上下文的语义搜索
+- 📅 **每日笔记** — 读取/追加/前插今日 Daily Note，获取路径
+- 🏷️ **标签与属性** — 统计标签、读写 frontmatter Properties
+- 🔗 **链接关系** — 查询出站链接和反向链接
+- 📐 **结构分析** — 大纲查看、字数统计、文件/文件夹浏览
+- ✅ **任务管理** — 获取待办任务，支持按文件/每日/全库筛选
+- 📋 **模板列表** — 列出 vault 中已配置的模板
+
+## 前置要求
+
+### 1. Obsidian v1.12+ 及官方 CLI
+
+ObsidianBridge 依赖 Obsidian 2026 年推出的官方 CLI。**它不是一个独立的命令行工具**，而是 Obsidian 桌面端内置的功能。
+
+**安装步骤：**
+
+1. 确保 Obsidian 已更新至 **v1.12.0** 或更高版本
+2. 打开 Obsidian → 设置 → 常规 (General/About)
+3. 找到 **Command Line Interface (CLI)** 选项
+4. 点击 **Register CLI** / **注册**
+5. 如果提示 Installer 过旧，请前往 [obsidian.md/download](https://obsidian.md/download) 下载最新安装包并覆盖安装
+
+**验证安装：**
+
+```bash
+# Windows (PowerShell)
+obsidian version
+
+# 如果返回版本号（如 1.12.7），说明 CLI 已就绪
+# 如果提示找不到命令，检查 PATH 或使用完整路径：
+# D:\你的Obsidian安装路径\Obsidian.com version
+```
+
+> ⚠️ **注意**：v1.12.7 的 Changelog 明确提到 "Obsidian Installer is now bundled with a new binary file for using the CLI"。如果你是从旧版本自动升级的，可能需要重新下载安装包覆盖安装，以获取最新的 CLI 二进制文件。
+
+### 2. 运行时要求
+
+- **Node.js 18+**（VCP 环境自带）
+- **使用 CLI 时必须保持 Obsidian 桌面端打开**（CLI 通过 IPC 与运行中的 Obsidian 通信）
+
+## 特性
+
+✅ **22 项命令** — 覆盖笔记读写、搜索、每日笔记、标签、属性、链接、任务、模板等
+✅ **零依赖** — 仅使用 Node.js 内置 `child_process`、`path`、`fs`
+✅ **可配置 CLI 路径** — 通过 `config.env` 指定 Obsidian CLI 路径，未配置时自动使用系统 PATH
+✅ **参数校验** — 无效 scope 值自动拦截，缺少必需参数明确报错
+✅ **Frontmatter 安全** — `prepend` 命令自动插入到 YAML `---` 之后，不破坏元数据
+✅ **多行内容** — `create` / `append` / `prepend` 支持 `\n` 换行
+✅ **VCP 标准接口** — 支持 stdio 和 `handleRequest()` 双入口
+
+## 技术架构
+
+```
+┌─────────────┐    JSON (stdin/stdout)    ┌────────────────────────┐
+│  VCP Server  │ ────── tool call ──────→  │  obsidian_bridge.js    │
+│  (Plugin.js) │ ←──── JSON result ──────  │  (Node.js, 零依赖)     │
+└─────────────┘                           └──────────┬─────────────┘
+                                                     │ execSync()
+                                                     │ (shell command)
+                                                     ▼
+                                          ┌──────────────────────┐
+                                          │  Obsidian CLI         │
+                                          │  (Obsidian.com/exe)   │
+                                          └──────────┬───────────┘
+                                                     │ IPC
+                                                     ▼
+                                          ┌──────────────────────┐
+                                          │  Obsidian Desktop     │
+                                          │  (运行中的 vault)      │
+                                          └──────────────────────┘
+```
+
+## 命令参考
+
+### 笔记读写
+
+| 命令 | 说明 | 必需参数 | 可选参数 |
+|------|------|----------|----------|
+| `read` | 读取笔记完整内容 | `file` 或 `path` | `vault` |
+| `create` | 创建新笔记 | `name` | `content`, `folder`, `template`, `overwrite`, `vault` |
+| `append` | 向笔记末尾追加内容 | `file`/`path` + `content` | `vault` |
+| `prepend` | 向笔记开头插入内容 | `file`/`path` + `content` | `inline`, `vault` |
+
+### 每日笔记
+
+| 命令 | 说明 | 必需参数 | 可选参数 |
+|------|------|----------|----------|
+| `daily_read` | 读取今日每日笔记 | 无 | `vault` |
+| `daily_append` | 向今日笔记末尾追加 | `content` | `vault` |
+| `daily_prepend` | 向今日笔记开头插入 | `content` | `inline`, `vault` |
+| `daily_path` | 获取今日笔记路径 | 无 | `vault` |
+
+### 搜索
+
+| 命令 | 说明 | 必需参数 | 可选参数 |
+|------|------|----------|----------|
+| `search` | 全文搜索 | `query` | `limit`, `folder`, `vault` |
+| `search_context` | 带上下文搜索（返回匹配行周围内容） | `query` | `limit`, `folder`, `case_sensitive`, `vault` |
+
+### 标签与属性
+
+| 命令 | 说明 | 必需参数 | 可选参数 |
+|------|------|----------|----------|
+| `tags` | 统计 vault 所有标签及使用次数 | 无 | `vault` |
+| `property_set` | 设置笔记 frontmatter 属性 | `file`/`path` + `name` + `value` | `type`, `vault` |
+| `property_read` | 读取笔记某个属性值 | `name` | `file`/`path`, `vault` |
+| `properties` | 列出 vault 或文件的所有属性 | 无 | `file`/`path`, `format`, `total`, `counts`, `sort`, `vault` |
+
+### 链接关系
+
+| 命令 | 说明 | 必需参数 | 可选参数 |
+|------|------|----------|----------|
+| `links` | 查询笔记的出站链接 | `file` 或 `path` | `total`, `vault` |
+| `backlinks` | 查询笔记的反向链接 | `file` 或 `path` | `vault` |
+
+### 结构与统计
+
+| 命令 | 说明 | 必需参数 | 可选参数 |
+|------|------|----------|----------|
+| `files` | 列出 vault 中的文件 | 无 | `folder`, `ext`, `total`, `vault` |
+| `folders` | 列出 vault 中的文件夹 | 无 | `folder`, `total`, `vault` |
+| `outline` | 显示笔记标题大纲 | 无 | `file`/`path`, `format` (tree/md/json), `total`, `vault` |
+| `wordcount` | 字数和字符数统计 | 无 | `file`/`path`, `words`, `characters`, `vault` |
+
+### 任务管理
+
+| 命令 | 说明 | 必需参数 | 可选参数 |
+|------|------|----------|----------|
+| `tasks` | 获取待办任务 | 无 | `file`/`path`, `scope` (daily/all), `done`, `status`, `vault` |
+
+> **scope 说明**：指定 `file`/`path` 时自动查该文件任务；未指定时默认 `daily`（今日每日笔记）；可设为 `all`（全库）。无效 scope 值会被拦截并报错。
+
+### 模板
+
+| 命令 | 说明 | 必需参数 | 可选参数 |
+|------|------|----------|----------|
+| `templates` | 列出 vault 可用模板 | 无 | `total`, `vault` |
+
+> **前提**：需要在 Obsidian 设置中配置 Templates 核心插件的模板文件夹。
+
+## 参数说明
+
+- **`file`**：按笔记名解析（类似 wikilink），如 `file=中心思想`
+- **`path`**：精确相对路径，如 `path=分析/复分析/核心与主干/中心思想.md`
+- **`vault`**：可选，指定 vault 名称（多 vault 环境下使用）
+- **`content`**：支持 `\n` 换行，`\t` 制表符
+- **`format`**：部分命令支持输出格式选择（`json`, `yaml`, `tsv`, `tree`, `md` 等）
+
+## 安装
+
+1. 将 `ObsidianBridge` 文件夹放入 VCPToolBox 的 `Plugin` 目录
+2. 将 `config.env.example` 复制为 `config.env`，根据需要填写 Obsidian CLI 路径（详见下方配置章节）
+3. 重启 VCPToolBox 后端（或等待插件热重载）
+4. 确认 Obsidian 桌面端已打开并已注册 CLI
+
+## 配置
+
+### Obsidian CLI 路径（可选）
+
+默认情况下，插件使用系统 PATH 中的 `obsidian` 命令。如果你的 Obsidian CLI 不在 PATH 中，或需要指定特定安装路径：
+
+1. 将 `config.env.example` 复制为 `config.env`
+2. 设置 `OBSIDIAN_CLI_PATH` 为你的 Obsidian CLI 完整路径
+
+```bash
+# Windows 示例
+OBSIDIAN_CLI_PATH=D:\Obsidian\ObProgram\Obsidian.com
+
+# macOS 示例
+OBSIDIAN_CLI_PATH=/Applications/Obsidian.app/Contents/MacOS/Obsidian
+```
+
+> 如果 `config.env` 不存在或 `OBSIDIAN_CLI_PATH` 为空，插件自动使用 `obsidian` 命令。
+
+如需支持 `templates` 命令，请在 Obsidian 中配置：
+- 设置 → 核心插件 → Templates → 模板文件夹位置
+
+如需支持 `daily_*` 系列命令，请在 Obsidian 中配置：
+- 设置 → 核心插件 → Daily Notes → 新文件存放位置 + 模板文件位置
+
+## 安全策略
+
+以下 Obsidian CLI 命令存在破坏性风险，**本插件不提供 handler**：
+
+| 命令 | 风险 |
+|------|------|
+| `delete` | 永久删除文件 |
+| `move` / `rename` | 可能破坏内链结构 |
+| `eval` | 在 Obsidian 中执行任意 JS 代码 |
+| `dev:*` | 开发者工具，权限过大 |
+| `plugin:install/uninstall` | 改变 Obsidian 运行环境 |
+| `history:restore` | 可能覆盖当前文件内容 |
+
+> 如需这些能力，请通过 Obsidian 桌面端或命令行手动执行。
+
+## 文件结构
+
+```
+Plugin/ObsidianBridge/
+├── obsidian_bridge.js      # 插件主体 (~17KB, 零依赖)
+├── config.env.example      # CLI 路径配置模板
+├── plugin-manifest.json    # VCP 插件清单 (22 命令)
+└── README.md               # 本文件
+```
+
+## 测试记录
+
+v1.2.0 配置化测试（2026-05-08）：
+
+**config.env 配置化加载（2项）**：
+- `OBSIDIAN_CLI_PATH` 填写绝对路径 → 正确加载并调用成功 ✅
+- `OBSIDIAN_CLI_PATH` 为空 → 正确 fallback 到系统 PATH 中的 `obsidian` ✅
+
+v1.1.2 共 23 项测试全部通过（2026-05-02）：
+
+**核心读写（6项）**：
+- `read` 读取笔记完整内容 ✅
+- `create` 创建笔记（含多行 content + YAML frontmatter）✅
+- `append` 多行追加 ✅
+- `prepend` 前插（自动插入 YAML 之后，不破坏 frontmatter）✅
+- `daily_read` 读取今日每日笔记 ✅
+- `daily_append` / `daily_prepend` / `daily_path` ✅
+
+**搜索（2项）**：
+- `search` 全文搜索 ✅
+- `search_context` 带上下文搜索 ✅
+
+**标签与属性（4项）**：
+- `tags` 标签统计 ✅
+- `property_set` 设置属性 ✅
+- `property_read` 读取属性 ✅
+- `properties` 列出属性（format=json/yaml）✅
+
+**链接关系（2项）**：
+- `links` 出站链接 ✅
+- `backlinks` 反向链接 ✅
+
+**结构与统计（4项）**：
+- `files` / `folders` 文件/文件夹列表 ✅
+- `outline` 标题大纲（format=tree/md）✅
+- `wordcount` 字数统计 ✅
+
+**任务管理（3项）**：
+- `tasks scope=daily` 今日任务 ✅
+- `tasks scope=all` 全库任务 ✅
+- `tasks path=指定文件` 指定文件任务 ✅
+
+**防御性测试（1项）**：
+- `tasks scope=monthly` → 正确返回 `scope invalid: monthly. Use: daily, all` ✅
+
+**模板（1项）**：
+- `templates` 列出已配置模板 ✅
+
+## 已知限制
+
+1. **依赖运行中的 Obsidian**：CLI 通过 IPC 与 Obsidian 通信，桌面端必须保持打开
+2. **命令拼接方式**：当前使用 `execSync` 字符串拼接。对于包含特殊 shell 字符的 content，理论上存在边缘风险。未来计划迁移至 `execFileSync` 参数数组
+3. **单 vault**：默认操作当前打开的 vault。多 vault 环境需通过 `vault` 参数指定
+
+## 版本历史
+
+- **v1.2.0** (2026-05-08): 新增 `config.env` 配置文件支持，CLI 路径不再硬编码；未配置时自动 fallback 到系统 PATH 中的 `obsidian` 命令
+- **v1.1.2** (2026-05-02): 修复 `tasks` 忽略 `file`/`path` 参数的问题；新增 `scope` 值白名单校验；版本号同步
+- **v1.1.1** (2026-05-02): 修复多行 `content` 写入时字面量 `\n` 被过度转义导致换行失效的问题
+- **v1.1.0** (2026-05-01): 新增 12 个命令（`files`/`folders`/`prepend`/`daily_prepend`/`daily_path`/`search_context`/`wordcount`/`outline`/`property_read`/`properties`/`links`/`templates`）；修复 `create` 的 `.md` 双重后缀和无效 `silent` flag
+- **v1.0.0** : 初始版本，10 个核心命令
+
+## 贡献者
+
+- **Nova & 水野小夜** — 原始架构设计与 v1.0.0 实现。将 Obsidian 官方 CLI 封装为 VCP 插件的创意和基本的完整功能来自他们，可谓是奠基作者。
+- **infinite-vector** — v1.1.x~v1.2.x 系列扩展：命令扩展、转义修复、任务修复、scope 校验、配置化 CLI 路径、单元测试、README
+
+## License
+
+MIT

--- a/Plugin/ObsidianBridge/config.env.example
+++ b/Plugin/ObsidianBridge/config.env.example
@@ -1,0 +1,14 @@
+# ObsidianBridge Configuration
+# Copy this file to "config.env" and modify as needed.
+
+# Path to the Obsidian CLI executable. 填写到obsidian cli的路径
+# Leave empty or comment out to use the default 'obsidian' command from system PATH. 如果obsidian cli在环境变量里，则可以留空
+# Set to the full absolute path if Obsidian CLI is not in your PATH. 如果不在系统环境变量里，则填写绝对路径
+
+# Examples:
+
+# Windows: OBSIDIAN_CLI_PATH=D:\Obsidian\ObProgram\Obsidian.com
+# macOS:   OBSIDIAN_CLI_PATH=/Applications/Obsidian.app/Contents/MacOS/Obsidian
+# Linux:   OBSIDIAN_CLI_PATH=/usr/local/bin/obsidian
+
+OBSIDIAN_CLI_PATH=

--- a/Plugin/ObsidianBridge/obsidian_bridge.js
+++ b/Plugin/ObsidianBridge/obsidian_bridge.js
@@ -1,0 +1,441 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+
+// ============================================
+// ObsidianBridge - VCP <-> Obsidian CLI 桥接器
+// Version: 1.2.0
+// Author: Nova & 小夜 | 扩展: infinite-vector
+// ============================================
+
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * Load OBSIDIAN_CLI_PATH from config.env (same directory as this script).
+ * Falls back to 'obsidian' (system PATH) if not configured.
+ */
+function loadCliPath() {
+    const envFile = path.join(__dirname, 'config.env');
+    if (fs.existsSync(envFile)) {
+        try {
+            const content = fs.readFileSync(envFile, 'utf-8');
+            for (const line of content.split(/\r?\n/)) {
+                const trimmed = line.trim();
+                if (trimmed.startsWith('#') || !trimmed.includes('=')) continue;
+                const [key, ...rest] = trimmed.split('=');
+                if (key.trim() === 'OBSIDIAN_CLI_PATH') {
+                    const val = rest.join('=').trim();
+                    if (val) return val;
+                }
+            }
+        } catch (_) { /* ignore read errors, fall through */ }
+    }
+    return 'obsidian';
+}
+
+const OBSIDIAN_CLI = loadCliPath();
+
+// --- 工具函数 ---
+
+function escapeValue(val, options = {}) {
+    if (val === undefined || val === null) return '';
+    let str = String(val);
+    if (!options.preserveBackslash) {
+        str = str.replace(/\\/g, '\\\\');
+    }
+    return str.replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\t/g, '\\t');
+}
+
+function buildCommand(subcommand, params = {}, flags = [], vault = null) {
+    const parts = [OBSIDIAN_CLI];
+    if (vault) {
+        parts.push(`vault="${escapeValue(vault)}"`);
+    }
+    parts.push(subcommand);
+    for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined && value !== null && value !== '') {
+            const preserveBackslash = key === 'content';
+            parts.push(`${key}="${escapeValue(value, { preserveBackslash })}"`);
+        }
+    }
+    for (const flag of flags) {
+        parts.push(flag);
+    }
+    return parts.join(' ');
+}
+
+function execCLI(cmdStr, timeoutMs = 25000) {
+    try {
+        const stdout = execSync(cmdStr, {
+            encoding: 'utf-8',
+            timeout: timeoutMs,
+            windowsHide: true,
+            maxBuffer: 10 * 1024 * 1024
+        });
+        return { success: true, output: stdout.trim() };
+    } catch (err) {
+        const stderr = err.stderr ? err.stderr.toString().trim() : '';
+        const stdout = err.stdout ? err.stdout.toString().trim() : '';
+        const message = stderr || stdout || err.message || 'Unknown CLI error';
+        return { success: false, output: message };
+    }
+}
+// --- 安全策略 ---
+// 以下 CLI 命令存在破坏性风险，不应添加 handler：
+// - 文件操作：delete, move, rename（可能破坏内链结构）
+// - 代码执行：eval, dev:*（等同于打开 Obsidian JS 执行权）
+// - 插件管理：plugin:install/uninstall（改变运行环境）
+// - 历史回滚：history:restore（可能覆盖当前文件）
+// - 命令映射说明：桥接器侧用下划线（daily_read），CLI 侧用冒号（daily:read）
+// --- 命令处理器 ---
+
+const COMMAND_HANDLERS = {
+
+    // ===== 原有命令（v1.0.0） =====
+
+    read: (args) => {
+        if (!args.file && !args.path) {
+            return error('缺少必需参数: file 或 path');
+        }
+        const params = {};
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        const cmd = buildCommand('read', params, [], args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('读取笔记失败: ' + result.output);
+        return success('笔记内容 [' + (args.file || args.path) + ']:\n\n' + result.output);
+    },
+
+    search: (args) => {
+        if (!args.query) return error('缺少必需参数: query');
+        const params = { query: args.query };
+        if (args.limit) params.limit = args.limit;
+        if (args.folder) params.path = args.folder;
+        const cmd = buildCommand('search', params, [], args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('搜索失败: ' + result.output);
+        return success('搜索 "' + args.query + '" 的结果:\n\n' + result.output);
+    },
+
+    create: (args) => {
+        if (!args.name) return error('缺少必需参数: name');
+        const params = { name: args.name };
+        if (args.content) params.content = args.content;
+        if (args.template) params.template = args.template;
+        if (args.folder) {
+            const baseName = args.name.replace(/\.md$/i, '');
+            const fullPath = args.folder.replace(/\/$/, '') + '/' + baseName + '.md';
+            params.path = fullPath;
+            delete params.name;
+        }
+        const flags = [];
+        if (args.overwrite) flags.push('overwrite');
+        const cmd = buildCommand('create', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('创建笔记失败: ' + result.output);
+        return success('笔记 "' + args.name + '" 创建成功。' + (result.output ? '\n' + result.output : ''));
+    },
+
+    append: (args) => {
+        if (!args.file && !args.path) return error('缺少必需参数: file 或 path');
+        if (!args.content) return error('缺少必需参数: content');
+        const params = { content: args.content };
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        const cmd = buildCommand('append', params, [], args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('追加内容失败: ' + result.output);
+        return success('已向 "' + (args.file || args.path) + '" 追加内容。' + (result.output ? '\n' + result.output : ''));
+    },
+
+    daily_read: (args) => {
+        const cmd = buildCommand('daily:read', {}, [], args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('读取每日笔记失败: ' + result.output);
+        return success('今日每日笔记内容:\n\n' + result.output);
+    },
+
+    daily_append: (args) => {
+        if (!args.content) return error('缺少必需参数: content');
+        const params = { content: args.content };
+        const cmd = buildCommand('daily:append', params, [], args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('追加每日笔记失败: ' + result.output);
+        return success('已向今日每日笔记追加内容。' + (result.output ? '\n' + result.output : ''));
+    },
+
+    backlinks: (args) => {
+        if (!args.file && !args.path) return error('缺少必需参数: file 或 path');
+        const params = {};
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        const cmd = buildCommand('backlinks', params, ['counts'], args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('查询反向链接失败: ' + result.output);
+        return success('"' + (args.file || args.path) + '" 的反向链接:\n\n' + result.output);
+    },
+
+    tags: (args) => {
+        const cmd = buildCommand('tags', {}, ['sort=count', 'counts'], args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('获取标签统计失败: ' + result.output);
+        return success('笔记库标签统计:\n\n' + result.output);
+    },
+
+    tasks: (args) => {
+        const params = {};
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        if (args.status) params.status = args.status;
+
+        const validScopes = ['daily', 'all', 'file']; if (args.scope && !validScopes.includes(args.scope)) { return error('scope invalid: ' + args.scope + '. Use: daily, all'); } const scope = args.scope || ((args.file || args.path) ? 'file' : 'daily');
+        const flags = [];
+
+        if (args.done) {
+            flags.push('done');
+        } else {
+            flags.push('todo');
+        }
+
+        if (args.verbose !== false) flags.push('verbose');
+        if (scope === 'daily' && !args.file && !args.path) flags.push('daily');
+
+        const cmd = buildCommand('tasks', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('获取任务列表失败: ' + result.output);
+
+        const scopeLabel = (args.file || args.path)
+            ? ('指定文件 [' + (args.file || args.path) + ']')
+            : (scope === 'daily' ? '今日每日笔记' : '全库');
+        return success(scopeLabel + '待办任务:\n\n' + result.output);
+    },
+
+    property_set: (args) => {
+        if (!args.file && !args.path) return error('缺少必需参数: file 或 path');
+        if (!args.name) return error('缺少必需参数: name (属性名)');
+        if (args.value === undefined || args.value === null) return error('缺少必需参数: value (属性值)');
+        const params = { name: args.name, value: args.value };
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        if (args.type) params.type = args.type;
+        const cmd = buildCommand('property:set', params, [], args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('设置属性失败: ' + result.output);
+        return success('已设置 "' + (args.file || args.path) + '" 的属性 [' + args.name + '] = "' + args.value + '"。' + (result.output ? '\n' + result.output : ''));
+    },
+
+    // ===== 新增命令（v1.1.0 by ResearchCC） =====
+
+    files: (args) => {
+        const params = {};
+        if (args.folder) params.folder = args.folder;
+        if (args.ext) params.ext = args.ext;
+        const flags = [];
+        if (args.total) flags.push('total');
+        const cmd = buildCommand('files', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('列出文件失败: ' + result.output);
+        return success('文件列表:\n\n' + result.output);
+    },
+
+    folders: (args) => {
+        const params = {};
+        if (args.folder) params.folder = args.folder;
+        const flags = [];
+        if (args.total) flags.push('total');
+        const cmd = buildCommand('folders', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('列出文件夹失败: ' + result.output);
+        return success('文件夹列表:\n\n' + result.output);
+    },
+
+    prepend: (args) => {
+        if (!args.file && !args.path) return error('缺少必需参数: file 或 path');
+        if (!args.content) return error('缺少必需参数: content');
+        const params = { content: args.content };
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        const flags = [];
+        if (args.inline) flags.push('inline');
+        const cmd = buildCommand('prepend', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('向文件开头写入失败: ' + result.output);
+        return success('已向 "' + (args.file || args.path) + '" 开头写入内容。' + (result.output ? '\n' + result.output : ''));
+    },
+
+    daily_prepend: (args) => {
+        if (!args.content) return error('缺少必需参数: content');
+        const params = { content: args.content };
+        const flags = [];
+        if (args.inline) flags.push('inline');
+        const cmd = buildCommand('daily:prepend', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('向每日笔记开头写入失败: ' + result.output);
+        return success('已向今日每日笔记开头写入内容。' + (result.output ? '\n' + result.output : ''));
+    },
+
+    daily_path: (args) => {
+        const cmd = buildCommand('daily:path', {}, [], args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('获取每日笔记路径失败: ' + result.output);
+        return success('今日每日笔记路径: ' + result.output);
+    },
+
+    search_context: (args) => {
+        if (!args.query) return error('缺少必需参数: query');
+        const params = { query: args.query };
+        if (args.limit) params.limit = args.limit;
+        if (args.folder) params.path = args.folder;
+        const flags = [];
+        if (args.case_sensitive) flags.push('case');
+        const cmd = buildCommand('search:context', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('上下文搜索失败: ' + result.output);
+        return success('搜索 "' + args.query + '" 的上下文结果:\n\n' + result.output);
+    },
+
+    wordcount: (args) => {
+        const params = {};
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        const flags = [];
+        if (args.words) flags.push('words');
+        if (args.characters) flags.push('characters');
+        const cmd = buildCommand('wordcount', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('字数统计失败: ' + result.output);
+        return success('字数统计 [' + (args.file || args.path || '活跃文件') + ']:\n' + result.output);
+    },
+
+    outline: (args) => {
+        const params = {};
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        if (args.format) params.format = args.format;
+        const flags = [];
+        if (args.total) flags.push('total');
+        const cmd = buildCommand('outline', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('获取大纲失败: ' + result.output);
+        return success('文件大纲 [' + (args.file || args.path || '活跃文件') + ']:\n\n' + result.output);
+    },
+
+    property_read: (args) => {
+        if (!args.name) return error('缺少必需参数: name (属性名)');
+        const params = { name: args.name };
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        const cmd = buildCommand('property:read', params, [], args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('读取属性失败: ' + result.output);
+        return success('[' + args.name + '] = ' + result.output);
+    },
+
+    properties: (args) => {
+        const params = {};
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        if (args.name) params.name = args.name;
+        if (args.format) params.format = args.format;
+        const flags = [];
+        if (args.total) flags.push('total');
+        if (args.counts) flags.push('counts');
+        if (args.sort) flags.push('sort=' + args.sort);
+        const cmd = buildCommand('properties', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('获取属性列表失败: ' + result.output);
+        return success('属性列表:\n\n' + result.output);
+    },
+
+    links: (args) => {
+        if (!args.file && !args.path) return error('缺少必需参数: file 或 path');
+        const params = {};
+        if (args.file) params.file = args.file;
+        if (args.path) params.path = args.path;
+        const flags = [];
+        if (args.total) flags.push('total');
+        const cmd = buildCommand('links', params, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('查询出站链接失败: ' + result.output);
+        return success('"' + (args.file || args.path) + '" 的出站链接:\n\n' + result.output);
+    },
+
+    templates: (args) => {
+        const flags = [];
+        if (args.total) flags.push('total');
+        const cmd = buildCommand('templates', {}, flags, args.vault);
+        const result = execCLI(cmd);
+        if (!result.success) return error('获取模板列表失败: ' + result.output);
+        return success('模板列表:\n\n' + result.output);
+    }
+};
+
+// --- 响应构建 ---
+
+function success(text, details = null) {
+    const result = {
+        status: 'success',
+        result: {
+            content: [{ type: 'text', text: text }]
+        }
+    };
+    if (details) result.result.details = details;
+    return result;
+}
+
+function error(message) {
+    return {
+        status: 'error',
+        error: message
+    };
+}
+
+// --- handleRequest 入口 ---
+
+async function handleRequest(args) {
+    const command = args.command;
+    if (!command) {
+        return error('缺少必需参数: command。可用命令: ' + Object.keys(COMMAND_HANDLERS).join(', '));
+    }
+    const handler = COMMAND_HANDLERS[command];
+    if (!handler) {
+        return error('未知命令: "' + command + '"。可用命令: ' + Object.keys(COMMAND_HANDLERS).join(', '));
+    }
+    try {
+        return handler(args);
+    } catch (err) {
+        return error('ObsidianBridge 内部错误: ' + err.message);
+    }
+}
+
+module.exports = { handleRequest };
+
+// --- stdio 主入口 ---
+
+async function main() {
+    let inputChunks = [];
+    process.stdin.setEncoding('utf8');
+    for await (const chunk of process.stdin) {
+        inputChunks.push(chunk);
+    }
+    const inputData = inputChunks.join('');
+    try {
+        if (!inputData.trim()) {
+            throw new Error('No input data received from stdin.');
+        }
+        const parsedArgs = JSON.parse(inputData);
+        const resultObject = await handleRequest(parsedArgs);
+        console.log(JSON.stringify(resultObject));
+    } catch (e) {
+        console.log(JSON.stringify({
+            status: 'error',
+            error: 'ObsidianBridge Error: ' + e.message
+        }));
+        process.exit(1);
+    }
+}
+
+if (require.main === module) {
+    main();
+}

--- a/Plugin/ObsidianBridge/plugin-manifest.json
+++ b/Plugin/ObsidianBridge/plugin-manifest.json
@@ -1,0 +1,131 @@
+{
+  "manifestVersion": "1.0.0",
+  "name": "ObsidianBridge",
+  "displayName": "Obsidian 笔记桥接器",
+  "version": "1.1.2",
+  "description": "通过 Obsidian CLI (v1.12.7) 桥接 VCP 与 Obsidian 笔记库。支持笔记读写、全文搜索(含上下文)、每日笔记、文件/文件夹浏览、任务管理、反向链接/出站链接查询、标签统计、属性管理、大纲查看、字数统计、模板列表等 22 项能力。v1.1.1 修复多行 content 写入时字面量反斜杠被过度转义导致换行符失效的问题。",
+  "author": "Nova & 小夜 | 扩展: infinite-vector",
+  "pluginType": "synchronous",
+  "entryPoint": {
+    "type": "nodejs",
+    "command": "node obsidian_bridge.js"
+  },
+  "communication": {
+    "protocol": "stdio",
+    "timeout": 30000
+  },
+  "capabilities": {
+    "invocationCommands": [
+      {
+        "commandIdentifier": "read",
+        "description": "读取指定 Obsidian 笔记的完整内容。参数: file(笔记名,wikilink风格) 或 path(精确相对路径), vault(可选,指定vault)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」read「末」,\nfile:「始」品牌洞察思考「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "search",
+        "description": "在 Obsidian 笔记库中全文搜索。参数: query(必需,搜索关键词), limit(可选,返回数量), folder(可选,限定文件夹)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」search「末」,\nquery:「始」Cauchy积分「末」,\nlimit:「始」10「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "search_context",
+        "description": "带上下文的全文搜索,返回匹配行及其周围内容,更适合AI阅读。参数: query(必需), limit(可选), folder(可选), case_sensitive(可选,布尔)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」search_context「末」,\nquery:「始」测度论「末」,\nlimit:「始」5「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "create",
+        "description": "创建新的 Obsidian 笔记。参数: name(必需,笔记名), content(可选,正文,支持字面量\\n换行), folder(可选,存放文件夹), template(可选,模板名), overwrite(可选,布尔)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」create「末」,\nname:「始」测试笔记「末」,\ncontent:「始」# 标题\\n\\n正文内容「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "append",
+        "description": "向已有笔记末尾追加内容。参数: file 或 path(必需), content(必需)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」append「末」,\nfile:「始」测试笔记「末」,\ncontent:「始」追加的内容「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "prepend",
+        "description": "向已有笔记开头插入内容。参数: file 或 path(必需), content(必需), inline(可选,不加换行)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」prepend「末」,\nfile:「始」测试笔记「末」,\ncontent:「始」插入到开头的内容「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "daily_read",
+        "description": "读取今日每日笔记(Daily Note)内容。参数: vault(可选)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」daily_read「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "daily_append",
+        "description": "向今日每日笔记末尾追加内容。参数: content(必需)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」daily_append「末」,\ncontent:「始」追加内容「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "daily_prepend",
+        "description": "向今日每日笔记开头插入内容。参数: content(必需), inline(可选,不加换行)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」daily_prepend「末」,\ncontent:「始」插入到开头的内容「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "daily_path",
+        "description": "获取今日每日笔记的文件路径。无必需参数。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」daily_path「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "files",
+        "description": "列出vault中的文件。参数: folder(可选,限定文件夹), ext(可选,限定扩展名), total(可选,布尔,仅返回数量)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」files「末」,\nfolder:「始」数学maths/分析「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "folders",
+        "description": "列出vault中的文件夹。参数: folder(可选,限定父文件夹), total(可选,布尔,仅返回数量)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」folders「末」,\nfolder:「始」数学maths「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "backlinks",
+        "description": "查询指定笔记的所有反向链接(谁链接了它)。参数: file 或 path(必需)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」backlinks「末」,\nfile:「始」中心思想「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "links",
+        "description": "查询指定笔记的出站链接(它链接了谁)。参数: file 或 path(必需), total(可选,布尔)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」links「末」,\nfile:「始」中心思想「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "tags",
+        "description": "统计笔记库中所有标签及使用次数,按使用频率排序。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」tags「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "tasks",
+        "description": "获取待办任务列表。参数: file 或 path(可选,指定文件), scope(可选,'daily'或'all',默认daily；指定file/path时自动查该文件), done(可选,查已完成), status(可选,按任务状态字符筛选)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」tasks「末」,\nscope:「始」daily「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "property_set",
+        "description": "设置笔记的 frontmatter/Properties 属性。参数: file 或 path(必需), name(必需,属性名), value(必需,属性值), type(可选,text/list/number/checkbox/date/datetime)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」property_set「末」,\nfile:「始」测试笔记「末」,\nname:「始」status「末」,\nvalue:「始」done「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "property_read",
+        "description": "读取笔记的某个 frontmatter/Properties 属性值。参数: name(必需,属性名), file 或 path(可选,省略则读活跃文件)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」property_read「末」,\nname:「始」tags「末」,\nfile:「始」测试笔记「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "properties",
+        "description": "列出vault或指定文件的所有属性。参数: file 或 path(可选), format(可选,yaml/json/tsv), total(可选), counts(可选), sort(可选,'count')。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」properties「末」,\nformat:「始」json「末」,\ncounts:「始」true「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "wordcount",
+        "description": "统计笔记的字数和字符数。参数: file 或 path(可选,省略则统计活跃文件), words(可选,仅返回字数), characters(可选,仅返回字符数)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」wordcount「末」,\nfile:「始」中心思想「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "outline",
+        "description": "显示笔记的标题大纲结构。参数: file 或 path(可选), format(可选,tree/md/json), total(可选,仅返回标题数)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」outline「末」,\nfile:「始」中心思想「末」,\nformat:「始」tree「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "templates",
+        "description": "列出vault中所有可用模板。参数: total(可选,布尔,仅返回数量)。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ObsidianBridge「末」,\ncommand:「始」templates「末」\n<<<[END_TOOL_REQUEST]>>>"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 改动内容

ObsidianBridge 插件的 Obsidian CLI 路径此前硬编码在 obsidian_bridge.js 中，
不同用户的安装路径不同，每次都需要手动改源码。

本 PR 将 CLI 路径改为通过 config.env 配置文件加载：


新增文件
1. config.env.example — 配置模板

2. obsidian_bridge.js

新增 loadCliPath() 函数，解析同目录下 config.env 中的 OBSIDIAN_CLI_PATH

未配置或为空时自动 fallback 到系统 PATH 中的 obsidian 命令

零新依赖（仅使用 Node.js 内置 path 和 fs）

版本号 1.1.2 → 1.2.0


3. README.md

安装步骤更新（不再要求修改源码）

新增配置章节说明

特性列表、文件结构、已知限制、版本历史同步更新

4. plugin-manifest.json


测试：

OBSIDIAN_CLI_PATH 填写绝对路径 → 调用成功 ✅

OBSIDIAN_CLI_PATH 为空 → fallback 到 PATH 中的 obsidian → 调用成功 ✅


贡献者

本插件原始架构由 @Nova 和 @mizunosayo 设计实现（v1.0.0），
本 PR 由 @infinite-vector 在其基础上扩展两次。