### PR TITLE
feat(ImageServer): 增强图片格式回退机制并补充表情包修复器配置文档

### DIFF
--- a/Plugin/EmojiListGenerator/README.md
+++ b/Plugin/EmojiListGenerator/README.md
@@ -36,4 +36,42 @@
 ## 注意事项
 
 -   确保 `PROJECT_BASE_PATH` 环境变量被正确设置。
--   插件会覆盖 `generated_lists/` 目录中已存在的同名 `.txt` 文件。
+-   插件会覆盖 `generated_lists/` 目录中已存在的同名 `.txt` 文件。## 前端表情包修复器配置
+
+VCPChat 前端内置了 AI 表情包 URL 修复器（`emoticonUrlFixer`），能自动修复 AI 生成的错误表情包 URL。该修复器依赖本插件生成的列表数据作为匹配知识库。
+
+### 配置步骤
+
+1. **复制列表文件**：将本插件目录下的 `generated_lists/` 整个文件夹复制到 VCPChat 的 `AppData/` 目录下
+   - 最终路径：`VCPChat/AppData/generated_lists/`
+
+2. **配置图床密码**：在 `VCPChat/AppData/generated_lists/` 目录下创建 `config.env` 文件，写入：
+   ```
+   file_key=你的图床密码
+   ```
+   > **重要**：`file_key` 的值必须与 VCPToolBox 根目录 `config.env` 中的 `Image_Key` 保持一致。
+
+3. **重启 VCPChat 客户端**，修复器会自动加载表情包库。
+
+### 验证配置
+
+启动 VCPChat 后，打开开发者工具（`Ctrl+Shift+I`）→ Console，搜索 `EmoticonFixer`：
+- 成功：`[EmoticonFixer] Library loaded with N items.`
+- 失败：`[EmoticonFixer] Library unavailable, fixer running in degraded passthrough mode.`
+
+## 表情包 URL 修复器工作原理
+
+当 AI 生成的表情包 URL 存在错误时（文件夹名错误、文件格式错误、文件名拼写错误等），前端修复器会自动尝试修复：
+
+### 修复机制（按优先级）
+
+1. **完美匹配检查**：URL 与库中某项完全一致 → 直接通过，不做修改
+2. **精确文件名匹配**：剥离扩展名后进行精确比对，忽略文件夹差异和格式差异。当 AI 写对了文件名但文件夹或格式错误时，能准确跨文件夹匹配到正确的表情包
+3. **模糊匹配**（降级方案）：使用编辑距离算法计算加权相似度（70% 文件夹名权重 + 30% 文件名权重），选择得分最高且超过阈值（0.6）的结果
+
+### 注意事项
+
+- 新增表情包目录后需**重启 VCPToolBox 后端**，本插件才会重新扫描生成列表
+- 重新生成列表后需**再次复制** `generated_lists/` 到前端 `AppData/` 目录
+- 修复器在库为空时自动降级为直通模式（passthrough），不做任何 URL 修改
+- 后端 ImageServer 提供了额外的图片格式回退机制（`.png`↔`.jpg`↔`.webp` 等），作为前端修复器的补充防御层

--- a/Plugin/EmojiListGenerator/README.md
+++ b/Plugin/EmojiListGenerator/README.md
@@ -36,7 +36,9 @@
 ## 注意事项
 
 -   确保 `PROJECT_BASE_PATH` 环境变量被正确设置。
--   插件会覆盖 `generated_lists/` 目录中已存在的同名 `.txt` 文件。## 前端表情包修复器配置
+-   插件会覆盖 `generated_lists/` 目录中已存在的同名 `.txt` 文件。
+
+## 前端表情包修复器配置
 
 VCPChat 前端内置了 AI 表情包 URL 修复器（`emoticonUrlFixer`），能自动修复 AI 生成的错误表情包 URL。该修复器依赖本插件生成的列表数据作为匹配知识库。
 
@@ -53,7 +55,7 @@ VCPChat 前端内置了 AI 表情包 URL 修复器（`emoticonUrlFixer`），能
 
 3. **重启 VCPChat 客户端**，修复器会自动加载表情包库。
 
-### 验证配置
+### 验证配置（可选）
 
 启动 VCPChat 后，打开开发者工具（`Ctrl+Shift+I`）→ Console，搜索 `EmoticonFixer`：
 - 成功：`[EmoticonFixer] Library loaded with N items.`

--- a/Plugin/ImageServer/image-server.js
+++ b/Plugin/ImageServer/image-server.js
@@ -362,8 +362,39 @@ function createSecureStaticMiddleware(rootDir, serviceType) {
             console.log(`[SecureStatic] 安全检查通过，请求文件: ${requestedFile}`);
         }
 
-        // 直接使用express.static中间件
-        staticMiddleware(req, res, next);
+        // 先尝试 express.static 精确匹配
+        staticMiddleware(req, res, () => {
+            // 精确匹配失败 → 尝试图片格式回退（仅限 Image 服务）
+            if (serviceType !== 'Image') return next();
+
+            // 关键：req.path 是 URL 编码的，必须解码后才能匹配文件系统路径
+            let decodedPath;
+            try {
+                decodedPath = decodeURIComponent(req.path);
+            } catch (e) {
+                return next(); // URL 解码失败，跳过回退
+            }
+
+            const ext = path.extname(decodedPath).toLowerCase();
+            if (!ext) return next(); // 无扩展名，跳过
+
+            const baseName = decodedPath.slice(0, -ext.length);
+            const fallbackExts = ['.png', '.jpg', '.jpeg', '.webp', '.gif'].filter(e => e !== ext);
+
+            for (const tryExt of fallbackExts) {
+                const tryPath = path.join(rootDir, baseName + tryExt);
+                const normalizedTry = path.resolve(tryPath);
+                // 安全检查：确保回退路径仍在允许目录内
+                if (!normalizedTry.startsWith(normalizedRoot)) continue;
+                if (fs.existsSync(tryPath)) {
+                    if (pluginDebugMode) {
+                        console.log(`[SecureStatic] 🔄 格式回退: ${decodedPath} -> ${baseName + tryExt}`);
+                    }
+                    return res.sendFile(normalizedTry);
+                }
+            }
+            next(); // 所有回退格式都找不到 → 404
+        });
     };
 }
 


### PR DESCRIPTION
ImageServer 图片格式回退 + EmojiListGenerator 文档补充

ImageServer 格式回退（image-server.js）：当 express.static 精确匹配失败时，自动尝试其他图片格式（.png↔.jpg↔.jpeg↔.webp↔.gif）。修复了 req.path 未经 decodeURIComponent 解码导致中文路径无法匹配文件系统的问题。

EmojiListGenerator README 补充（README.md）：追加了前端表情包 URL 修复器的配置步骤（generated_lists 复制、config.env 配置、验证方法）和修复机制说明（精确匹配 → 模糊匹配的降级链路）。

总之就是无足轻重的更新
