### PR TITLE
TavilySearch 和 VolcSearch 添加并发搜索模式

### DIFF
--- a/Plugin/TavilySearch/TavilySearch.js
+++ b/Plugin/TavilySearch/TavilySearch.js
@@ -2,6 +2,28 @@
 const { tavily } = require('@tavily/core'); // Using the official Node.js client
 const stdin = require('process').stdin;
 
+/**
+ * 将 Tavily 搜索结果格式化为 Markdown
+ */
+function formatTavilyResults(response) {
+    let md = '';
+    if (response.answer) {
+        md += `### 直接回答\n${response.answer}\n\n`;
+    }
+    if (response.results && response.results.length > 0) {
+        md += `### 搜索结果\n`;
+        response.results.forEach((item, index) => {
+            md += `${index + 1}. **[${item.title}](${item.url})**\n`;
+            if (item.content) {
+                md += `   ${item.content}\n\n`;
+            }
+        });
+    } else {
+        md += `未找到相关搜索结果。\n`;
+    }
+    return md;
+}
+
 async function main() {
     let inputData = '';
     stdin.setEncoding('utf8');
@@ -124,27 +146,58 @@ async function main() {
                 }
             }
 
-            const response = await tvly.search(query, searchOptions);
+            // 检测是否包含 || 分隔的多个查询
+            const subQueries = query.split('||').map(q => q.trim()).filter(q => q.length > 0);
 
