### PR TITLE
fix(TDBKnowledge): skip re-embedding when file content unchanged (checksum dedup)

### DIFF
--- a/TDBKnowledge.js
+++ b/TDBKnowledge.js
@@ -310,7 +310,16 @@ class TDBKnowledgeManager {
         const checksum = crypto.createHash('sha256').update(content).digest('hex');
 
         const old = this.metaDb.prepare('SELECT checksum, mtime, size FROM files WHERE library = ? AND path = ?').get(library, relPath);
-        if (old && old.checksum === checksum && old.mtime === stats.mtimeMs && old.size === stats.size) return;
+        // 内容去重：checksum + size 一致即认为文件未改变，跳过昂贵的重新 Embedding。
+        // 当 mtime 因 git pull / 文件复制等操作被刷新但内容未变时，仅同步 metaDb 中的时间戳。
+        // 与 KnowledgeBaseManager（热记忆系统）的增量判断逻辑对齐。
+        if (old && old.checksum === checksum && old.size === stats.size) {
+            if (old.mtime !== stats.mtimeMs) {
+                this.metaDb.prepare('UPDATE files SET mtime = ?, updated_at = ? WHERE library = ? AND path = ?')
+                    .run(stats.mtimeMs, Math.floor(Date.now() / 1000), library, relPath);
+            }
+            return;
+        }
 
         const handle = this.getOrOpenLibrary(library);
         this._beginLibraryUse(handle);


### PR DESCRIPTION
## 问题
TDBKnowledge 的 upsertFile() 在判断文件是否需要重新索引时，要求 checksum + mtime + size 三项全部一致才跳过。
当文件因 git pull、文件复制、云同步等操作被 touch（mtime 刷新）但内容未改变时，系统会对所有文件重新调用 Embedding API 并重建 TriviumDB 节点，造成大量无谓的 API 消耗和启动延迟。
修复

将跳过条件改为 checksum + size 一致即跳过（与 KnowledgeBaseManager 的热记忆系统一致）。
当仅 mtime 变化时，静默更新 metaDb 中的时间戳记录，避免下次启动再次误判。


测试


对 knowledge/ 下已索引的文件执行 touch（仅刷新 mtime）

重启服务，观察日志不再出现 [TDBKnowledge] ✅ Indexed 输出

修改文件内容后重启，确认正常触发重新索引