### PR TITLE
feat(ThoughtClusterManager): 新增列出思维簇列表功能

### DIFF
--- a/Plugin/ThoughtClusterManager/ThoughtClusterManager.js
+++ b/Plugin/ThoughtClusterManager/ThoughtClusterManager.js
@@ -2,6 +2,7 @@ const fs = require('fs').promises;
 const path = require('path');
 
 const DAILYNOTE_DIR = process.env.KNOWLEDGEBASE_ROOT_PATH || path.join(__dirname, '../../dailynote');
+const META_CHAINS_PATH = path.join(__dirname, '..', 'RAGDiaryPlugin', 'meta_thinking_chains.json');
 
 async function main() {
     try {
@@ -28,6 +29,9 @@ async function main() {
                 case 'EditClusterFile':
                     result = await editClusterFile(parameters);
                     break;
+                case 'ListClusters':
+                    result = await listClusters(parameters);
+                    break;
                 default:
                     result = { success: false, error: `Unknown command: ${command}` };
             }
@@ -37,6 +41,87 @@ async function main() {
         console.log(JSON.stringify({ status: 'error', error: error.message }));
         process.exit(1);
     }
+}
+
+async function listClusters({ clusterName, chainName }) {
+    const targetFolders = new Set();
+
+    // 模式3：通过链名解析簇文件夹列表
+    if (chainName) {
+        try {
+            const chainsData = JSON.parse(await fs.readFile(META_CHAINS_PATH, 'utf8'));
+            const chainNames = chainName.split(/[,，|]/).map(n => n.trim()).filter(Boolean);
+            for (const name of chainNames) {
+                const chain = chainsData.chains?.[name];
+                if (chain && Array.isArray(chain.clusters)) {
+                    chain.clusters.forEach(c => targetFolders.add(c));
+                } else {
+                    const available = Object.keys(chainsData.chains || {}).join(', ');
+                    return {
+                        success: false,
+                        error: `未找到链 "${name}"。可用链名: ${available}`
+                    };
+                }
+            }
+        } catch (e) {
+            return { success: false, error: `读取 meta_thinking_chains.json 失败: ${e.message}` };
+        }
+    }
+
+    // 模式2：直接指定簇文件夹名
+    if (clusterName) {
+        const names = clusterName.split(/[,，|]/).map(n => n.trim().replace(/\s/g, '')).filter(Boolean);
+        names.forEach(n => targetFolders.add(n));
+    }
+
+    // 模式1：未指定任何参数，全量枚举
+    if (targetFolders.size === 0) {
+        try {
+            const allDirs = await fs.readdir(DAILYNOTE_DIR, { withFileTypes: true });
+            allDirs
+                .filter(d => d.isDirectory() && d.name.endsWith('簇'))
+                .forEach(d => targetFolders.add(d.name));
+        } catch (e) {
+            return { success: false, error: `读取 dailynote 目录失败: ${e.message}` };
+        }
+    }
+
+    if (targetFolders.size === 0) {
+        return { success: true, message: '未找到任何思维簇文件夹。' };
+    }
+
+    // 读取并返回内容
+    let result = `共找到 ${targetFolders.size} 个簇文件夹:\n`;
+
+    for (const folderName of [...targetFolders].sort()) {
+        const dirPath = path.join(DAILYNOTE_DIR, folderName);
+
+        try {
+            const stat = await fs.stat(dirPath);
+            if (!stat.isDirectory()) {
+                result += `\n⚠️ "${folderName}" 不是有效目录，已跳过。\n`;
+                continue;
+            }
+        } catch {
+            result += `\n⚠️ "${folderName}" 不存在，已跳过。\n`;
+            continue;
+        }
+
+        const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.md') || f.endsWith('.txt'));
+        result += `\n${'═'.repeat(50)}\n`;
+        result += `📁 ${folderName} (${files.length} 个文件)\n`;
+        result += `${'═'.repeat(50)}\n`;
+
+        for (const file of files.sort()) {
+            const filePath = path.join(dirPath, file);
+            const content = await fs.readFile(filePath, 'utf8');
+            result += `\n┌── 📄 ${file}\n`;
+            result += `${content}\n`;
+            result += `└${'─'.repeat(40)}\n`;
+        }
+    }
+
+    return { success: true, message: result };
 }
 
 async function createClusterFile({ clusterName, content }) {
@@ -135,6 +220,7 @@ async function processBatchRequest(request) {
         const command = request[`command${i}`];
         const parameters = {
             clusterName: request[`clusterName${i}`],
+            chainName: request[`chainName${i}`],
             content: request[`content${i}`],
             targetText: request[`targetText${i}`],
             replacementText: request[`replacementText${i}`]
@@ -147,6 +233,9 @@ async function processBatchRequest(request) {
                 break;
             case 'EditClusterFile':
                 result = await editClusterFile(parameters);
+                break;
+            case 'ListClusters':
+                result = await listClusters(parameters);
                 break;
             default:
                 result = { success: false, error: `Unknown command: ${command}` };

--- a/Plugin/ThoughtClusterManager/plugin-manifest.json
+++ b/Plugin/ThoughtClusterManager/plugin-manifest.json
@@ -24,6 +24,11 @@
       {
         "commandIdentifier": "EditClusterFile",
         "description": "编辑一个已存在的思维簇文件，通过查找并替换文本内容。\n参数:\n- clusterName (字符串, 可选): 指定在哪个簇文件夹中进行搜索。如果未提供，将在所有'簇'结尾的文件夹中搜索。\n- targetText (字符串, 必需): 需要被替换的目标文本，长度不能少于15个字符。\n- replacementText (字符串, 必需): 用于替换目标文本的新内容。\n调用格式:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」ThoughtClusterManager「末」,\ncommand:「始」EditClusterFile「末」,\nclusterName:「始」前思维簇「末」,\ntargetText:「始」这是需要被替换的旧的思考内容，确保它不少于15字。「末」,\nreplacementText:「始」这是更新后的新的思考内容。「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "ListClusters",
+        "description": "查看思维簇文件内容。支持三种查询模式：\n1. 不传参数：列出所有以'簇'结尾的文件夹及完整内容\n2. clusterName参数：指定簇文件夹名（逗号分隔多个）\n3. chainName参数：按链名查询（从meta_thinking_chains.json解析对应的簇列表）\n\n调用格式:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」ThoughtClusterManager「末」,\ncommand:「始」ListClusters「末」,\nchainName:「始」coding「末」\n<<<[END_TOOL_REQUEST]>>>",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」ThoughtClusterManager「末」,\ncommand:「始」ListClusters「末」,\nchainName:「始」default「末」\n<<<[END_TOOL_REQUEST]>>>"
       }
     ]
   }


### PR DESCRIPTION
## 概要
为 ThoughtClusterManager 插件新增 ListClusters 命令，使用户能够查看思维簇文件夹的完整内容。

## 改动说明
- `Plugin/ThoughtClusterManager/ThoughtClusterManager.js`：
  - 新增 `listClusters()` 函数，支持三种查询模式：
    1. 无参数：枚举所有以"簇"结尾的文件夹并返回全部 .md 文件内容
    2. clusterName 参数：指定簇文件夹名（支持逗号/管道符分隔多个）
    3. chainName 参数：从 meta_thinking_chains.json 解析对应链的簇列表
  - 新增 META_CHAINS_PATH 常量（跨插件读取 RAGDiaryPlugin 的链配置）
  - switch 语句和批量处理函数中新增 ListClusters 分支
- `Plugin/ThoughtClusterManager/plugin-manifest.json`：
  - invocationCommands 数组新增 ListClusters 命令声明

## 测试
- 使用 `chainName: "default"` 测试：成功返回 4 个簇文件夹共 17 个 .md 文件的完整内容
- 使用无效链名测试：正确返回错误信息及可用链名列表
- 无参数全量枚举测试：正常工作

## 注意事项
- ListClusters 通过 META_CHAINS_PATH 读取 RAGDiaryPlugin 目录下的 meta_thinking_chains.json
  路径为相对于自身的 `../RAGDiaryPlugin/`，与现有的目录结构一致
- 不修改任何现有命令的行为，纯增量变更