### PR TITLE
feat(MetaThinking): Auto模式支持白名单/黑名单chain过滤

### DIFF
--- a/Plugin/RAGDiaryPlugin/MetaThinkingManager.js
+++ b/Plugin/RAGDiaryPlugin/MetaThinkingManager.js
@@ -103,7 +103,7 @@ class MetaThinkingManager {
     /**
      * 处理VCP元思考链 - 递归向量增强的多阶段推理
      */
-    async processMetaThinkingChain(chainName, queryVector, userContent, aiContent, combinedQueryForDisplay, kSequence, useGroup, isAutoMode = false, autoThreshold = 0.65) {
+    async processMetaThinkingChain(chainName, queryVector, userContent, aiContent, combinedQueryForDisplay, kSequence, useGroup, isAutoMode = false, autoThreshold = 0.65, autoWhitelist = null, autoBlacklist = null) {
 
         // 🌟 兜底：如果配置尚未加载，先执行加载
         if (!this.metaThinkingChains.chains || Object.keys(this.metaThinkingChains.chains).length === 0) {
@@ -121,6 +121,9 @@ class MetaThinkingManager {
             }
 
             for (const [themeName, themeVector] of themeEntries) {
+                // 🌟 白名单/黑名单过滤
+                if (autoWhitelist && !autoWhitelist.includes(themeName)) continue;
+                if (autoBlacklist && autoBlacklist.includes(themeName)) continue;
                 const similarity = this.ragPlugin.cosineSimilarity(queryVector, themeVector);
                 if (similarity > maxSimilarity) {
                     maxSimilarity = similarity;
@@ -272,7 +275,7 @@ class MetaThinkingManager {
                         const avgResultVector = this._getAverageVector(resultVectors);
                         const config = this.ragPlugin.ragParams?.RAGDiaryPlugin || {};
                         const metaWeights = config.metaThinkingWeights || [0.8, 0.2];
-                        
+
                         currentQueryVector = this.ragPlugin._getWeightedAverageVector(
                             [queryVector, avgResultVector],
                             metaWeights

--- a/Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
+++ b/Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
@@ -1416,6 +1416,8 @@ class RAGDiaryPlugin {
             let useGroup = false;
             let isAutoMode = false;
             let autoThreshold = 0.65; // 默认自动切换阈值
+            let autoWhitelist = null; // 🌟 auto 白名单
+            let autoBlacklist = null; // 🌟 auto 黑名单
 
             // 分析修饰符字符串
             if (modifiersAndParams) {
@@ -1427,11 +1429,27 @@ class RAGDiaryPlugin {
 
                     if (lowerPart.startsWith('auto')) {
                         isAutoMode = true;
-                        const thresholdMatch = part.match(/:(\d+\.?\d*)/);
-                        if (thresholdMatch) {
-                            const parsedThreshold = parseFloat(thresholdMatch[1]);
-                            if (!isNaN(parsedThreshold)) {
-                                autoThreshold = parsedThreshold;
+                        // 🌟 新语法: auto[:阈值][:范围]
+                        // 示例: auto:0.65:Coding,investigation (白名单)
+                        //       auto:0.65:!disco (黑名单)
+                        //       auto:!disco (黑名单+默认阈值)
+                        const autoMatch = part.match(/^auto(?::([\d.]+))?(?::(.+))?$/i);
+                        if (autoMatch) {
+                            if (autoMatch[1]) {
+                                const parsedThreshold = parseFloat(autoMatch[1]);
+                                if (!isNaN(parsedThreshold)) {
+                                    autoThreshold = parsedThreshold;
+                                }
+                            }
+                            if (autoMatch[2]) {
+                                const scopePart = autoMatch[2];
+                                if (scopePart.startsWith('!')) {
+                                    autoBlacklist = scopePart.slice(1).split(',').map(s => s.trim()).filter(Boolean);
+                                    console.log(`[RAGDiaryPlugin] Auto 黑名单: ${autoBlacklist.join(', ')}`);
+                                } else {
+                                    autoWhitelist = scopePart.split(',').map(s => s.trim()).filter(Boolean);
+                                    console.log(`[RAGDiaryPlugin] Auto 白名单: ${autoWhitelist.join(', ')}`);
+                                }
                             }
                         }
                         // 在自动模式下，链名称将由auto逻辑决定
@@ -1459,7 +1477,9 @@ class RAGDiaryPlugin {
                     null, // kSequence现在从JSON配置中获取，不再从占位符传递
                     useGroup,
                     isAutoMode,
-                    autoThreshold
+                    autoThreshold,
+                    autoWhitelist,
+                    autoBlacklist
                 );
 
                 processedContent = processedContent.replace(placeholder, metaResult);
@@ -3634,7 +3654,7 @@ class RAGDiaryPlugin {
             // ✅ 新增：包含Tag相关信息（如果存在）
             if (r.originalScore !== undefined) cleaned.originalScore = r.originalScore;
             if (r.tagMatchScore !== undefined) cleaned.tagMatchScore = r.tagMatchScore;
-            
+
             let finalTags = [];
             if (r.matchedTags && Array.isArray(r.matchedTags)) {
                 finalTags = r.matchedTags.map(t => {
@@ -3649,7 +3669,7 @@ class RAGDiaryPlugin {
             if (finalTags.length > 0) {
                 cleaned.matchedTags = finalTags;
             }
-            
+
             if (r.tagMatchCount !== undefined) cleaned.tagMatchCount = r.tagMatchCount;
             if (r.boostFactor !== undefined) cleaned.boostFactor = r.boostFactor;
             if (r._associateCoCount !== undefined) cleaned.associateCoCount = r._associateCoCount; // 🌟 V10
@@ -3786,6 +3806,8 @@ class RAGDiaryPlugin {
             useGroup = false,
             isAutoMode = false,
             ghostTags = [],
+            autoWhitelist = null,
+            autoBlacklist = null,
             isFreshTimeConversationStart = false
         } = params;
 
@@ -3807,6 +3829,8 @@ class RAGDiaryPlugin {
             auto: isAutoMode,
             date: currentDate,
             ghosts: ghostTagString,
+            auto_wl: autoWhitelist ? autoWhitelist.sort().join(',') : '',
+            auto_bl: autoBlacklist ? autoBlacklist.sort().join(',') : '',
             fresh_time_start: isFreshTimeConversationStart
         });
     }
@@ -3963,7 +3987,7 @@ class RAGDiaryPlugin {
         // 匹配 http, https, file 协议的链接
         const regex = /(https?:\/\/[^\s\)\"\'\>]+|file:\/\/[^\s\)\"\'\>]+)/gi;
         const matches = text.match(regex) || [];
-        
+
         return matches.filter(url => {
             const lowerUrl = url.toLowerCase();
             // 排除表情包路径
@@ -3992,11 +4016,11 @@ class RAGDiaryPlugin {
                 } else if (filePath.startsWith('/')) {
                     // 可能需要根据系统调整
                 }
-                
+
                 // 尝试解码 URL 编码的路径
                 try {
                     filePath = decodeURIComponent(filePath);
-                } catch (e) {}
+                } catch (e) { }
 
                 buffer = await fs.readFile(filePath);
                 mimeType = mime.lookup(filePath) || 'application/octet-stream';


### PR DESCRIPTION
## 功能：元思考链Auto模式支持白名单/黑名单chain过滤

变更概述
为 [[VCP元思考::auto]] 占位符新增可选的chain范围限定语法，允许每个Agent只在指定的chain子集中做auto切换，而非全局竞争。

语法：

白名单：[[VCP元思考::auto:0.65:coding,investigation::Group]]
黑名单：[[VCP元思考::auto:0.65:!investigation::Group]]
省略阈值：[[VCP元思考::auto:coding,investigation::Group]]
不写范围（向后兼容）：[[VCP元思考::auto::Group]] → 行为不变

改动文件

Plugin/RAGDiaryPlugin/RAGDiaryPlugin.js
auto解析正则扩展，支持白名单/黑名单解析
调用processMetaThinkingChain时传入autoWhitelist/autoBlacklist
_generateCacheKey加入auto_wl/auto_bl字段


Plugin/RAGDiaryPlugin/MetaThinkingManager.js
processMetaThinkingChain签名追加autoWhitelist/autoBlacklist参数
auto模式for循环内加入白名单/黑名单continue过滤



测试

✅ 白名单：auto:0.52:coding,investigation → coding以0.5211胜出
✅ 黑名单：auto:0.59:!investigation → coding以0.6281胜出
✅ 向后兼容：不写范围参数时全局扫描，行为不变
✅ 边界case：白名单中chain不存在→池子空→fallback default

向后兼容性
100%。不加范围参数时autoWhitelist/autoBlacklist为null，条件短路，全局扫描逻辑不变。