### PR TITLE
fix(FileOperator): 修复 resolveAndNormalizePath 幂等性保护对裸相对路径的误判

### DIFF
--- a/Plugin/FileOperator/FileOperator.js
+++ b/Plugin/FileOperator/FileOperator.js
@@ -239,15 +239,11 @@ function resolveAndNormalizePath(inputPath) {
     return path.resolve(originalPath);
   }
 
-  // 2. 🔧 关键修改：幂等性保护 - 如果路径已经在 FileOperator 目录下，直接返回
-  const resolvedInput = path.resolve(originalPath);
-  const fileOperatorRoot = path.resolve(__dirname);
-
-  // 使用 startsWith 检查是否已经是 FileOperator 下的绝对路径
-  // 注意：Windows 下路径大小写不敏感，但这里主要是解决 Linux/Mac 的双写问题
-  if (resolvedInput.toLowerCase().startsWith(fileOperatorRoot.toLowerCase())) {
-    return resolvedInput;
-  }
+  // 2. BASE_PATH: configurable project root for bare relative paths.
+  // Falls back to two levels up from this plugin's directory.
+  const BASE_PATH = process.env.BASE_PATH
+    ? path.resolve(process.env.BASE_PATH)
+    : path.resolve(__dirname, '..', '..');
 
   // 3. 虚拟根逻辑：将 /xxx 映射到 FileOperator/xxx
   // 在 Windows 上，/foo 不是绝对路径，所以会进入此逻辑
@@ -272,9 +268,8 @@ function resolveAndNormalizePath(inputPath) {
   const startsWithDotDot = normalized.startsWith(`..${path.sep}`);
 
   if (!startsWithDot && !startsWithDotDot) {
-    // Path is like 'foo/bar', so treat it as relative to the project root.
-    // The project root is two levels up from this script's directory.
-    return path.resolve(__dirname, '..', '..', normalized);
+    // Treat plain relative paths like "foo/bar" as BASE_PATH relative.
+    return path.resolve(BASE_PATH, normalized);
   } else {
     // Path is like './foo' or '../foo', so it's explicitly relative to this script's directory.
     return path.resolve(__dirname, normalized);

--- a/Plugin/FileOperator/config.env.example
+++ b/Plugin/FileOperator/config.env.example
@@ -43,3 +43,7 @@ BACKUP_DIRECTORY=
 # Priority: WEB_FILE_DIR > DEFAULT_DOWNLOAD_DIR > VCPToolBox/file/
 # If not set, falls back to DEFAULT_DOWNLOAD_DIR, then to the built-in file/ directory
 # WEB_FILE_DIR=
+
+# Base path for resolving bare relative paths (e.g. "Plugin/foo/bar")
+# Defaults to two levels up from this plugin's directory (i.e. VCPToolBox root)
+# BASE_PATH=


### PR DESCRIPTION
## 概要
修复 FileOperator 插件 resolveAndNormalizePath 函数中幂等性保护逻辑对裸相对路径的误判。

## 问题描述
当使用裸相对路径（如 `Plugin/RAGDiaryPlugin/xxx`）调用 ServerFileOperator 时，
路径被错误解析为 `Plugin/FileOperator/Plugin/RAGDiaryPlugin/xxx`。
根因：幂等性保护中 `path.resolve(相对路径)` 在 cwd=__dirname 时，任何裸相对路径
都会以 __dirname 开头，触发 startsWith 检查直接返回错误路径。

## 修复方案
- 移除冗余的幂等性保护（绝对路径已由第1步 isAbsolute 覆盖）
- 引入 BASE_PATH 环境变量，为裸相对路径提供可配置的解析基准
- 默认值 __dirname/../.. 即项目根目录

## 测试
- 裸相对路径 `Plugin/RAGDiaryPlugin/meta_thinking_chains.json` → ✅ 正确解析
- 绝对路径 → ✅ 不受影响（回归测试通过）
- 跨平台安全：修复不依赖 cwd，在 Linux/Mac/Windows 上行为一致