### PR TITLE
fix: 自动包裹 tool_name 块为 TOOL_REQUEST 标记，修复 VCPMobile 工具调用失效

### DIFF
--- a/Plugin/VCPToolBridge/config.env
+++ b/Plugin/VCPToolBridge/config.env
@@ -1,0 +1,9 @@
+# VCP 工具桥接器配置
+# 启用 VCPMobile 工具调用桥接
+Bridge_Enabled=true
+
+# 不导出的工具黑名单（调用名，逗号分隔）
+Excluded_Tools=VCPLog,VCPInfo,VCPToolBridge
+
+# 不导出的显示名称关键词（逗号分隔，包含即排除）
+Excluded_Display_Keywords="[AIO]"

--- a/modules/handlers/streamHandler.js
+++ b/modules/handlers/streamHandler.js
@@ -258,7 +258,23 @@ class StreamHandler {
       }
       currentMessagesForLoop.push(...assistantMessages);
 
-      const toolCalls = vcpToolUseForbidden ? [] : ToolCallParser.parse(currentAIContentForLoop);
+      // --- 预处理：为裸 tool_name: 块自动包裹 <<<[TOOL_REQUEST]>>> 标记 ---
+      // AI 模型可能输出不带块标记的 tool_name: 格式，需要兼容处理
+      let contentForParsing = currentAIContentForLoop;
+      if (contentForParsing && !contentForParsing.includes('<<<[TOOL_REQUEST]>>>')) {
+        // 匹配从 tool_name: 开始、到内容末尾的工具调用块
+        // 格式: tool_name:xxx,\nfield:value,\nfield:value,...
+        const toolBlockRegex = /(?:^|\n)(tool_name\s*:\s*[^\n]+(?:\n\s*\w+\s*:\s*[^\n]+)*)/;
+        const match = contentForParsing.match(toolBlockRegex);
+        if (match) {
+          const toolBlock = match[1];
+          const beforeBlock = contentForParsing.substring(0, match.index + (match[0].startsWith('\n') ? 1 : 0));
+          contentForParsing = beforeBlock + '\n<<<[TOOL_REQUEST]>>>\n' + toolBlock.trim() + '\n<<<[END_TOOL_REQUEST]>>>';
+          if (DEBUG_MODE) console.log('[VCP Stream Loop] Auto-wrapped bare tool_name block with TOOL_REQUEST markers.');
+        }
+      }
+
+      const toolCalls = vcpToolUseForbidden ? [] : ToolCallParser.parse(contentForParsing);
       if (toolCalls.length === 0) {
         if (DEBUG_MODE) console.log('[VCP Stream Loop] No tool calls found. Exiting loop.');
         if (!res.writableEnded) {


### PR DESCRIPTION
## 根因

VCP Stream Loop 的 ToolCallParser 严格要求 `<<<[TOOL_REQUEST]>>>` ... `<<<[END_TOOL_REQUEST]>>>` 块标记，但当前 AI 模型输出的是裸 `tool_name:xxx` 格式（无块标记），导致工具调用永远无法被解析和执行。

VCPMobile 客户端表现：AI 回复聊天文字但不执行工具（如「查看日记」→ LightMemo 不触发）。

## 修复

1. **streamHandler.js** — 在 ToolCallParser.parse() 前添加预处理：用正则检测裸 `tool_name:` 块并自动包裹 `<<<[TOOL_REQUEST]>>>` 标记
2. **VCPToolBridge/config.env** — 启用桥接 (`Bridge_Enabled=true`)，使 VCPMobile 分布式节点能注册和调用工具

## 验证

修复后 VCP Stream Loop 日志：
```
[VCP Stream Loop] Auto-wrapped bare tool_name block with TOOL_REQUEST markers.
[ToolExecutor] Processing tool: LightMemo
[ToolExecutor] Calling processToolCall for LightMemo → success
```
工具调用链路完整打通。