-            // 将 Tavily 搜索结果转换为 Markdown 格式
-            let markdownResult = '';
-            if (response.answer) {
-                markdownResult += `### 直接回答\n${response.answer}\n\n`;
+            if (subQueries.length === 0) {
+                throw new Error("No valid search query after splitting by '||'");
             }
 
-            if (response.results && response.results.length > 0) {
-                markdownResult += `### 搜索结果\n`;
-                response.results.forEach((item, index) => {
-                    markdownResult += `${index + 1}. **[${item.title}](${item.url})**\n`;
-                    if (item.content) {
-                        markdownResult += `   ${item.content}\n\n`;
+            if (subQueries.length > 1) {
+                // 多个子查询 => 并发搜索
+                const searchPromises = subQueries.map(subQuery =>
+                    tvly.search(subQuery, searchOptions)
+                        .then(response => ({ subQuery, response }))
+                );
+
+                const settledResults = await Promise.allSettled(searchPromises);
+
+                let markdownResult = '';
+                const failedResults = [];
+                let hasAnySuccess = false;
+
+                settledResults.forEach((result, index) => {
+                    if (result.status === 'fulfilled') {
+                        hasAnySuccess = true;
+                        const { subQuery, response } = result.value;
+                        markdownResult += `## 🔍 查询: ${subQuery}\n\n`;
+                        markdownResult += formatTavilyResults(response);
+                        markdownResult += '\n\n---\n\n';
+                    } else {
+                        failedResults.push({ subQuery: subQueries[index], error: result.reason?.message || '未知错误' });
                     }
                 });
-            } else {
-                markdownResult += `未找到相关搜索结果。\n`;
-            }
 
-            output = { status: "success", result: markdownResult };
+                // 补充失败查询信息
+                if (failedResults.length > 0) {
+                    markdownResult += `## ⚠️ 以下查询失败\n\n`;
+                    for (const fail of failedResults) {
+                        markdownResult += `### 查询: ${fail.subQuery}\n`;
+                        markdownResult += `错误: ${fail.error}\n\n`;
+                    }
+                }
+
+                if (!hasAnySuccess && failedResults.length > 0) {
+                    throw new Error(`All searches failed. First error: ${failedResults[0].error}`);
+                }
+
+                output = { status: "success", result: markdownResult };
+
+            } else {
+                // 单个查询 => 原有流程
+                const response = await tvly.search(query, searchOptions);
+                output = { status: "success", result: formatTavilyResults(response) };
+            }
 
         } catch (e) {
             let errorMessage;

--- a/Plugin/TavilySearch/plugin-manifest.json
+++ b/Plugin/TavilySearch/plugin-manifest.json
@@ -3,7 +3,7 @@
   "name": "TavilySearch",
   "displayName": "Tavily 搜索插件",
   "version": "0.1.0",
-  "description": "使用 Tavily API 进行高级网络搜索。AI可以指定搜索查询、主题、最大结果数，并可选择包含原始内容、图片链接及描述，以及设定搜索时间范围。",
+  "description": "使用 Tavily API 进行高级网络搜索。AI可以指定搜索查询、主题、最大结果数，并可选择包含原始内容、图片链接及描述，以及设定搜索时间范围。支持使用 || 分隔多个关键词进行并发搜索，所有结果同时返回。",
   "author": "Roo",
   "pluginType": "synchronous",
   "entryPoint": {
@@ -21,7 +21,7 @@
     "invocationCommands": [
       {
         "commandIdentifier": "TavilySearch",
-        "description": "调用此工具使用 Tavily API 进行高级网络搜索。默认启用高级搜索模式并返回图片链接。重要提示：请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。请在您的回复中，使用以下精确格式来请求搜索，确保所有参数值都用「始」和「末」准确包裹：\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」TavilySearch「末」,\nquery:「始」(必需) 搜索的关键词或问题。「末」,\nsearch_depth:「始」(可选, 默认为 'basic') 搜索深度。'ultra-fast': 不太准但最快, 'fast':快速搜索, 'basic':兼顾速度与准确度, 'advanced':牺牲速度进行高精度查找。「末」,\ntopic:「始」(可选, 默认为 'general') 搜索的主题，只允许['general', 'news', 'finance']。「末」,\nmax_results:「始」(可选, 默认为 10) 返回的最大结果数量，范围 0-20。「末」,\ninclude_raw_content:「始」(可选) 如果需要获取网页原始内容，请将此值设为 'markdown' 或 'text'。「末」,\ncountry:「始」(可选) 仅在topic为 'general' 时可用，搜索结果的国家来源，使用小写英文名例如 'china' (中国)。「末」,\ntime_range:「始」(可选) 指定周期(day, week, month, year)搜索最近的结果。注意：此参数与 start_date/end_date 互斥，如果设置了 start_date 或 end_date，则 time_range 参数会被忽略。「末」,\nstart_date:「始」(可选) 搜索开始日期，格式为 YYYY-MM-DD。「末」,\nend_date:「始」(可选) 搜索结束日期，格式为 YYYY-MM-DD。「末」\n<<<[END_TOOL_REQUEST]>>>\n\n重要提示给AI：\n当此工具执行完毕后，您将收到包含搜索结果的JSON对象。请基于这些结果回答用户的问题或完成相关任务。\n请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。",
+        "description": "调用此工具使用 Tavily API 进行高级网络搜索。默认启用高级搜索模式并返回图片链接。重要提示：请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。请在您的回复中，使用以下精确格式来请求搜索，确保所有参数值都用「始」和「末」准确包裹：\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」TavilySearch「末」,\nquery:「始」(必需) 搜索的关键词或问题，支持使用 || 分隔多个关键词进行并发搜索「末」,\nsearch_depth:「始」(可选, 默认为 'basic') 搜索深度。'ultra-fast': 不太准但最快, 'fast':快速搜索, 'basic':兼顾速度与准确度, 'advanced':牺牲速度进行高精度查找。「末」,\ntopic:「始」(可选, 默认为 'general') 搜索的主题，只允许['general', 'news', 'finance']。「末」,\nmax_results:「始」(可选, 默认为 10) 返回的最大结果数量，范围 0-20。「末」,\ninclude_raw_content:「始」(可选) 如果需要获取网页原始内容，请将此值设为 'markdown' 或 'text'。「末」,\ncountry:「始」(可选) 仅在topic为 'general' 时可用，搜索结果的国家来源，使用小写英文名例如 'china' (中国)。「末」,\ntime_range:「始」(可选) 指定周期(day, week, month, year)搜索最近的结果。注意：此参数与 start_date/end_date 互斥，如果设置了 start_date 或 end_date，则 time_range 参数会被忽略。「末」,\nstart_date:「始」(可选) 搜索开始日期，格式为 YYYY-MM-DD。「末」,\nend_date:「始」(可选) 搜索结束日期，格式为 YYYY-MM-DD。「末」\n<<<[END_TOOL_REQUEST]>>>\n\n重要提示给AI：\n当此工具执行完毕后，您将收到包含搜索结果的JSON对象。请基于这些结果回答用户的问题或完成相关任务。\n请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。",
         "example": "```text\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」TavilySearch「末」,\nquery:「始」最近一周的AI技术进展「末」,\nsearch_depth:「始」advanced「末」,\ntopic:「始」technology「末」,\nmax_results:「始」5「末」,\time_range:「始」d「末」\n<<<[END_TOOL_REQUEST]>>>\n```"
       }
     ]

--- a/Plugin/VolcSearch/VolcSearch.js
+++ b/Plugin/VolcSearch/VolcSearch.js
@@ -4,6 +4,35 @@ const stdin = require('process').stdin;
 
 const API_ENDPOINT = 'open.feedcoopapi.com';
 const API_PATH = '/search_api/web_search';
+const STAGGER_INTERVAL_MS = 1000; // 并发搜索时每个子查询的启动间隔(ms)，用于控制 QPS
+const MAX_CONCURRENCY = 5; // 最大并发请求数（VolcEngine 默认 QPS 5，留有余量避免限流）
+
+/**
+ * 简单信号量（Semaphore），用于控制最大并发数
+ * acquire() 获取一个许可，release() 释放一个许可
+ * 当并发数达到上限时，acquire() 会自动等待
+ */
+class Semaphore {
+    constructor(max) {
+        this.max = max;
+        this.current = 0;
+        this.queue = [];
+    }
+    async acquire() {
+        if (this.current < this.max) {
+            this.current++;
+            return;
+        }
+        await new Promise(resolve => this.queue.push(resolve));
+    }
+    release() {
+        if (this.queue.length > 0) {
+            this.queue.shift()();
+        } else {
+            this.current--;
+        }
+    }
+}
 
 async function main() {
     let inputData = '';
@@ -73,230 +102,296 @@ async function main() {
             }
 
             // Build request body per Volc Engine API spec
-            const requestBody = {
-                Query: query,
-                SearchType: searchType,
-                Count: count
-            };
-// NeedSummary: automatically true for web_summary, otherwise optional
-            if (searchType === 'web_summary') {
-                requestBody.NeedSummary = true;
-            } else if (needSummary === true || needSummary === 'true') {
-                requestBody.NeedSummary = true;
-            }
+            // 搜索逻辑已封装到 executeSingleSearch(subQuery) 中
 
-            // Optional: ContentFormats
-            if (contentFormat === 'markdown' || contentFormat === 'text') {
-                requestBody.ContentFormats = contentFormat;
-            }
+            /**
+             * 执行单次搜索并返回 Markdown 结果
+             */
+            async function executeSingleSearch(subQuery) {
+                const body = {
+                    Query: subQuery,
+                    SearchType: searchType,
+                    Count: count
+                };
 
-            // Optional: Filter
-            const filter = {};
-            let hasFilter = false;
+                // NeedSummary: automatically true for web_summary, otherwise optional
+                if (searchType === 'web_summary') {
+                    body.NeedSummary = true;
+                } else if (needSummary === true || needSummary === 'true') {
+                    body.NeedSummary = true;
+                }
 
-            if (!snippetsOnly) {
-                filter.NeedContent = true;
-                hasFilter = true;
-            }
+                // Optional: ContentFormats
+                if (contentFormat === 'markdown' || contentFormat === 'text') {
+                    body.ContentFormats = contentFormat;
+                }
 
-            if (sites) {
-                filter.Sites = sites;
-                hasFilter = true;
-            }
+                // Optional: Filter
+                const filter = {};
+                let hasFilter = false;
 
-            if (blockHosts) {
-                filter.BlockHosts = blockHosts;
-                hasFilter = true;
-            }
-
-            if (needUrl === true || needUrl === 'true') {
-                filter.NeedUrl = true;
-                hasFilter = true;
-            }
-
-            if (authInfoLevel !== undefined && authInfoLevel !== null) {
-                const level = parseInt(authInfoLevel, 10);
-                if (level === 0 || level === 1) {
-                    filter.AuthInfoLevel = level;
+                if (!snippetsOnly) {
+                    filter.NeedContent = true;
                     hasFilter = true;
                 }
-            }
-
-            if (hasFilter) {
-                requestBody.Filter = filter;
-            }
-
-            // Optional: TimeRange
-            if (timeRange) {
-                const validTimeRanges = ['OneDay', 'OneWeek', 'OneMonth', 'OneYear'];
-                // Also support date range format like "2024-12-30..2025-12-30"
-                const dateRangePattern = /^\d{4}-\d{2}-\d{2}\.\.\d{4}-\d{2}-\d{2}$/;
-                if (validTimeRanges.includes(timeRange) || dateRangePattern.test(timeRange)) {
-                    requestBody.TimeRange = timeRange;
+                if (sites) {
+                    filter.Sites = sites;
+                    hasFilter = true;
                 }
-            }
-
-            // Optional: Industry
-            if (industry) {
-                const validIndustries = ['finance', 'game'];
-                if (validIndustries.includes(industry)) {
-                    requestBody.Industry = industry;
+                if (blockHosts) {
+                    filter.BlockHosts = blockHosts;
+                    hasFilter = true;
                 }
-            }
-
-            // Optional: QueryControl.QueryRewrite
-            if (queryRewrite === true || queryRewrite === 'true') {
-                requestBody.QueryControl = { QueryRewrite: true };
-            }
-
-            // Send request to Volc Engine API
-            const response = await sendApiRequest(apiKey, requestBody);
-
-            // Parse response - handles both single JSON and SSE streaming format
-            let resultData;
-            try {
-                resultData = JSON.parse(response);
-            } catch (e) {
-                // Try SSE/streaming format: multiple JSON objects separated by newlines
-                const lines = response.split('\n')
-                    .map(line => line.replace(/^data:\s*/, '').trim())
-                    .filter(line => line && line !== '[DONE]' && line.startsWith('{'));
-
-                if (lines.length === 0) {
-                    throw new Error(`Failed to parse API response: ${e.message}`);
+                if (needUrl === true || needUrl === 'true') {
+                    filter.NeedUrl = true;
+                    hasFilter = true;
+                }
+                if (authInfoLevel !== undefined && authInfoLevel !== null) {
+                    const level = parseInt(authInfoLevel, 10);
+                    if (level === 0 || level === 1) {
+                        filter.AuthInfoLevel = level;
+                        hasFilter = true;
+                    }
+                }
+                if (hasFilter) {
+                    body.Filter = filter;
                 }
 
-                let aggregatedResponse = null;
-                for (const line of lines) {
-                    try {
-                        const frameData = JSON.parse(line);
-                        if (!frameData.Result) continue;
-
-                        if (!aggregatedResponse) {
-                            aggregatedResponse = frameData;
-                        } else {
-                            // Accumulate Choices delta content from streaming frames
-                            const frameResult = frameData.Result;
-                            if (frameResult.Choices && frameResult.Choices.length > 0) {
-                                const streamChoice = frameResult.Choices[0];
-                                if (streamChoice.Delta && streamChoice.Delta.Content) {
-                                    if (!aggregatedResponse.Result.Choices) {
-                                        aggregatedResponse.Result.Choices = [{
-                                            Message: { content: '' },
-                                            FinishReason: '',
-                                            Index: 0
-                                        }];
-                                    }
-                                    const aggChoice = aggregatedResponse.Result.Choices[0];
-                                    if (aggChoice.Message) {
-                                        aggChoice.Message.content = (aggChoice.Message.content || '') + streamChoice.Delta.Content;
-                                    }
-                                }
-                                // Capture FinishReason from final frame
-                                if (streamChoice.FinishReason) {
-                                    if (!aggregatedResponse.Result.Choices[0]) {
-                                        aggregatedResponse.Result.Choices[0] = {};
-                                    }
-                                    aggregatedResponse.Result.Choices[0].FinishReason = streamChoice.FinishReason;
-                                }
-                            }
-                            // Capture Usage from final frame
-                            if (frameResult.Usage) {
-                                aggregatedResponse.Result.Usage = frameResult.Usage;
-                            }
-                        }
-                    } catch (parseError) {
-                        // Skip malformed frames
+                // Optional: TimeRange
+                if (timeRange) {
+                    const validTimeRanges = ['OneDay', 'OneWeek', 'OneMonth', 'OneYear'];
+                    const dateRangePattern = /^\d{4}-\d{2}-\d{2}\.\d{4}-\d{2}-\d{2}$/;
+                    if (validTimeRanges.includes(timeRange) || dateRangePattern.test(timeRange)) {
+                        body.TimeRange = timeRange;
                     }
                 }
 
-                if (aggregatedResponse) {
-                    resultData = aggregatedResponse;
+                // Optional: Industry
+                if (industry) {
+                    const validIndustries = ['finance', 'game'];
+                    if (validIndustries.includes(industry)) {
+                        body.Industry = industry;
+                    }
+                }
+
+                // Optional: QueryControl.QueryRewrite
+                if (queryRewrite === true || queryRewrite === 'true') {
+                    body.QueryControl = { QueryRewrite: true };
+                }
+
+                // Send request to Volc Engine API
+                const response = await sendApiRequest(apiKey, body);
+
+                // Parse response - handles both single JSON and SSE streaming format
+                let resultData;
+                try {
+                    resultData = JSON.parse(response);
+                } catch (e) {
+                    // Try SSE/streaming format: multiple JSON objects separated by newlines
+                    const lines = response.split('\n')
+                        .map(line => line.replace(/^data:\s*/, '').trim())
+                        .filter(line => line && line !== '[DONE]' && line.startsWith('{'));
+
+                    if (lines.length === 0) {
+                        throw new Error(`Failed to parse API response: ${e.message}`);
+                    }
+
+                    let aggregatedResponse = null;
+                    for (const line of lines) {
+                        try {
+                            const frameData = JSON.parse(line);
+                            if (!frameData.Result) continue;
+
+                            if (!aggregatedResponse) {
+                                aggregatedResponse = frameData;
+                            } else {
+                                // Accumulate Choices delta content from streaming frames
+                                const frameResult = frameData.Result;
+                                if (frameResult.Choices && frameResult.Choices.length > 0) {
+                                    const streamChoice = frameResult.Choices[0];
+                                    if (streamChoice.Delta && streamChoice.Delta.Content) {
+                                        if (!aggregatedResponse.Result.Choices) {
+                                            aggregatedResponse.Result.Choices = [{
+                                                Message: { content: '' },
+                                                FinishReason: '',
+                                                Index: 0
+                                            }];
+                                        }
+                                        const aggChoice = aggregatedResponse.Result.Choices[0];
+                                        if (aggChoice.Message) {
+                                            aggChoice.Message.content = (aggChoice.Message.content || '') + streamChoice.Delta.Content;
+                                        }
+                                    }
+                                    // Capture FinishReason from final frame
+                                    if (streamChoice.FinishReason) {
+                                        if (!aggregatedResponse.Result.Choices[0]) {
+                                            aggregatedResponse.Result.Choices[0] = {};
+                                        }
+                                        aggregatedResponse.Result.Choices[0].FinishReason = streamChoice.FinishReason;
+                                    }
+                                }
+                                // Capture Usage from final frame
+                                if (frameResult.Usage) {
+                                    aggregatedResponse.Result.Usage = frameResult.Usage;
+                                }
+                            }
+                        } catch (parseError) {
+                            // Skip malformed frames
+                        }
+                    }
+
+                    if (aggregatedResponse) {
+                        resultData = aggregatedResponse;
+                    } else {
+                        throw new Error('Failed to parse API response: streaming format not recognized');
+                    }
+                }
+
+                // Check for API-level errors
+                const responseMeta = resultData.ResponseMetadata;
+                if (responseMeta && responseMeta.Error) {
+                    const apiError = responseMeta.Error;
+                    throw new Error(`Volc Engine API Error [${apiError.Code}]: ${apiError.Message}`);
+                }
+
+                const apiResult = resultData.Result;
+                if (!apiResult) {
+                    throw new Error("API response missing Result field.");
+                }
+
+                // Convert results to Markdown
+                let md = '';
+
+                // For web_summary mode, extract LLM summary from Choices
+                if (searchType === 'web_summary' && apiResult.Choices && apiResult.Choices.length > 0) {
+                    const choice = apiResult.Choices[0];
+                    let summaryText = '';
+
+                    // Non-streaming mode: Message.content (or already aggregated from streaming)
+                    if (choice.Message && choice.Message.content) {
+                        summaryText = choice.Message.content;
+                    }
+                    // Fallback: raw Delta.content (if streaming aggregation didn't run)
+                    if (!summaryText && choice.Delta && choice.Delta.Content) {
+                        summaryText = choice.Delta.Content;
+                    }
+
+                    if (summaryText) {
+                        md += `### 搜索总结\n${summaryText}\n\n---\n\n`;
+                    }
+                }
+
+                if (apiResult.WebResults && apiResult.WebResults.length > 0) {
+                    md += `### 搜索结果 (共 ${apiResult.ResultCount || apiResult.WebResults.length} 条)\n\n`;
+                    apiResult.WebResults.forEach((item, index) => {
+                        const title = item.Title || '无标题';
+                        const url = item.Url || '';
+                        const snippet = item.Snippet || '';
+                        const summary = item.Summary || '';
+                        const content = item.Content || '';
+                        const publishTime = item.PublishTime || '';
+                        const siteName = item.SiteName || '';
+                        const authInfo = item.AuthInfoDes || '';
+
+                        md += `${index + 1}. **[${title}](${url})**\n`;
+
+                        if (siteName) {
+                            md += `   - **来源**: ${siteName}`;
+                            if (publishTime && publishTime !== '1970-01-01T08:00:00+08:00') {
+                                const date = new Date(publishTime);
+                                if (!isNaN(date.getTime())) {
+                                    md += ` | **时间**: ${date.toLocaleDateString('zh-CN')}`;
+                                }
+                            }
+                            if (authInfo) {
+                                md += ` | **权威度**: ${authInfo}`;
+                            }
+                            md += '\n';
+                        }
+
+                        // Prefer Summary over Snippet if needSummary is enabled
+                        if (needSummary && summary) {
+                            md += `   ${summary}\n\n`;
+                        } else if (snippet) {
+                            md += `   ${snippet}\n\n`;
+                        }
+
+                        // Include full content if snippets_only is false
+                        if (!snippetsOnly && content) {
+                            const trimmedContent = content.length > 2000 ? content.substring(0, 2000) + '...' : content;
+                            md += `   > ${trimmedContent.replace(/\n/g, '\n   > ')}\n\n`;
+                        }
+                    });
                 } else {
-                    throw new Error(`Failed to parse API response: streaming format not recognized`);
-                }
-            }
-
-            // Check for API-level errors
-            const responseMeta = resultData.ResponseMetadata;
-            if (responseMeta && responseMeta.Error) {
-                const apiError = responseMeta.Error;
-                throw new Error(`Volc Engine API Error [${apiError.Code}]: ${apiError.Message}`);
-            }
-
-            const apiResult = resultData.Result;
-            if (!apiResult) {
-                throw new Error("API response missing Result field.");
-            }
-
-            // Convert results to Markdown
-            let markdownResult = '';
-
-            // For web_summary mode, extract LLM summary from Choices
-            if (searchType === 'web_summary' && apiResult.Choices && apiResult.Choices.length > 0) {
-                const choice = apiResult.Choices[0];
-                let summaryText = '';
-
-                // Non-streaming mode: Message.content (or already aggregated from streaming)
-                if (choice.Message && choice.Message.content) {
-                    summaryText = choice.Message.content;
-                }
-                // Fallback: raw Delta.content (if streaming aggregation didn't run)
-                if (!summaryText && choice.Delta && choice.Delta.Content) {
-                    summaryText = choice.Delta.Content;
+                    md += '未找到相关搜索结果。\n';
                 }
 
-                if (summaryText) {
-                    markdownResult += `### 搜索总结\n${summaryText}\n\n---\n\n`;
-                }
+                return md;
             }
 
-            if (apiResult.WebResults && apiResult.WebResults.length > 0) {
-                markdownResult += `### 搜索结果 (共 ${apiResult.ResultCount || apiResult.WebResults.length} 条)\n\n`;
-                apiResult.WebResults.forEach((item, index) => {
-                    const title = item.Title || '无标题';
-                    const url = item.Url || '';
-                    const snippet = item.Snippet || '';
-                    const summary = item.Summary || '';
-                    const content = item.Content || '';
-                    const publishTime = item.PublishTime || '';
-                    const siteName = item.SiteName || '';
-                    const authInfo = item.AuthInfoDes || '';
+            // 检测是否包含 || 分隔的多个查询
+            const subQueries = query.split('||').map(q => q.trim()).filter(q => q.length > 0);
 
-                    markdownResult += `${index + 1}. **[${title}](${url})**\n`;
+            if (subQueries.length === 0) {
+                throw new Error("No valid search query after splitting by '||'");
+            }
 
-                    if (siteName) {
-                        markdownResult += `   - **来源**: ${siteName}`;
-                        if (publishTime && publishTime !== '1970-01-01T08:00:00+08:00') {
-                            const date = new Date(publishTime);
-                            if (!isNaN(date.getTime())) {
-                                markdownResult += ` | **时间**: ${date.toLocaleDateString('zh-CN')}`;
-                            }
-                        }
-                        if (authInfo) {
-                            markdownResult += ` | **权威度**: ${authInfo}`;
-                        }
-                        markdownResult += '\n';
+            if (subQueries.length > 1) {
+                // 多个子查询 => 并发搜索，双重保护：
+                // 1) STAGGER_INTERVAL_MS 控制启动间隔，平滑 QPS
+                // 2) Semaphore 控制最大并发数，防止突发限流
+                // 设置 STAGGER_INTERVAL_MS = 0 可关闭启动间隔
+                const sem = new Semaphore(MAX_CONCURRENCY);
+                const searchPromises = subQueries.map(async (subQuery, index) => {
+                    if (STAGGER_INTERVAL_MS > 0) {
+                        await new Promise(resolve => setTimeout(resolve, index * STAGGER_INTERVAL_MS));
                     }
-
-                    // Prefer Summary over Snippet if needSummary is enabled
-                    if (needSummary && summary) {
-                        markdownResult += `   ${summary}\n\n`;
-                    } else if (snippet) {
-                        markdownResult += `   ${snippet}\n\n`;
-                    }
-
-                    // Include full content if snippets_only is false
-                    if (!snippetsOnly && content) {
-                        const trimmedContent = content.length > 2000 ? content.substring(0, 2000) + '...' : content;
-                        markdownResult += `   > ${trimmedContent.replace(/\n/g, '\n   > ')}\n\n`;
+                    await sem.acquire();
+                    try {
+                        const result = await executeSingleSearch(subQuery);
+                        return { subQuery, result };
+                    } finally {
+                        sem.release();
                     }
                 });
-            } else {
-                markdownResult += `未找到相关搜索结果。\n`;
-            }
 
-            output = { status: "success", result: markdownResult };
+                const settledResults = await Promise.allSettled(searchPromises);
+
+                let markdownResult = '';
+                const failedResults = [];
+                let hasAnySuccess = false;
+
+                settledResults.forEach((settled, index) => {
+                    if (settled.status === 'fulfilled') {
+                        hasAnySuccess = true;
+                        markdownResult += `## 🔍 查询: ${settled.value.subQuery}\n\n`;
+                        markdownResult += settled.value.result;
+                        markdownResult += '\n\n---\n\n';
+                    } else {
+                        failedResults.push({ subQuery: subQueries[index], error: settled.reason?.message || '未知错误' });
+                    }
+                });
+
+                // 补充失败查询信息
+                if (failedResults.length > 0) {
+                    markdownResult += `## ⚠️ 以下查询失败\n\n`;
+                    for (const fail of failedResults) {
+                        markdownResult += `### 查询: ${fail.subQuery}\n`;
+                        markdownResult += `错误: ${fail.error}\n\n`;
+                    }
+                }
+
+                if (!hasAnySuccess && failedResults.length > 0) {
+                    throw new Error(`All searches failed. First error: ${failedResults[0].error}`);
+                }
+
+                output = { status: "success", result: markdownResult };
+
+            } else {
+                // 单个查询 => 原有流程
+                const singleResult = await executeSingleSearch(query);
+                output = { status: "success", result: singleResult };
+            }
 
         } catch (e) {
             let errorMessage;

--- a/Plugin/VolcSearch/plugin-manifest.json
+++ b/Plugin/VolcSearch/plugin-manifest.json
@@ -3,7 +3,7 @@
   "name": "VolcSearch",
   "displayName": "火山引擎搜索插件",
   "version": "0.2.0",
-  "description": "使用火山引擎联网搜索 API 进行中文网络搜索。支持普通网页搜索（web）和带LLM总结的网页搜索（web_summary）两种模式。AI可以指定搜索查询、搜索模式、返回结果数量，并可选择包含正文内容、设置搜索时间范围等。",
+  "description": "使用火山引擎联网搜索 API 进行中文网络搜索。支持普通网页搜索（web）和带LLM总结的网页搜索（web_summary）两种模式。AI可以指定搜索查询、搜索模式、返回结果数量，并可选择包含正文内容、设置搜索时间范围等。支持使用 || 分隔多个关键词进行并发搜索，所有结果同时返回。",
   "author": "Roo",
   "pluginType": "synchronous",
   "entryPoint": {
@@ -21,7 +21,7 @@
     "invocationCommands": [
       {
         "commandIdentifier": "VolcSearch",
-        "description": "调用此工具使用火山引擎联网搜索 API 进行中文网络搜索。支持普通网页搜索（web）和带LLM总结的网页搜索（web_summary）两种模式。请注意优先使用中文词作为检索词。请在您的回复中，使用以下精确格式来请求搜索，确保所有参数值都用「始」和「末」准确包裹：\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」VolcSearch「末」,\nquery:「始」(必需) 搜索的关键词或问题。「末」,\nsearch_type:「始」(可选, 默认为 'web') 搜索模式。'web': 普通网页搜索；'web_summary': 网页搜索+LLM总结，返回大模型对搜索结果的总结内容。「末」,\ncount:「始」(可选, 默认为 10) 返回的最大结果数量，范围 1-50。「末」,\nneed_summary:「始」(可选, 默认为 false) 是否需要精准摘要（500字左右的模型处理片段，推荐用于AI场景）。仅在 search_type 为 'web' 时有效；'web_summary' 模式下自动启用。「末」,\ncontent_format:「始」(可选, 默认为 'text') 返回正文的格式，'text' 或 'markdown'。仅当 snippets_only 为 false 时有效。「末」,\nsnippets_only:「始」(可选, 默认为 true) 如果只想获取搜索结果摘要（Snippet），设为 true。如需包含正文内容，设为 false。「末」,\ntime_range:「始」(可选) 指定搜索的发文时间范围。可选值：'OneDay'(1天内), 'OneWeek'(1周内), 'OneMonth'(1月内), 'OneYear'(1年内), 或日期区间格式如 '2024-12-30..2025-12-30'。「末」,\nsites:「始」(可选) 指定搜索的站点范围，多个站点使用 '|' 分隔，最多支持20个。示例：'aliyun.com|mp.qq.com'。「末」,\nblock_hosts:「始」(可选) 指定屏蔽的搜索站点，多个域名使用 '|' 分隔，最多支持5个。示例：'example.com|spam.com'。「末」,\nindustry:「始」(可选) 执行行业类型搜索，支持 'finance'(金融)、'game'(电子游戏)。「末」,\nquery_rewrite:「始」(可选, 默认为 false) 是否开启 Query 改写（开启后会增加搜索耗时）。「末」,\nneed_url:「始」(可选, 默认为 false) 是否仅返回有原文链接的结果。仅在 search_type 为 'web' 时有效。「末」,\nauth_info_level:「始」(可选) 限制搜索结果的权威等级。0: 不限制；1: 仅返回非常权威的内容。「末」\n<<<[END_TOOL_REQUEST]>>>\n\n重要提示给AI：\n当此工具执行完毕后，您将收到包含搜索结果的JSON对象。请基于这些结果回答用户的问题或完成相关任务。\n请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。",
+        "description": "调用此工具使用火山引擎联网搜索 API 进行中文网络搜索。支持普通网页搜索（web）和带LLM总结的网页搜索（web_summary）两种模式。请注意优先使用中文词作为检索词。请在您的回复中，使用以下精确格式来请求搜索，确保所有参数值都用「始」和「末」准确包裹：\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」VolcSearch「末」,\nquery:「始」(必需) 搜索的关键词或问题，支持使用 || 分隔多个关键词进行并发搜索。「末」,\nsearch_type:「始」(可选, 默认为 'web') 搜索模式。'web': 普通网页搜索；'web_summary': 网页搜索+LLM总结，返回大模型对搜索结果的总结内容。「末」,\ncount:「始」(可选, 默认为 10) 返回的最大结果数量，范围 1-50。「末」,\nneed_summary:「始」(可选, 默认为 false) 是否需要精准摘要（500字左右的模型处理片段，推荐用于AI场景）。仅在 search_type 为 'web' 时有效；'web_summary' 模式下自动启用。「末」,\ncontent_format:「始」(可选, 默认为 'text') 返回正文的格式，'text' 或 'markdown'。仅当 snippets_only 为 false 时有效。「末」,\nsnippets_only:「始」(可选, 默认为 true) 如果只想获取搜索结果摘要（Snippet），设为 true。如需包含正文内容，设为 false。「末」,\ntime_range:「始」(可选) 指定搜索的发文时间范围。可选值：'OneDay'(1天内), 'OneWeek'(1周内), 'OneMonth'(1月内), 'OneYear'(1年内), 或日期区间格式如 '2024-12-30..2025-12-30'。「末」,\nsites:「始」(可选) 指定搜索的站点范围，多个站点使用 '|' 分隔，最多支持20个。示例：'aliyun.com|mp.qq.com'。「末」,\nblock_hosts:「始」(可选) 指定屏蔽的搜索站点，多个域名使用 '|' 分隔，最多支持5个。示例：'example.com|spam.com'。「末」,\nindustry:「始」(可选) 执行行业类型搜索，支持 'finance'(金融)、'game'(电子游戏)。「末」,\nquery_rewrite:「始」(可选, 默认为 false) 是否开启 Query 改写（开启后会增加搜索耗时）。「末」,\nneed_url:「始」(可选, 默认为 false) 是否仅返回有原文链接的结果。仅在 search_type 为 'web' 时有效。「末」,\nauth_info_level:「始」(可选) 限制搜索结果的权威等级。0: 不限制；1: 仅返回非常权威的内容。「末」\n<<<[END_TOOL_REQUEST]>>>\n\n重要提示给AI：\n当此工具执行完毕后，您将收到包含搜索结果的JSON对象。请基于这些结果回答用户的问题或完成相关任务。\n请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。",
         "example": "```text\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」VolcSearch「末」,\nquery:「始」2026年AI技术最新进展「末」,\nsearch_type:「始」web_summary「末」,\ncount:「始」5「末」,\ntime_range:「始」OneYear「末」\n<<<[END_TOOL_REQUEST]>>>\n```"
       }
     ]


### PR DESCRIPTION
VSearch的并发模式无法设定参数，且总结模型只能事先配置好，总结提示词是内置的。
但面对不同情况，总结的要求不同，提示词和总结模型固定就不够灵活，还是把总结交给前端模型和前端提示词更好。