### PR TITLE
Add clean core external plugin contract bridge

### DIFF
--- a/Plugin.js
+++ b/Plugin.js
@@ -11,9 +11,23 @@ const chokidar = require('chokidar');
 const { getAuthCode } = require('./modules/captchaDecoder'); // 导入统一的解码函数
 const ToolApprovalManager = require('./modules/toolApprovalManager');
 const { hasFoldMarkers, buildDynamicFoldObject } = require('./modules/foldProtocol');
+const {
+    createPluginRootResolver,
+    discoverLegacyManifestRecordsFromRoot
+} = require('./modules/pluginRootResolver');
+const { classifyExternalPluginManifest } = require('./modules/externalPluginSafetyGate');
+const {
+    evaluateExternalPluginAllowPolicy
+} = require('./modules/externalPluginAllowPolicy');
+const {
+    buildExternalPluginRuntimeEnv,
+    isPluginRuntimeEnvKeyDenied
+} = require('./modules/pluginRuntimeEnvSandbox');
 
 const PLUGIN_DIR = path.join(__dirname, 'Plugin');
 const manifestFileName = 'plugin-manifest.json';
+const EXTERNAL_LEGACY_PLUGIN_DIRS_ENV = 'VCP_PLUGIN_DIRS';
+const EXTERNAL_PLUGIN_ALLOWLIST_ENV = 'VCP_EXTERNAL_PLUGIN_ALLOWLIST';
 const PREPROCESSOR_ORDER_FILE = path.join(__dirname, 'preprocessor_order.json');
 const SSH_MANAGER_ENV_PLUGIN_ALLOWLIST = new Set([
     'LinuxShellExecutor',
@@ -22,6 +36,43 @@ const SSH_MANAGER_ENV_PLUGIN_ALLOWLIST = new Set([
 const LOG_MONITOR_ENV_PLUGIN_ALLOWLIST = new Set([
     'LinuxLogMonitor'
 ]);
+
+const PLUGIN_DIAGNOSTIC_SECRET_PATTERNS = [
+    /((?:api[_-]?key|apikey|token|secret|password|passwd|pwd|authorization|bearer|cookie|session|credential|private[_-]?key)\s*[:=]\s*)[^\s"',;}\]]+/gi,
+    /\b(?:sk|ghp|github_pat|xox[baprs]|ya29)\b[-_A-Za-z0-9]{12,}/gi,
+    /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi
+];
+
+function scrubPluginDiagnosticText(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    let text = String(value);
+    for (const pattern of PLUGIN_DIAGNOSTIC_SECRET_PATTERNS) {
+        text = text.replace(pattern, (match, prefix) => (
+            prefix ? `${prefix}[redacted]` : '[redacted]'
+        ));
+    }
+    text = text.replace(/\b[A-Za-z]:\\[^\s"',;}\]]+/g, '[path]');
+    text = text.replace(/(^|[\s"'(])\/(?:Users|home|var|tmp|etc|opt|srv|mnt)\/[^\s"',;}\]]+/g, '$1[path]');
+    text = text.replace(/\\\\[^\\\s"',;}\]]+(?:\\[^\s"',;}\]]+)+/g, '[path]');
+    return text;
+}
+
+function scrubPluginDiagnosticSnippet(value, maxLength) {
+    return scrubPluginDiagnosticText(value).substring(0, maxLength);
+}
+
+function formatRuntimeEnvDebugKeyList(env = {}) {
+    const keys = Object.keys(env || {});
+    const visibleKeys = keys
+        .filter(key => !isPluginRuntimeEnvKeyDenied(key))
+        .sort();
+    const redactedCount = keys.length - visibleKeys.length;
+    const suffix = redactedCount > 0 ? ` (redacted ${redactedCount} sensitive keys)` : '';
+    return `${visibleKeys.join(',')}${suffix}`;
+}
 
 class PluginManager extends EventEmitter {
     constructor() {
@@ -42,6 +93,11 @@ class PluginManager extends EventEmitter {
         this.tdbKnowledgeManager = null; // 冷知识库管理器，等待 server.js 注入
         this.toolApprovalManager = new ToolApprovalManager(path.join(__dirname, 'toolApprovalConfig.json'));
         this.pendingApprovals = new Map(); // requestId -> { resolve, reject, timeoutId }
+        this.pluginRootResolver = createPluginRootResolver({
+            projectRoot: __dirname,
+            env: process.env
+        });
+        this.lastPluginRootSnapshot = null;
     }
 
     setWebSocketServer(wss) {
@@ -183,6 +239,409 @@ class PluginManager extends EventEmitter {
         return true;
     }
 
+    _isExternalPluginManifest(plugin) {
+        return plugin?.pluginSource === 'external';
+    }
+
+    _spawnPluginProcess(command, args, options) {
+        return spawn(command, args, options);
+    }
+
+    _buildPluginProcessEnv(plugin, pluginConfig = {}, additionalEnv = {}) {
+        if (this._isExternalPluginManifest(plugin)) {
+            return buildExternalPluginRuntimeEnv(process.env, pluginConfig, additionalEnv);
+        }
+
+        return {
+            ...process.env,
+            ...Object.fromEntries(
+                Object.entries(pluginConfig || {})
+                    .filter(([, value]) => value !== undefined)
+                    .map(([key, value]) => [key, String(value)])
+            ),
+            ...additionalEnv
+        };
+    }
+
+    async _loadPluginEnvConfig(pluginPath, pluginName) {
+        try {
+            const pluginEnvContent = await fs.readFile(path.join(pluginPath, 'config.env'), 'utf-8');
+            return dotenv.parse(pluginEnvContent);
+        } catch (envError) {
+            if (envError.code !== 'ENOENT') {
+                console.warn(`[PluginManager] Error reading config.env for ${pluginName}:`, scrubPluginDiagnosticText(envError.message));
+            }
+            return {};
+        }
+    }
+
+    _parseExternalLegacyPluginDirs(rawValue) {
+        if (!rawValue || typeof rawValue !== 'string') {
+            return [];
+        }
+
+        const hasWindowsDrivePrefix = /^[A-Za-z]:[\\/]/.test(rawValue);
+        const primarySeparator = rawValue.includes(';') ? ';' : (hasWindowsDrivePrefix ? null : ':');
+        const rawParts = primarySeparator ? rawValue.split(primarySeparator) : [rawValue];
+        const seen = new Set();
+        const dirs = [];
+
+        for (const rawPart of rawParts) {
+            const trimmed = rawPart.trim();
+            if (!trimmed) continue;
+
+            const resolved = path.resolve(__dirname, trimmed);
+            const key = process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            dirs.push(resolved);
+        }
+
+        return dirs;
+    }
+
+    _getExternalLegacyPluginDirs() {
+        return this._parseExternalLegacyPluginDirs(process.env[EXTERNAL_LEGACY_PLUGIN_DIRS_ENV]);
+    }
+
+    _formatPluginRootForLog(rootInfo, fallbackLabel = 'plugin-root') {
+        if (!rootInfo || typeof rootInfo !== 'object') return fallbackLabel;
+        const rootId = rootInfo.rootId || fallbackLabel;
+        const displayPath = rootInfo.displayPath || rootInfo.root || null;
+        return displayPath ? `${rootId}(${displayPath})` : rootId;
+    }
+
+    _formatPluginRootDiagnosticForLog(item) {
+        if (!item || typeof item !== 'object') return 'plugin-root';
+        return this._formatPluginRootForLog(
+            { rootId: item.rootId || item.code || 'plugin-root', displayPath: item.root || null },
+            item.code || 'plugin-root'
+        );
+    }
+
+    _formatPluginErrorForLog(error) {
+        if (!error || typeof error !== 'object') return 'UNKNOWN_ERROR';
+        return error.code || error.name || 'UNKNOWN_ERROR';
+    }
+
+    getPluginRootSnapshot() {
+        return this.lastPluginRootSnapshot || this.pluginRootResolver.getPluginRootSnapshotSync();
+    }
+
+    _getPluginRootInfosForLog(snapshot = null) {
+        const rootSnapshot = snapshot || this.getPluginRootSnapshot();
+        return [
+            rootSnapshot.coreLegacyRoot,
+            rootSnapshot.coreModernRoot,
+            ...(rootSnapshot.externalLegacyRoots || [])
+        ].filter(Boolean);
+    }
+
+    _isPathInsideRoot(candidatePath, rootPath) {
+        const relative = path.relative(path.resolve(rootPath), path.resolve(candidatePath));
+        return !relative.startsWith('..') && !path.isAbsolute(relative);
+    }
+
+    _formatPluginEventPathForLog(filePath) {
+        if (!filePath || typeof filePath !== 'string') return 'unknown';
+        const rootInfos = this._getPluginRootInfosForLog()
+            .filter(rootInfo => rootInfo.rootPath)
+            .sort((a, b) => b.rootPath.length - a.rootPath.length);
+
+        for (const rootInfo of rootInfos) {
+            if (this._isPathInsideRoot(filePath, rootInfo.rootPath)) {
+                const relative = path.relative(rootInfo.rootPath, filePath).replace(/\\/g, '/');
+                return `${this._formatPluginRootForLog(rootInfo)}/${relative || path.basename(filePath)}`;
+            }
+        }
+
+        return path.basename(filePath);
+    }
+
+    _getExternalPluginRuntimeAllowPolicy() {
+        return process.env[EXTERNAL_PLUGIN_ALLOWLIST_ENV] || '';
+    }
+
+    _getExternalRegistrationReasonCode(policyDecision, classification) {
+        const reasons = [
+            ...(classification?.reasons || []),
+            ...(policyDecision?.reasons || [])
+        ].join('\n');
+
+        if (classification?.duplicateOfBuiltIn) return 'external_runtime_duplicate_core_name';
+        if (/missing a concrete plugin name|missing a plugin name/i.test(reasons)) return 'external_runtime_missing_name';
+        if (/missing a base path/i.test(reasons)) return 'external_runtime_missing_base_path';
+        if (/invalid entries|wildcard allowlist|name-only allowlist|path-only/i.test(reasons)) return 'external_runtime_invalid_policy';
+        if (/source directory did not match/i.test(reasons)) return 'external_runtime_source_mismatch';
+        if (/requires explicit name and source directory allow policy/i.test(reasons)) return 'external_runtime_allowlist_required';
+        if (/entrypoint is missing or unsupported/i.test(reasons)) return 'external_runtime_unsupported_entrypoint';
+        return 'external_runtime_registration_blocked';
+    }
+
+    _sanitizeExternalRootIdForLog(rootId) {
+        if (typeof rootId !== 'string') return 'external:unknown';
+
+        const trimmed = rootId.trim();
+        if (!trimmed.startsWith('external:')) return 'external:unknown';
+
+        const value = trimmed.slice('external:'.length).trim();
+        if (!value) return 'external:unknown';
+
+        if (
+            value.includes('/') ||
+            value.includes('\\') ||
+            path.isAbsolute(value) ||
+            path.win32.isAbsolute(value)
+        ) {
+            return 'external:path';
+        }
+
+        if (!/^[A-Za-z0-9_.-]+$/.test(value)) {
+            return 'external:opaque';
+        }
+
+        return `external:${value}`;
+    }
+
+    _sanitizeExternalRuntimeRootId(rootId) {
+        return this._sanitizeExternalRootIdForLog(rootId);
+    }
+
+    _sanitizeExternalRuntimeDisplayPath(displayPath) {
+        if (typeof displayPath === 'string' && displayPath.startsWith('[external]')) {
+            return displayPath;
+        }
+        return '[external]';
+    }
+
+    _isExternalDirectOrHybridSameProcess(manifest) {
+        if (!this._isExternalPluginManifest(manifest)) {
+            return false;
+        }
+        const protocol = manifest?.communication?.protocol;
+        return protocol === 'direct' && typeof manifest.entryPoint?.script === 'string' && manifest.entryPoint.script.trim();
+    }
+
+    _getExternalDirectRuntimeBlockReason(manifest) {
+        if (manifest?.requiresAdmin === true) {
+            return 'external_direct_requires_admin_denied';
+        }
+
+        if (manifest?.pluginType === 'hybridservice') {
+            return 'external_hybrid_runtime_denied';
+        }
+
+        return 'external_direct_runtime_denied';
+    }
+
+    _evaluateExternalPluginRuntimeRegistration(manifest) {
+        if (!this._isExternalPluginManifest(manifest)) {
+            return {
+                allowed: true,
+                decision: 'observe',
+                pluginName: manifest?.name || 'unknown',
+                pluginSource: manifest?.pluginSource || 'core'
+            };
+        }
+
+        const classification = classifyExternalPluginManifest(manifest, {
+            projectRoot: __dirname,
+            isExternal: true,
+            builtInPluginNames: Array.from(this.plugins.keys())
+        });
+
+        if (this._isExternalDirectOrHybridSameProcess(manifest)) {
+            return {
+                allowed: false,
+                decision: 'blocked',
+                code: this._getExternalDirectRuntimeBlockReason(manifest),
+                pluginName: classification.pluginName,
+                pluginSource: 'external',
+                pluginRootId: this._sanitizeExternalRuntimeRootId(manifest.pluginRootId),
+                pluginRootDisplayPath: this._sanitizeExternalRuntimeDisplayPath(manifest.pluginRootDisplayPath),
+                risk: classification.risk,
+                entryPointKind: classification.entryPointKind
+            };
+        }
+
+        const policyDecision = evaluateExternalPluginAllowPolicy(
+            classification,
+            this._getExternalPluginRuntimeAllowPolicy(),
+            { projectRoot: __dirname }
+        );
+        const duplicateExisting = Boolean(manifest.name && this.plugins.has(manifest.name));
+        const allowed = policyDecision.decision === 'would_allow'
+            && classification.duplicateOfBuiltIn !== true
+            && duplicateExisting !== true;
+
+        return {
+            allowed,
+            decision: allowed ? 'allowed' : 'blocked',
+            code: allowed
+                ? 'external_runtime_registration_allowed'
+                : this._getExternalRegistrationReasonCode(policyDecision, {
+                    ...classification,
+                    duplicateOfBuiltIn: classification.duplicateOfBuiltIn || duplicateExisting
+                }),
+            pluginName: classification.pluginName,
+            pluginSource: 'external',
+            pluginRootId: this._sanitizeExternalRuntimeRootId(manifest.pluginRootId),
+            pluginRootDisplayPath: this._sanitizeExternalRuntimeDisplayPath(manifest.pluginRootDisplayPath),
+            risk: classification.risk,
+            entryPointKind: classification.entryPointKind
+        };
+    }
+
+    _warnExternalPluginRegistrationBlocked(decision) {
+        const pluginName = decision?.pluginName || 'unknown';
+        const rootId = decision?.pluginRootId || 'external:unknown';
+        const rootLabel = decision?.pluginRootDisplayPath || '[external]';
+        const code = decision?.code || 'external_runtime_registration_blocked';
+        console.warn(`[PluginManager] Skipped external plugin runtime registration: ${pluginName} (${rootId}, ${rootLabel}) ${code}`);
+    }
+
+    _sanitizeRuntimeDuplicateSource(source) {
+        if (source === 'external') return 'external';
+        if (source === 'distributed') return 'distributed';
+        return 'core';
+    }
+
+    _sanitizeRuntimeDuplicateRootId(source, rootId) {
+        const safeSource = this._sanitizeRuntimeDuplicateSource(source);
+        if (typeof rootId !== 'string' || !rootId.trim()) {
+            return safeSource === 'external' ? 'external:unknown' : `${safeSource}:unknown`;
+        }
+        if (rootId.startsWith('external:')) return this._sanitizeExternalRootIdForLog(rootId);
+        if (rootId.startsWith('core:')) return rootId;
+        if (rootId.startsWith('distributed:')) return rootId;
+        return `${safeSource}:unknown`;
+    }
+
+    _buildRuntimeDuplicateDescriptor(manifest) {
+        const source = this._sanitizeRuntimeDuplicateSource(
+            manifest?.pluginSource || (manifest?.isDistributed ? 'distributed' : 'core')
+        );
+        return {
+            source,
+            rootId: this._sanitizeRuntimeDuplicateRootId(source, manifest?.pluginRootId)
+        };
+    }
+
+    _warnDuplicateLocalPluginSkipped(skippedManifest, existingManifest = null) {
+        const pluginName = skippedManifest?.name || 'unknown';
+        const skipped = this._buildRuntimeDuplicateDescriptor(skippedManifest);
+        const existing = this._buildRuntimeDuplicateDescriptor(existingManifest);
+        console.warn(
+            `[PluginManager] Skipped duplicate local plugin manifest: ${pluginName} ` +
+            `(existing ${existing.source}/${existing.rootId}, skipped ${skipped.source}/${skipped.rootId}) duplicate_plugin_name`
+        );
+    }
+
+    async _discoverLegacyPluginManifestsFromDir(pluginRoot, sourceLabel = 'core', rootInfo = null) {
+        const effectiveRootInfo = rootInfo || {
+            rootId: sourceLabel === 'external' ? 'external:manual' : 'core:legacy',
+            source: sourceLabel,
+            rootPath: pluginRoot,
+            displayPath: sourceLabel === 'external' ? '[external]' : 'Plugin',
+            allowConfigEnv: sourceLabel !== 'external',
+            enabled: true
+        };
+        const result = await discoverLegacyManifestRecordsFromRoot(effectiveRootInfo);
+
+        if (result.diagnostics?.length && this.debugMode) {
+            result.diagnostics.forEach(item => {
+                const rootLabel = this._formatPluginRootDiagnosticForLog(item);
+                console.warn(`[PluginManager] Plugin manifest diagnostic: ${item.code} ${rootLabel}`.trim());
+            });
+        }
+
+        const manifests = [];
+        for (const record of result.records || []) {
+            if (!record.enabled) continue;
+
+            try {
+                await fs.access(path.join(record.pluginPath, '.disabled'));
+                continue;
+            } catch (error) {
+                if (error.code !== 'ENOENT') {
+                    continue;
+                }
+            }
+
+            const manifest = record.manifest;
+            if (!manifest.name || !manifest.pluginType || !manifest.entryPoint) continue;
+
+            manifest.basePath = record.pluginPath;
+            manifest.pluginSource = record.source;
+            manifest.pluginRoot = record.rootPath;
+            manifest.pluginRootId = record.rootId;
+            manifest.pluginRootDisplayPath = record.rootDisplayPath;
+            manifest.pluginSpecificEnvConfig = record.allowConfigEnv === false
+                ? {}
+                : await this._loadPluginEnvConfig(record.pluginPath, manifest.name);
+            manifests.push(manifest);
+        }
+
+        return manifests;
+    }
+
+    async _discoverLegacyPluginManifests() {
+        const rootSnapshot = await this.pluginRootResolver.getPluginRootSnapshot();
+        this.lastPluginRootSnapshot = rootSnapshot;
+
+        if (rootSnapshot.diagnostics?.length && this.debugMode) {
+            rootSnapshot.diagnostics.forEach(item => {
+                const rootLabel = this._formatPluginRootDiagnosticForLog(item);
+                console.warn(`[PluginManager] Plugin root diagnostic: ${item.code} ${rootLabel} ${item.message || ''}`.trim());
+            });
+        }
+
+        const manifests = [];
+        for (const rootInfo of rootSnapshot.legacyLoadRoots) {
+            const rootManifests = await this._discoverLegacyPluginManifestsFromDir(
+                rootInfo.rootPath,
+                rootInfo.source,
+                rootInfo
+            );
+            manifests.push(...rootManifests);
+        }
+        return manifests;
+    }
+
+    async _registerLocalPlugin(manifest, discoveredPreprocessors, modulesToInitialize) {
+        const registrationDecision = this._evaluateExternalPluginRuntimeRegistration(manifest);
+        if (!registrationDecision.allowed) {
+            this._warnExternalPluginRegistrationBlocked(registrationDecision);
+            return false;
+        }
+
+        this.plugins.set(manifest.name, manifest);
+        console.log(`[PluginManager] Loaded manifest: ${manifest.displayName} (${manifest.name}, Type: ${manifest.pluginType})`);
+
+        const isPreprocessor = manifest.pluginType === 'messagePreprocessor' || manifest.pluginType === 'hybridservice';
+        const isService = manifest.pluginType === 'service' || manifest.pluginType === 'hybridservice';
+
+        if ((isPreprocessor || isService) && manifest.entryPoint.script && manifest.communication?.protocol === 'direct') {
+            try {
+                const scriptPath = path.join(manifest.basePath, manifest.entryPoint.script);
+                const module = require(scriptPath);
+
+                modulesToInitialize.push({ manifest, module });
+
+                if (isPreprocessor && typeof module.processMessages === 'function') {
+                    discoveredPreprocessors.set(manifest.name, module);
+                }
+                if (isService) {
+                    this.serviceModules.set(manifest.name, { manifest, module });
+                }
+            } catch (error) {
+                console.error(`[PluginManager] Error loading module for ${manifest.name}:`, scrubPluginDiagnosticText(error.message));
+            }
+        }
+
+        return true;
+    }
+
     /**
      * 跨平台进程树终止方法。
      * Windows 上 shell:true 会创建 cmd.exe 包装进程，直接 kill 只杀 cmd 不杀子进程，
@@ -222,19 +681,14 @@ class PluginManager extends EventEmitter {
 
         return new Promise((resolve, reject) => {
             const pluginConfig = this._getPluginConfig(plugin);
-            const envForProcess = { ...process.env };
-            for (const key in pluginConfig) {
-                if (pluginConfig.hasOwnProperty(key) && pluginConfig[key] !== undefined) {
-                    envForProcess[key] = String(pluginConfig[key]);
-                }
-            }
+            const additionalEnv = {};
             if (this.projectBasePath) { // Add projectBasePath for static plugins too if needed
-                envForProcess.PROJECT_BASE_PATH = this.projectBasePath;
+                additionalEnv.PROJECT_BASE_PATH = this.projectBasePath;
             }
-
+            const envForProcess = this._buildPluginProcessEnv(plugin, pluginConfig, additionalEnv);
 
             const [command, ...args] = plugin.entryPoint.command.split(' ');
-            const pluginProcess = spawn(command, args, { cwd: plugin.basePath, shell: true, env: envForProcess, windowsHide: true });
+            const pluginProcess = this._spawnPluginProcess(command, args, { cwd: plugin.basePath, shell: true, env: envForProcess, windowsHide: true });
             let output = '';
             let errorOutput = '';
             let processExited = false;
@@ -255,8 +709,9 @@ class PluginManager extends EventEmitter {
             pluginProcess.on('error', (err) => {
                 processExited = true;
                 clearTimeout(timeoutId);
-                console.error(`[PluginManager] Failed to start static plugin ${plugin.name}: ${err.message}`);
-                reject(err);
+                const safeMessage = scrubPluginDiagnosticText(err.message);
+                console.error(`[PluginManager] Failed to start static plugin ${plugin.name}: ${safeMessage}`);
+                reject(new Error(safeMessage));
             });
 
             pluginProcess.on('exit', (code, signal) => {
@@ -271,12 +726,12 @@ class PluginManager extends EventEmitter {
                     return;
                 }
                 if (code !== 0) {
-                    const errMsg = `Static plugin ${plugin.name} exited with code ${code}. Stderr: ${errorOutput.trim()}`;
+                    const errMsg = `Static plugin ${plugin.name} exited with code ${code}. Stderr: ${scrubPluginDiagnosticText(errorOutput.trim())}`;
                     console.error(`[PluginManager] ${errMsg}`);
                     reject(new Error(errMsg));
                 } else {
                     if (errorOutput.trim() && this.debugMode) {
-                        console.warn(`[PluginManager] Static plugin ${plugin.name} produced stderr output: ${errorOutput.trim()}`);
+                        console.warn(`[PluginManager] Static plugin ${plugin.name} produced stderr output: ${scrubPluginDiagnosticText(errorOutput.trim())}`);
                     }
                     resolve(output.trim());
                 }
@@ -567,55 +1022,13 @@ class PluginManager extends EventEmitter {
 
         try {
             // 2. 发现并加载所有插件模块，但不初始化
-            const pluginFolders = await fs.readdir(PLUGIN_DIR, { withFileTypes: true });
-            for (const folder of pluginFolders) {
-                if (folder.isDirectory()) {
-                    const pluginPath = path.join(PLUGIN_DIR, folder.name);
-                    const manifestPath = path.join(pluginPath, manifestFileName);
-                    try {
-                        const manifestContent = await fs.readFile(manifestPath, 'utf-8');
-                        const manifest = JSON.parse(manifestContent);
-                        if (!manifest.name || !manifest.pluginType || !manifest.entryPoint) continue;
-                        if (this.plugins.has(manifest.name)) continue;
-
-                        manifest.basePath = pluginPath;
-                        manifest.pluginSpecificEnvConfig = {};
-                        try {
-                            const pluginEnvContent = await fs.readFile(path.join(pluginPath, 'config.env'), 'utf-8');
-                            manifest.pluginSpecificEnvConfig = dotenv.parse(pluginEnvContent);
-                        } catch (envError) {
-                            if (envError.code !== 'ENOENT') console.warn(`[PluginManager] Error reading config.env for ${manifest.name}:`, envError.message);
-                        }
-
-                        this.plugins.set(manifest.name, manifest);
-                        console.log(`[PluginManager] Loaded manifest: ${manifest.displayName} (${manifest.name}, Type: ${manifest.pluginType})`);
-
-                        const isPreprocessor = manifest.pluginType === 'messagePreprocessor' || manifest.pluginType === 'hybridservice';
-                        const isService = manifest.pluginType === 'service' || manifest.pluginType === 'hybridservice';
-
-                        if ((isPreprocessor || isService) && manifest.entryPoint.script && manifest.communication?.protocol === 'direct') {
-                            try {
-                                const scriptPath = path.join(pluginPath, manifest.entryPoint.script);
-                                const module = require(scriptPath);
-
-                                modulesToInitialize.push({ manifest, module });
-
-                                if (isPreprocessor && typeof module.processMessages === 'function') {
-                                    discoveredPreprocessors.set(manifest.name, module);
-                                }
-                                if (isService) {
-                                    this.serviceModules.set(manifest.name, { manifest, module });
-                                }
-                            } catch (e) {
-                                console.error(`[PluginManager] Error loading module for ${manifest.name}:`, e);
-                            }
-                        }
-                    } catch (error) {
-                        if (error.code !== 'ENOENT' && !(error instanceof SyntaxError)) {
-                            console.error(`[PluginManager] Error loading plugin from ${folder.name}:`, error);
-                        }
-                    }
+            const legacyManifests = await this._discoverLegacyPluginManifests();
+            for (const manifest of legacyManifests) {
+                if (this.plugins.has(manifest.name)) {
+                    this._warnDuplicateLocalPluginSkipped(manifest, this.plugins.get(manifest.name));
+                    continue;
                 }
+                await this._registerLocalPlugin(manifest, discoveredPreprocessors, modulesToInitialize);
             }
 
             // 3. 确定预处理器加载顺序
@@ -1131,7 +1544,7 @@ class PluginManager extends EventEmitter {
         }
     }
 
-    async executePlugin(pluginName, inputData, requestIp = null) {
+    async executePlugin(pluginName, inputData, requestIp = null, executionContext = null) {
         const plugin = this.plugins.get(pluginName);
         if (!plugin) {
             // This case should ideally be caught by processToolCall before calling executePlugin
@@ -1146,14 +1559,6 @@ class PluginManager extends EventEmitter {
         }
 
         const pluginConfig = this._getPluginConfig(plugin);
-        const envForProcess = { ...process.env };
-
-        for (const key in pluginConfig) {
-            if (pluginConfig.hasOwnProperty(key) && pluginConfig[key] !== undefined) {
-                envForProcess[key] = String(pluginConfig[key]);
-            }
-        }
-
         const additionalEnv = {};
         if (this.projectBasePath) {
             additionalEnv.PROJECT_BASE_PATH = this.projectBasePath;
@@ -1161,8 +1566,26 @@ class PluginManager extends EventEmitter {
             if (this.debugMode) console.warn("[PluginManager executePlugin] projectBasePath not set, PROJECT_BASE_PATH will not be available to plugins.");
         }
 
+        if (executionContext && typeof executionContext === 'object') {
+            if (executionContext.requestSource) {
+                additionalEnv.VCP_REQUEST_SOURCE = executionContext.requestSource;
+            }
+            if (executionContext.agentAlias) {
+                additionalEnv.VCP_AGENT_ALIAS = executionContext.agentAlias;
+            }
+            if (executionContext.agentId) {
+                additionalEnv.VCP_AGENT_ID = executionContext.agentId;
+            }
+            if (executionContext.executionContext) {
+                additionalEnv.VCP_EXECUTION_CONTEXT = executionContext.executionContext;
+            }
+        }
+
         // 如果插件需要管理员权限，则获取解密后的验证码并注入环境变量
         if (plugin.requiresAdmin) {
+            if (this._isExternalPluginManifest(plugin)) {
+                throw new Error(`External plugin "${pluginName}" cannot receive admin authentication.`);
+            }
             const decryptedCode = await this._getDecryptedAuthCode();
             if (decryptedCode) {
                 additionalEnv.DECRYPTED_AUTH_CODE = decryptedCode;
@@ -1225,10 +1648,11 @@ class PluginManager extends EventEmitter {
 
         // Force Python stdio encoding to UTF-8
         additionalEnv.PYTHONIOENCODING = 'utf-8';
-        const finalEnv = { ...envForProcess, ...additionalEnv };
+        const finalEnv = this._buildPluginProcessEnv(plugin, pluginConfig, additionalEnv);
 
         if (this.debugMode && plugin.pluginType === 'asynchronous') {
-            console.log(`[PluginManager executePlugin] Final ENV for async plugin ${pluginName}:`, JSON.stringify(finalEnv, null, 2).substring(0, 500) + "...");
+            const scope = this._isExternalPluginManifest(plugin) ? 'External' : 'Core';
+            console.log(`[PluginManager executePlugin] ${scope} async plugin ${pluginName} runtime env keys:`, formatRuntimeEnvDebugKeyList(finalEnv));
         }
 
         return new Promise((resolve, reject) => {
@@ -1236,7 +1660,7 @@ class PluginManager extends EventEmitter {
             const [command, ...args] = plugin.entryPoint.command.split(' ');
             if (this.debugMode) console.log(`[PluginManager executePlugin Internal] Attempting to spawn command: "${command}" with args: [${args.join(', ')}] in cwd: ${plugin.basePath}`);
 
-            const pluginProcess = spawn(command, args, { cwd: plugin.basePath, shell: true, env: finalEnv, windowsHide: true });
+            const pluginProcess = this._spawnPluginProcess(command, args, { cwd: plugin.basePath, shell: true, env: finalEnv, windowsHide: true });
 
 
             let outputBuffer = ''; // Buffer to accumulate data chunks
@@ -1271,7 +1695,7 @@ class PluginManager extends EventEmitter {
                 if (processExited || (isAsyncPlugin && initialResponseSent)) {
                     // If async and initial response sent, or process exited, ignore further stdout for this Promise.
                     // The plugin's background task might still log to its own stdout, but we don't collect it here.
-                    if (this.debugMode && isAsyncPlugin && initialResponseSent) console.log(`[PluginManager executePlugin Internal] Async plugin ${pluginName} (initial response sent) produced more stdout: ${data.substring(0, 100)}...`);
+                    if (this.debugMode && isAsyncPlugin && initialResponseSent) console.log(`[PluginManager executePlugin Internal] Async plugin ${pluginName} (initial response sent) produced more stdout: ${scrubPluginDiagnosticSnippet(data, 100)}...`);
                     return;
                 }
                 outputBuffer += data;
@@ -1305,22 +1729,23 @@ class PluginManager extends EventEmitter {
                     }
                 } catch (e) {
                     // Incomplete JSON or invalid JSON, wait for more data or 'exit' event.
-                    if (this.debugMode && outputBuffer.length > 2) console.log(`[PluginManager executePlugin Internal] Plugin "${pluginName}" stdout buffer not yet a complete JSON or invalid. Buffer: ${outputBuffer.substring(0, 100)}...`);
+                    if (this.debugMode && outputBuffer.length > 2) console.log(`[PluginManager executePlugin Internal] Plugin "${pluginName}" stdout buffer not yet a complete JSON or invalid. Buffer: ${scrubPluginDiagnosticSnippet(outputBuffer, 100)}...`);
                 }
             });
 
             pluginProcess.stderr.setEncoding('utf8');
             pluginProcess.stderr.on('data', (data) => {
                 errorOutput += data;
-                if (this.debugMode) console.warn(`[PluginManager executePlugin Internal stderr] Plugin "${pluginName}": ${data.trim()}`);
+                if (this.debugMode) console.warn(`[PluginManager executePlugin Internal stderr] Plugin "${pluginName}": ${scrubPluginDiagnosticText(data.trim())}`);
             });
 
             pluginProcess.on('error', (err) => {
                 processExited = true; clearTimeout(timeoutId);
+                const safeMessage = scrubPluginDiagnosticText(err.message);
                 if (!initialResponseSent) { // Only reject if initial response (for async) or any response (for sync) hasn't been sent
-                    reject(new Error(`Failed to start plugin "${pluginName}": ${err.message}`));
+                    reject(new Error(`Failed to start plugin "${pluginName}": ${safeMessage}`));
                 } else if (this.debugMode) {
-                    console.error(`[PluginManager executePlugin Internal] Error after initial response for async plugin "${pluginName}": ${err.message}. Process might have been expected to continue.`);
+                    console.error(`[PluginManager executePlugin Internal] Error after initial response for async plugin "${pluginName}": ${safeMessage}. Process might have been expected to continue.`);
                 }
             });
 
@@ -1350,26 +1775,26 @@ class PluginManager extends EventEmitter {
                         if (code === 0 && parsedOutput.status === "error" && this.debugMode) {
                             console.warn(`[PluginManager executePlugin Internal] Plugin "${pluginName}" exited with code 0 but reported error in JSON. Trusting JSON.`);
                         }
-                        if (errorOutput.trim()) parsedOutput.pluginStderr = errorOutput.trim();
+                        if (errorOutput.trim()) parsedOutput.pluginStderr = scrubPluginDiagnosticText(errorOutput.trim());
 
                         if (!initialResponseSent) resolve(parsedOutput); // Ensure resolve only once
                         else if (this.debugMode) console.log(`[PluginManager executePlugin Internal] Plugin ${pluginName} exited, initial async response already sent.`);
                         return;
                     }
-                    if (this.debugMode) console.warn(`[PluginManager executePlugin Internal] Plugin "${pluginName}" final stdout was not in the expected JSON format: ${outputBuffer.trim().substring(0, 100)}`);
+                    if (this.debugMode) console.warn(`[PluginManager executePlugin Internal] Plugin "${pluginName}" final stdout was not in the expected JSON format: ${scrubPluginDiagnosticSnippet(outputBuffer.trim(), 100)}`);
                 } catch (e) {
-                    if (this.debugMode) console.warn(`[PluginManager executePlugin Internal] Failed to parse final stdout JSON from plugin "${pluginName}". Error: ${e.message}. Stdout: ${outputBuffer.trim().substring(0, 100)}`);
+                    if (this.debugMode) console.warn(`[PluginManager executePlugin Internal] Failed to parse final stdout JSON from plugin "${pluginName}". Error: ${scrubPluginDiagnosticText(e.message)}. Stdout: ${scrubPluginDiagnosticSnippet(outputBuffer.trim(), 100)}`);
                 }
 
                 if (!initialResponseSent) { // Only reject if no response has been sent yet
                     if (code !== 0) {
                         let detailedError = `Plugin "${pluginName}" exited with code ${code}.`;
-                        if (outputBuffer.trim()) detailedError += ` Stdout: ${outputBuffer.trim().substring(0, 200)}`;
-                        if (errorOutput.trim()) detailedError += ` Stderr: ${errorOutput.trim().substring(0, 200)}`;
+                        if (outputBuffer.trim()) detailedError += ` Stdout: ${scrubPluginDiagnosticSnippet(outputBuffer.trim(), 200)}`;
+                        if (errorOutput.trim()) detailedError += ` Stderr: ${scrubPluginDiagnosticSnippet(errorOutput.trim(), 200)}`;
                         reject(new Error(detailedError));
                     } else {
                         // Exit code 0, but no valid initial JSON response was sent/parsed.
-                        reject(new Error(`Plugin "${pluginName}" exited successfully but did not provide a valid initial JSON response. Stdout: ${outputBuffer.trim().substring(0, 200)}`));
+                        reject(new Error(`Plugin "${pluginName}" exited successfully but did not provide a valid initial JSON response. Stdout: ${scrubPluginDiagnosticSnippet(outputBuffer.trim(), 200)}`));
                     }
                 }
             });
@@ -1380,9 +1805,10 @@ class PluginManager extends EventEmitter {
                 }
                 pluginProcess.stdin.end();
             } catch (e) {
-                console.error(`[PluginManager executePlugin Internal] Stdin write error for "${pluginName}": ${e.message}`);
+                const safeMessage = scrubPluginDiagnosticText(e.message);
+                console.error(`[PluginManager executePlugin Internal] Stdin write error for "${pluginName}": ${safeMessage}`);
                 if (!initialResponseSent) { // Only reject if no response has been sent yet
-                    reject(new Error(`Stdin write error for "${pluginName}": ${e.message}`));
+                    reject(new Error(`Stdin write error for "${pluginName}": ${safeMessage}`));
                 }
             }
         });
@@ -1922,7 +2348,8 @@ class PluginManager extends EventEmitter {
     startPluginWatcher() {
         if (this.debugMode) console.log('[PluginManager] Starting plugin file watcher...');
 
-        const watcher = chokidar.watch(PLUGIN_DIR, {
+        const watchRoots = this.pluginRootResolver.getWatchRoots();
+        const watcher = chokidar.watch(watchRoots, {
             ignored: [
                 '**/node_modules/**',
                 '**/.git/**',
@@ -1955,7 +2382,7 @@ class PluginManager extends EventEmitter {
                 if (filterManifest(filePath)) this.handlePluginManifestChange('unlink', filePath);
             });
 
-        console.log(`[PluginManager] Chokidar is now watching ${PLUGIN_DIR} for manifest changes.`);
+        console.log(`[PluginManager] Chokidar is now watching ${watchRoots.map(rootPath => this._formatPluginEventPathForLog(rootPath)).join(', ')} for manifest changes.`);
     }
 
     handlePluginManifestChange(eventType, filePath) {

--- a/modules/externalPluginAllowPolicy.js
+++ b/modules/externalPluginAllowPolicy.js
@@ -1,0 +1,291 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function normalizeString(value) {
+    return typeof value === 'string' && value.trim()
+        ? value.trim()
+        : null;
+}
+
+function normalizePath(value, projectRoot = process.cwd()) {
+    const pathValue = normalizeString(value);
+    if (!pathValue) {
+        return null;
+    }
+    return path.resolve(projectRoot, pathValue);
+}
+
+function splitPolicyEntries(rawPolicy) {
+    if (typeof rawPolicy !== 'string') {
+        return [];
+    }
+    return rawPolicy
+        .split(/[;\r\n]+/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+}
+
+function looksLikePathOnly(value) {
+    return /^[A-Za-z]:[\\/]/.test(value) || value.includes('/') || value.includes('\\');
+}
+
+function hasWildcard(value) {
+    return typeof value === 'string' && value.includes('*');
+}
+
+function isDotOnlyPath(value) {
+    const pathValue = normalizeString(value);
+    if (!pathValue) {
+        return false;
+    }
+    return pathValue.replace(/[\\/]/g, '') === '.';
+}
+
+function isParsedRoot(parsedPath) {
+    return Boolean(parsedPath.root) && parsedPath.dir === parsedPath.root && !parsedPath.base;
+}
+
+function isFilesystemRootPath(value, options = {}) {
+    const pathValue = normalizeString(value);
+    if (!pathValue) {
+        return false;
+    }
+
+    const normalized = normalizePath(pathValue, options.projectRoot);
+    if (normalized && normalized === path.parse(normalized).root) {
+        return true;
+    }
+
+    if (path.posix.isAbsolute(pathValue) && isParsedRoot(path.posix.parse(path.posix.resolve(pathValue)))) {
+        return true;
+    }
+
+    return path.win32.isAbsolute(pathValue) && isParsedRoot(path.win32.parse(path.win32.resolve(pathValue)));
+}
+
+function isBroadSourceDirectory(value, options = {}) {
+    return isDotOnlyPath(value) || isFilesystemRootPath(value, options);
+}
+
+function makeError(entry, reason) {
+    return { entry, reason };
+}
+
+function parsePolicyEntry(rawEntry, options = {}) {
+    const separatorIndex = rawEntry.indexOf('@');
+    if (separatorIndex === -1) {
+        return {
+            entry: null,
+            error: makeError(
+                rawEntry,
+                looksLikePathOnly(rawEntry) ? 'missing-plugin-name' : 'missing-source-directory'
+            )
+        };
+    }
+
+    const pluginName = normalizeString(rawEntry.slice(0, separatorIndex));
+    const sourceDirectory = normalizeString(rawEntry.slice(separatorIndex + 1));
+
+    if (!pluginName) {
+        return { entry: null, error: makeError(rawEntry, 'missing-plugin-name') };
+    }
+    if (!sourceDirectory) {
+        return { entry: null, error: makeError(rawEntry, 'missing-source-directory') };
+    }
+    if (hasWildcard(pluginName) || hasWildcard(sourceDirectory)) {
+        return { entry: null, error: makeError(rawEntry, 'wildcard-entry-not-allowed') };
+    }
+    if (isBroadSourceDirectory(sourceDirectory, options)) {
+        return { entry: null, error: makeError(rawEntry, 'broad-source-directory-not-allowed') };
+    }
+
+    return {
+        entry: {
+            pluginName,
+            sourceDirectory,
+            normalizedSourceDirectory: normalizePath(sourceDirectory, options.projectRoot)
+        },
+        error: null
+    };
+}
+
+function parseExternalPluginAllowPolicy(rawPolicy, options = {}) {
+    const entries = [];
+    const errors = [];
+    const seen = new Set();
+
+    for (const rawEntry of splitPolicyEntries(rawPolicy)) {
+        const parsed = parsePolicyEntry(rawEntry, options);
+        if (parsed.error) {
+            errors.push(parsed.error);
+            continue;
+        }
+
+        const dedupeKey = `${parsed.entry.pluginName}\0${parsed.entry.normalizedSourceDirectory}`;
+        if (seen.has(dedupeKey)) {
+            continue;
+        }
+        seen.add(dedupeKey);
+        entries.push(parsed.entry);
+    }
+
+    return { entries, errors };
+}
+
+function normalizePolicy(policy, options = {}) {
+    if (typeof policy === 'string') {
+        return parseExternalPluginAllowPolicy(policy, options);
+    }
+    if (!policy || typeof policy !== 'object') {
+        return { entries: [], errors: [] };
+    }
+    return {
+        entries: Array.isArray(policy.entries) ? policy.entries.slice() : [],
+        errors: Array.isArray(policy.errors) ? policy.errors.slice() : []
+    };
+}
+
+function normalizeComparablePath(value, options = {}) {
+    const pathValue = normalizeString(value);
+    if (!pathValue) {
+        return null;
+    }
+    const normalized = path.resolve(pathValue);
+    return (options.platform || process.platform) === 'win32'
+        ? normalized.toLowerCase()
+        : normalized;
+}
+
+function isPathInsideOrEqual(sourceDirectory, candidatePath, options = {}) {
+    const source = normalizeComparablePath(sourceDirectory, options);
+    const candidate = normalizeComparablePath(candidatePath, options);
+    if (!source || !candidate) {
+        return false;
+    }
+    if (candidate === source) {
+        return true;
+    }
+
+    const relativePath = path.relative(source, candidate);
+    return Boolean(relativePath)
+        && !relativePath.startsWith('..')
+        && !path.isAbsolute(relativePath);
+}
+
+function resolveFreshRealPath(value, options = {}) {
+    const normalized = normalizePath(value, options.projectRoot);
+    if (!normalized) {
+        return null;
+    }
+
+    const realpathSync = typeof options.realpathSync === 'function'
+        ? options.realpathSync
+        : (fs.realpathSync.native || fs.realpathSync);
+    try {
+        return path.resolve(realpathSync(normalized));
+    } catch {
+        return null;
+    }
+}
+
+function getEntrySourceDirectory(entry) {
+    return entry?.normalizedSourceDirectory || entry?.sourceDirectory;
+}
+
+function makeMatchedPolicy(entry, options = {}, realSourceDirectory = null) {
+    if (!entry) {
+        return null;
+    }
+    return {
+        pluginName: entry.pluginName,
+        normalizedSourceDirectory: normalizePath(getEntrySourceDirectory(entry), options.projectRoot),
+        realSourceDirectory: realSourceDirectory || resolveFreshRealPath(getEntrySourceDirectory(entry), options)
+    };
+}
+
+function evaluateExternalPluginAllowPolicy(classification = {}, policy, options = {}) {
+    const parsedPolicy = normalizePolicy(policy, options);
+    const pluginName = normalizeString(classification.pluginName || classification.name);
+    const basePath = normalizePath(classification.basePath, options.projectRoot);
+    const baseRealPath = resolveFreshRealPath(classification.basePath, options);
+    const isExternal = classification.isExternal === true || classification.pluginSource === 'external';
+    const reasons = [];
+
+    if (!isExternal) {
+        return {
+            pluginName: pluginName || 'unknown',
+            basePath,
+            baseRealPath,
+            decision: 'observe',
+            matchedPolicy: null,
+            reasons: ['non-external plugin does not require external allow policy']
+        };
+    }
+
+    if (!pluginName || pluginName === 'unknown') {
+        reasons.push('external plugin is missing a concrete plugin name');
+    }
+    if (!basePath) {
+        reasons.push('external plugin is missing a base path');
+    } else if (!baseRealPath) {
+        reasons.push('external plugin base path realpath is unavailable');
+    }
+    if (parsedPolicy.errors.length > 0) {
+        reasons.push('external plugin allow policy contains invalid entries');
+    }
+
+    if (pluginName && pluginName !== 'unknown' && basePath && baseRealPath) {
+        const sameNameEntries = parsedPolicy.entries.filter((entry) => entry.pluginName === pluginName);
+        const scopedSameNameEntries = sameNameEntries
+            .filter((entry) => !isBroadSourceDirectory(getEntrySourceDirectory(entry), options))
+            .map((entry) => ({
+                entry,
+                realSourceDirectory: resolveFreshRealPath(getEntrySourceDirectory(entry), options)
+            }))
+            .filter((item) => item.realSourceDirectory);
+
+        if (sameNameEntries.length > scopedSameNameEntries.length) {
+            reasons.push('external plugin allow policy contains broad or unresolved source directory entries');
+        }
+
+        const matchedEntry = scopedSameNameEntries.find((item) => (
+            isPathInsideOrEqual(item.realSourceDirectory, baseRealPath, options)
+        ));
+
+        if (matchedEntry) {
+            return {
+                pluginName,
+                basePath,
+                baseRealPath,
+                decision: 'would_allow',
+                matchedPolicy: makeMatchedPolicy(matchedEntry.entry, options, matchedEntry.realSourceDirectory),
+                reasons: [
+                    'external plugin matched explicit name and source directory policy',
+                    ...reasons
+                ]
+            };
+        }
+
+        if (sameNameEntries.length > 0) {
+            reasons.push('external plugin name matched allow policy but source directory did not match');
+        } else {
+            reasons.push('external plugin requires explicit name and source directory allow policy');
+        }
+    }
+
+    return {
+        pluginName: pluginName || 'unknown',
+        basePath,
+        baseRealPath,
+        decision: 'would_block',
+        matchedPolicy: null,
+        reasons
+    };
+}
+
+module.exports = {
+    parseExternalPluginAllowPolicy,
+    evaluateExternalPluginAllowPolicy
+};

--- a/modules/externalPluginSafetyGate.js
+++ b/modules/externalPluginSafetyGate.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const path = require('path');
+
+const KNOWN_PLUGIN_SOURCES = new Set(['legacy', 'external', 'modern']);
+
+function normalizeString(value) {
+    return typeof value === 'string' && value.trim()
+        ? value.trim()
+        : null;
+}
+
+function normalizePluginSource(value) {
+    const source = normalizeString(value);
+    return source && KNOWN_PLUGIN_SOURCES.has(source)
+        ? source
+        : 'legacy';
+}
+
+function resolvePluginSource(manifest, options) {
+    const explicitSource = normalizeString(manifest.pluginSource || options.pluginSource);
+    if (explicitSource && KNOWN_PLUGIN_SOURCES.has(explicitSource)) {
+        return explicitSource;
+    }
+    return options.isExternal === true
+        ? 'external'
+        : 'legacy';
+}
+
+function normalizeBasePath(value, projectRoot = process.cwd()) {
+    const basePath = normalizeString(value);
+    if (!basePath) {
+        return null;
+    }
+    return path.resolve(projectRoot, basePath);
+}
+
+function normalizeBuiltInPluginNames(names) {
+    if (!names) {
+        return new Set();
+    }
+    if (names instanceof Set) {
+        return new Set(Array.from(names).map(normalizeString).filter(Boolean));
+    }
+    if (Array.isArray(names)) {
+        return new Set(names.map(normalizeString).filter(Boolean));
+    }
+    return new Set();
+}
+
+function getEntryPointKind(entryPoint) {
+    if (!entryPoint || typeof entryPoint !== 'object') {
+        return 'unknown';
+    }
+    if (normalizeString(entryPoint.command)) {
+        return 'command';
+    }
+    if (normalizeString(entryPoint.script)) {
+        return 'script';
+    }
+    return 'unknown';
+}
+
+function getCommunicationProtocol(manifest) {
+    return normalizeString(manifest?.communication?.protocol);
+}
+
+function classifyManifestRisk(manifest, entryPointKind, communicationProtocol) {
+    if (entryPointKind === 'command') {
+        return 'executes_process';
+    }
+    if (entryPointKind === 'script' && communicationProtocol === 'direct') {
+        return 'loads_code';
+    }
+    if (entryPointKind === 'script') {
+        return 'unknown';
+    }
+    return 'unknown';
+}
+
+function classifyExternalPluginManifest(manifest = {}, options = {}) {
+    const pluginName = normalizeString(manifest.name) || 'unknown';
+    const pluginSource = resolvePluginSource(manifest, options);
+    const basePath = normalizeBasePath(manifest.basePath, options.projectRoot);
+    const isExternal = options.isExternal === true || pluginSource === 'external';
+    const builtInPluginNames = normalizeBuiltInPluginNames(options.builtInPluginNames);
+    const duplicateOfBuiltIn = isExternal && builtInPluginNames.has(pluginName);
+    const pluginType = normalizeString(manifest.pluginType);
+    const communicationProtocol = getCommunicationProtocol(manifest);
+    const entryPointKind = getEntryPointKind(manifest.entryPoint);
+    const risk = classifyManifestRisk(manifest, entryPointKind, communicationProtocol);
+    const reasons = [];
+
+    if (!normalizeString(manifest.name)) {
+        reasons.push('manifest is missing a plugin name');
+    }
+    if (!pluginType) {
+        reasons.push('manifest is missing a plugin type');
+    }
+    if (!basePath) {
+        reasons.push('manifest is missing a base path');
+    }
+    if (entryPointKind === 'unknown') {
+        reasons.push('manifest entrypoint is missing or unsupported');
+    }
+    if (isExternal) {
+        reasons.push('external plugin requires explicit allow policy before registration');
+    }
+    if (duplicateOfBuiltIn) {
+        reasons.push('external plugin name duplicates a built-in plugin');
+    }
+    if (risk === 'loads_code') {
+        reasons.push('direct script entrypoint can load plugin code during registration');
+    } else if (risk === 'executes_process') {
+        reasons.push('command entrypoint can execute a process during tool use');
+    } else if (risk === 'unknown') {
+        reasons.push('entrypoint risk could not be determined from manifest metadata');
+    }
+
+    return {
+        pluginName,
+        pluginSource,
+        basePath,
+        isExternal,
+        duplicateOfBuiltIn,
+        pluginType,
+        communicationProtocol,
+        entryPointKind,
+        risk,
+        decision: isExternal ? 'would_block' : 'observe',
+        reasons
+    };
+}
+
+function classifyExternalPluginManifests(manifests = [], options = {}) {
+    if (!Array.isArray(manifests)) {
+        return [];
+    }
+    return manifests.map((manifest) => classifyExternalPluginManifest(manifest, options));
+}
+
+module.exports = {
+    classifyExternalPluginManifest,
+    classifyExternalPluginManifests
+};

--- a/modules/pluginRootResolver.js
+++ b/modules/pluginRootResolver.js
@@ -1,0 +1,578 @@
+// modules/pluginRootResolver.js
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+
+const LEGACY_MANIFEST_FILE_NAME = 'plugin-manifest.json';
+const BLOCKED_MANIFEST_SUFFIX = '.block';
+const BLOCKED_MANIFEST_FILE_NAME = `${LEGACY_MANIFEST_FILE_NAME}${BLOCKED_MANIFEST_SUFFIX}`;
+const VCP_PLUGIN_DIRS_ENV = 'VCP_PLUGIN_DIRS';
+const VCP_PLUGIN_ALLOWED_ROOTS_ENV = 'VCP_PLUGIN_ALLOWED_ROOTS';
+const VCP_PLUGIN_INSTALL_DIR_ENV = 'VCP_PLUGIN_INSTALL_DIR';
+
+function uniqueByResolvedPath(paths) {
+    const seen = new Set();
+    const result = [];
+    for (const value of paths) {
+        if (!value) continue;
+        const resolved = path.resolve(value);
+        const key = process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        result.push(resolved);
+    }
+    return result;
+}
+
+function splitPathList(rawValue) {
+    if (!rawValue || typeof rawValue !== 'string') return [];
+
+    const trimmed = rawValue.trim();
+    if (!trimmed) return [];
+
+    if (trimmed.includes(';')) {
+        return trimmed.split(';').map(item => item.trim()).filter(Boolean);
+    }
+
+    if (/^[A-Za-z]:[\\/]/.test(trimmed)) {
+        return [trimmed];
+    }
+
+    return trimmed.split(path.delimiter).map(item => item.trim()).filter(Boolean);
+}
+
+function isSubPath(candidate, parent) {
+    const resolvedCandidate = path.resolve(candidate);
+    const resolvedParent = path.resolve(parent);
+    if (resolvedCandidate === resolvedParent) return true;
+
+    const relative = path.relative(resolvedParent, resolvedCandidate);
+    return Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function pathKey(targetPath) {
+    const resolved = path.resolve(targetPath);
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function toDisplayPath(projectRoot, absolutePath, source = 'external') {
+    const resolved = path.resolve(absolutePath);
+    const resolvedProjectRoot = path.resolve(projectRoot);
+
+    if (isSubPath(resolved, resolvedProjectRoot)) {
+        return path.relative(resolvedProjectRoot, resolved).replace(/\\/g, '/') || '.';
+    }
+
+    return `[${source}]/${path.basename(resolved)}`;
+}
+
+async function isManagedPathInsideRoot(candidatePath, rootPath) {
+    const rootRealPath = await realpathOrResolve(rootPath);
+    const candidateParentRealPath = await realpathOrResolve(path.dirname(candidatePath));
+    return isSubPath(candidateParentRealPath, rootRealPath);
+}
+
+async function isPathInsideRootByRealpath(candidatePath, rootPath) {
+    if (!candidatePath || !rootPath) return false;
+    const rootRealPath = await realpathOrResolve(rootPath);
+    const candidateRealPath = await realpathOrResolve(candidatePath);
+    return isSubPath(candidateRealPath, rootRealPath);
+}
+
+function toRootRelativeDisplayPath(rootInfo, targetPath) {
+    const source = rootInfo?.source === 'external' ? 'external' : 'core';
+    if (!rootInfo?.rootPath || !targetPath) return `[${source}]/unknown`;
+
+    const relative = path.relative(path.resolve(rootInfo.rootPath), path.resolve(targetPath));
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+        return `[${source}]/${path.basename(path.resolve(targetPath))}`;
+    }
+
+    return `[${source}]/${relative.replace(/\\/g, '/')}`;
+}
+
+function isUnsafeRoot(projectRoot, rootPath) {
+    const resolvedProjectRoot = path.resolve(projectRoot);
+    const resolvedRoot = path.resolve(rootPath);
+
+    if (resolvedRoot === resolvedProjectRoot) {
+        return 'external root must not equal project root';
+    }
+
+    const lowered = resolvedRoot.toLowerCase();
+    if (lowered.includes(`${path.sep}.git${path.sep}`) || lowered.endsWith(`${path.sep}.git`)) {
+        return 'external root must not be inside .git';
+    }
+
+    if (lowered.includes(`${path.sep}node_modules${path.sep}`) || lowered.endsWith(`${path.sep}node_modules`)) {
+        return 'external root must not be inside node_modules';
+    }
+
+    return null;
+}
+
+async function pathExists(targetPath) {
+    try {
+        await fsp.access(targetPath);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function realpathOrResolve(targetPath) {
+    try {
+        return await fsp.realpath(targetPath);
+    } catch {
+        return path.resolve(targetPath);
+    }
+}
+
+function realpathOrResolveSync(targetPath) {
+    try {
+        return fs.realpathSync(targetPath);
+    } catch {
+        return path.resolve(targetPath);
+    }
+}
+
+async function readManifestCandidate(filePath, state, fsPromises = fsp) {
+    try {
+        const stat = await fsPromises.lstat(filePath);
+        if (stat.isSymbolicLink()) {
+            return {
+                exists: true,
+                state,
+                skipped: true,
+                code: 'manifest_symlink_unsupported'
+            };
+        }
+        if (!stat.isFile()) {
+            return {
+                exists: true,
+                state,
+                skipped: true,
+                code: 'manifest_not_file'
+            };
+        }
+
+        const raw = await fsPromises.readFile(filePath, 'utf-8');
+        return {
+            exists: true,
+            state,
+            manifest: JSON.parse(raw),
+            manifestPath: filePath
+        };
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return { exists: false, state };
+        }
+
+        return {
+            exists: true,
+            state,
+            skipped: true,
+            code: error instanceof SyntaxError ? 'manifest_json_invalid' : 'manifest_read_error',
+            errorCode: error.code || null
+        };
+    }
+}
+
+async function discoverLegacyManifestRecordsFromRoot(rootInfo, options = {}) {
+    const fsPromises = options.fsPromises || fsp;
+    const diagnostics = [];
+    const records = [];
+
+    if (!rootInfo || !rootInfo.rootPath) {
+        return {
+            records,
+            diagnostics: [{ level: 'warn', code: 'missing_root_info', rootId: 'unknown' }]
+        };
+    }
+
+    let folders;
+    try {
+        folders = await fsPromises.readdir(rootInfo.rootPath, { withFileTypes: true });
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            diagnostics.push({
+                level: 'warn',
+                code: 'managed_root_read_error',
+                rootId: rootInfo.rootId || 'unknown',
+                root: rootInfo.displayPath || toRootRelativeDisplayPath(rootInfo, rootInfo.rootPath),
+                errorCode: error.code || 'UNKNOWN'
+            });
+        }
+        return { records, diagnostics };
+    }
+
+    for (const folder of folders) {
+        if (!folder.isDirectory()) continue;
+
+        const pluginPath = path.join(rootInfo.rootPath, folder.name);
+        if (!isSubPath(pluginPath, rootInfo.rootPath)) {
+            diagnostics.push({
+                level: 'warn',
+                code: 'plugin_path_outside_root',
+                rootId: rootInfo.rootId || 'unknown',
+                folder: folder.name
+            });
+            continue;
+        }
+
+        const activeManifestPath = path.join(pluginPath, LEGACY_MANIFEST_FILE_NAME);
+        const blockedManifestPath = path.join(pluginPath, BLOCKED_MANIFEST_FILE_NAME);
+        const active = await readManifestCandidate(activeManifestPath, 'enabled', fsPromises);
+        const blocked = await readManifestCandidate(blockedManifestPath, 'disabled', fsPromises);
+
+        if (active.exists && blocked.exists && !active.skipped) {
+            diagnostics.push({
+                level: 'warn',
+                code: 'blocked_manifest_shadowed',
+                rootId: rootInfo.rootId || 'unknown',
+                folder: folder.name
+            });
+        }
+
+        const selected = active.exists && !active.skipped ? active : (blocked.exists && !blocked.skipped ? blocked : null);
+        for (const candidate of [active, blocked]) {
+            if (candidate.exists && candidate.skipped) {
+                diagnostics.push({
+                    level: 'warn',
+                    code: candidate.code,
+                    rootId: rootInfo.rootId || 'unknown',
+                    folder: folder.name,
+                    state: candidate.state,
+                    errorCode: candidate.errorCode || null
+                });
+            }
+        }
+
+        if (!selected) continue;
+        if (!selected.manifest || typeof selected.manifest !== 'object' || !selected.manifest.name) {
+            diagnostics.push({
+                level: 'warn',
+                code: 'manifest_missing_name',
+                rootId: rootInfo.rootId || 'unknown',
+                folder: folder.name,
+                state: selected.state
+            });
+            continue;
+        }
+
+        records.push({
+            name: selected.manifest.name,
+            folderName: folder.name,
+            manifest: selected.manifest,
+            manifestPath: selected.manifestPath,
+            activeManifestPath,
+            blockedManifestPath,
+            pluginPath,
+            enabled: selected.state === 'enabled',
+            source: rootInfo.source || 'core',
+            rootId: rootInfo.rootId || null,
+            rootPath: rootInfo.rootPath,
+            rootDisplayPath: rootInfo.displayPath || null,
+            allowConfigEnv: rootInfo.allowConfigEnv !== false,
+            displayPath: toRootRelativeDisplayPath(rootInfo, pluginPath),
+            pathKey: pathKey(pluginPath)
+        });
+    }
+
+    return { records, diagnostics };
+}
+
+async function discoverAdminLegacyManifestRecords(rootSnapshot, options = {}) {
+    const roots = [
+        rootSnapshot?.coreLegacyRoot,
+        ...(rootSnapshot?.externalLegacyRoots || [])
+    ].filter(Boolean);
+    const records = [];
+    const diagnostics = [];
+
+    for (const rootInfo of roots) {
+        const result = await discoverLegacyManifestRecordsFromRoot(rootInfo, options);
+        records.push(...result.records);
+        diagnostics.push(...result.diagnostics);
+    }
+
+    return { records, diagnostics };
+}
+
+class PluginRootResolver {
+    constructor(options = {}) {
+        this.projectRoot = path.resolve(options.projectRoot || path.join(__dirname, '..'));
+        this.env = options.env || process.env;
+        this.coreLegacyRoot = path.resolve(options.coreLegacyRoot || path.join(this.projectRoot, 'Plugin'));
+        this.coreModernRoot = path.resolve(options.coreModernRoot || path.join(this.projectRoot, 'plugins'));
+    }
+
+    resolvePathList(rawValue) {
+        return uniqueByResolvedPath(
+            splitPathList(rawValue).map(item => {
+                const normalized = path.normalize(item);
+                return path.isAbsolute(normalized)
+                    ? normalized
+                    : path.resolve(this.projectRoot, normalized);
+            })
+        ).map(rootPath => ({
+            rootPath,
+            displayPath: toDisplayPath(this.projectRoot, rootPath, 'external')
+        }));
+    }
+
+    resolveSinglePath(rawValue) {
+        const normalized = path.normalize(String(rawValue || '').trim());
+        if (!normalized) return null;
+        return path.isAbsolute(normalized)
+            ? normalized
+            : path.resolve(this.projectRoot, normalized);
+    }
+
+    getAllowedRootsSync() {
+        return this.resolvePathList(this.env[VCP_PLUGIN_ALLOWED_ROOTS_ENV])
+            .map(root => realpathOrResolveSync(root.rootPath));
+    }
+
+    _buildExternalRootInfo(entry, index, allowedRoots, diagnostics, options = {}) {
+        const rootId = `external:${index + 1}`;
+        const rootPath = options.realpath
+            ? options.realpath(entry.rootPath)
+            : realpathOrResolveSync(entry.rootPath);
+        const displayPath = toDisplayPath(this.projectRoot, rootPath, 'external');
+        const unsafeReason = isUnsafeRoot(this.projectRoot, rootPath);
+
+        if (unsafeReason) {
+            diagnostics.push({ level: 'warn', code: 'unsafe_external_root', rootId, root: displayPath, message: unsafeReason });
+            return null;
+        }
+
+        if (allowedRoots.length === 0) {
+            diagnostics.push({ level: 'warn', code: 'external_roots_require_allowlist', rootId, root: displayPath });
+            return null;
+        }
+
+        const allowed = allowedRoots.some(allowedRoot => isSubPath(rootPath, allowedRoot));
+        if (!allowed) {
+            diagnostics.push({ level: 'warn', code: 'external_root_not_allowed', rootId, root: displayPath });
+            return null;
+        }
+
+        return {
+            rootId,
+            source: 'external',
+            rootPath,
+            displayPath,
+            allowConfigEnv: false,
+            enabled: true
+        };
+    }
+
+    getExternalLegacyRootsSync() {
+        const allowedRoots = this.getAllowedRootsSync();
+        const diagnostics = [];
+        const roots = [];
+
+        this.resolvePathList(this.env[VCP_PLUGIN_DIRS_ENV]).forEach((entry, index) => {
+            const rootInfo = this._buildExternalRootInfo(entry, index, allowedRoots, diagnostics);
+            if (rootInfo) roots.push(rootInfo);
+        });
+
+        return { roots, diagnostics };
+    }
+
+    getWatchRoots() {
+        return this.getPluginRootSnapshotSync().watchRoots;
+    }
+
+    getPluginRootSnapshotSync() {
+        const { roots: externalLegacyRoots, diagnostics } = this.getExternalLegacyRootsSync();
+        const coreLegacyRoot = {
+            rootId: 'core:legacy',
+            source: 'core',
+            rootPath: this.coreLegacyRoot,
+            displayPath: toDisplayPath(this.projectRoot, this.coreLegacyRoot, 'core'),
+            allowConfigEnv: true,
+            enabled: true
+        };
+
+        const coreModernRoot = {
+            rootId: 'core:modern',
+            source: 'core-modern',
+            rootPath: this.coreModernRoot,
+            displayPath: toDisplayPath(this.projectRoot, this.coreModernRoot, 'core'),
+            allowConfigEnv: true,
+            enabled: true
+        };
+
+        return {
+            projectRoot: this.projectRoot,
+            coreLegacyRoot,
+            coreModernRoot,
+            externalLegacyRoots,
+            legacyLoadRoots: [coreLegacyRoot, ...externalLegacyRoots],
+            watchRoots: uniqueByResolvedPath([
+                this.coreLegacyRoot,
+                this.coreModernRoot,
+                ...externalLegacyRoots.map(root => root.rootPath)
+            ]),
+            diagnostics
+        };
+    }
+
+    async getAllowedRoots() {
+        const roots = this.resolvePathList(this.env[VCP_PLUGIN_ALLOWED_ROOTS_ENV]);
+        const resolved = [];
+        for (const root of roots) {
+            resolved.push(await realpathOrResolve(root.rootPath));
+        }
+        return uniqueByResolvedPath(resolved);
+    }
+
+    async getExternalLegacyRoots() {
+        const allowedRoots = await this.getAllowedRoots();
+        const diagnostics = [];
+        const roots = [];
+        const entries = this.resolvePathList(this.env[VCP_PLUGIN_DIRS_ENV]);
+
+        for (let index = 0; index < entries.length; index += 1) {
+            const entry = entries[index];
+            const exists = await pathExists(entry.rootPath);
+            const realRoot = await realpathOrResolve(entry.rootPath);
+            const displayPath = toDisplayPath(this.projectRoot, realRoot, 'external');
+
+            if (!exists) {
+                diagnostics.push({ level: 'warn', code: 'external_root_missing', rootId: `external:${index + 1}`, root: displayPath });
+                continue;
+            }
+
+            const rootInfo = this._buildExternalRootInfo(
+                { ...entry, rootPath: realRoot },
+                index,
+                allowedRoots,
+                diagnostics,
+                { realpath: value => value }
+            );
+            if (rootInfo) roots.push(rootInfo);
+        }
+
+        return { roots, diagnostics };
+    }
+
+    async getPluginRootSnapshot() {
+        const coreLegacyRealPath = await realpathOrResolve(this.coreLegacyRoot);
+        const coreModernRealPath = await realpathOrResolve(this.coreModernRoot);
+        const { roots: externalLegacyRoots, diagnostics } = await this.getExternalLegacyRoots();
+
+        const coreLegacyRoot = {
+            rootId: 'core:legacy',
+            source: 'core',
+            rootPath: coreLegacyRealPath,
+            displayPath: toDisplayPath(this.projectRoot, coreLegacyRealPath, 'core'),
+            allowConfigEnv: true,
+            enabled: true
+        };
+
+        const coreModernRoot = {
+            rootId: 'core:modern',
+            source: 'core-modern',
+            rootPath: coreModernRealPath,
+            displayPath: toDisplayPath(this.projectRoot, coreModernRealPath, 'core'),
+            allowConfigEnv: true,
+            enabled: true
+        };
+
+        return {
+            projectRoot: this.projectRoot,
+            coreLegacyRoot,
+            coreModernRoot,
+            externalLegacyRoots,
+            legacyLoadRoots: [coreLegacyRoot, ...externalLegacyRoots],
+            watchRoots: uniqueByResolvedPath([
+                coreLegacyRealPath,
+                coreModernRealPath,
+                ...externalLegacyRoots.map(root => root.rootPath)
+            ]),
+            diagnostics
+        };
+    }
+
+    async getPluginStoreInstallRoot() {
+        const rawInstallDir = this.env[VCP_PLUGIN_INSTALL_DIR_ENV];
+        if (typeof rawInstallDir !== 'string' || rawInstallDir.trim() === '') {
+            const coreLegacyRealPath = await realpathOrResolve(this.coreLegacyRoot);
+            return {
+                mode: 'legacy',
+                source: 'core',
+                rootId: 'core:legacy',
+                rootPath: coreLegacyRealPath,
+                displayPath: toDisplayPath(this.projectRoot, coreLegacyRealPath, 'core'),
+                allowConfigEnv: true,
+                diagnostics: []
+            };
+        }
+
+        const requestedRoot = this.resolveSinglePath(rawInstallDir);
+        const requestedRealPath = await realpathOrResolve(requestedRoot);
+        const requestedDisplayPath = toDisplayPath(this.projectRoot, requestedRealPath, 'external');
+        const allowedRoots = await this.getAllowedRoots();
+        const { roots: externalLegacyRoots, diagnostics } = await this.getExternalLegacyRoots();
+
+        if (allowedRoots.length === 0) {
+            const error = new Error('VCP_PLUGIN_INSTALL_DIR requires VCP_PLUGIN_ALLOWED_ROOTS.');
+            error.code = 'plugin_install_root_allowlist_required';
+            error.displayPath = requestedDisplayPath;
+            throw error;
+        }
+
+        const insideAllowedRoot = allowedRoots.some(allowedRoot => isSubPath(requestedRealPath, allowedRoot));
+        if (!insideAllowedRoot) {
+            const error = new Error('VCP_PLUGIN_INSTALL_DIR is outside VCP_PLUGIN_ALLOWED_ROOTS.');
+            error.code = 'plugin_install_root_not_allowed';
+            error.displayPath = requestedDisplayPath;
+            throw error;
+        }
+
+        const matchedRoot = externalLegacyRoots.find(root => pathKey(root.rootPath) === pathKey(requestedRealPath));
+        if (!matchedRoot) {
+            const error = new Error('VCP_PLUGIN_INSTALL_DIR must match a current allowlisted external legacy root.');
+            error.code = 'plugin_install_root_not_managed';
+            error.displayPath = requestedDisplayPath;
+            throw error;
+        }
+
+        return {
+            mode: 'external',
+            source: 'external',
+            rootId: matchedRoot.rootId,
+            rootPath: matchedRoot.rootPath,
+            displayPath: matchedRoot.displayPath,
+            allowConfigEnv: false,
+            diagnostics
+        };
+    }
+}
+
+function createPluginRootResolver(options = {}) {
+    return new PluginRootResolver(options);
+}
+
+module.exports = {
+    createPluginRootResolver,
+    PluginRootResolver,
+    splitPathList,
+    isSubPath,
+    toDisplayPath,
+    LEGACY_MANIFEST_FILE_NAME,
+    BLOCKED_MANIFEST_SUFFIX,
+    BLOCKED_MANIFEST_FILE_NAME,
+    VCP_PLUGIN_DIRS_ENV,
+    VCP_PLUGIN_ALLOWED_ROOTS_ENV,
+    VCP_PLUGIN_INSTALL_DIR_ENV,
+    discoverAdminLegacyManifestRecords,
+    discoverLegacyManifestRecordsFromRoot,
+    isManagedPathInsideRoot,
+    isPathInsideRootByRealpath,
+    pathKey,
+    toRootRelativeDisplayPath
+};

--- a/modules/pluginRuntimeEnvSandbox.js
+++ b/modules/pluginRuntimeEnvSandbox.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const DEFAULT_EXTERNAL_RUNTIME_ENV_KEYS = new Set([
+    'PATH',
+    'Path',
+    'HOME',
+    'USERPROFILE',
+    'TEMP',
+    'TMP',
+    'TMPDIR',
+    'SystemRoot',
+    'windir',
+    'ComSpec',
+    'NO_COLOR',
+    'CI'
+]);
+
+const EXTERNAL_RUNTIME_ADDITIONAL_ENV_KEYS = new Set([
+    'PROJECT_BASE_PATH',
+    'VCP_REQUEST_IP',
+    'VCP_REQUEST_SOURCE',
+    'VCP_AGENT_ALIAS',
+    'VCP_AGENT_ID',
+    'VCP_EXECUTION_CONTEXT',
+    'SERVER_PORT',
+    'PYTHONIOENCODING',
+    'CALLBACK_BASE_URL',
+    'CALLBACK_AUTH_SECRET',
+    'PLUGIN_CALLBACK_URL',
+    'PLUGIN_NAME_FOR_CALLBACK'
+]);
+
+const EXTERNAL_RUNTIME_SENSITIVE_ADDITIONAL_ENV_KEYS = new Set([
+    'CALLBACK_AUTH_SECRET'
+]);
+
+const PLUGIN_RUNTIME_ENV_DENY_PATTERNS = [
+    /admin.*pass/i,
+    /password|passwd|pwd/i,
+    /secret/i,
+    /token/i,
+    /api[_-]?key|apikey/i,
+    /authorization|bearer/i,
+    /cookie|session/i,
+    /credential/i,
+    /private[_-]?key/i,
+    /github_token|gh_token/i,
+    /openai|anthropic|gemini|google|azure|aws|s3|slack|discord|telegram|dingtalk|feishu|wecom/i,
+    /decrypted[_-]?auth[_-]?code/i,
+    /(^|[_-])key($|[_-])/i
+];
+
+function isPluginRuntimeEnvKeyDenied(key) {
+    return PLUGIN_RUNTIME_ENV_DENY_PATTERNS.some(pattern => pattern.test(String(key || '')));
+}
+
+function copyStringValue(target, key, value) {
+    if (value === undefined || value === null) return;
+    target[key] = String(value);
+}
+
+function buildExternalPluginRuntimeEnv(baseEnv = {}, pluginConfig = {}, additionalEnv = {}) {
+    const env = {};
+
+    for (const key of DEFAULT_EXTERNAL_RUNTIME_ENV_KEYS) {
+        if (!Object.prototype.hasOwnProperty.call(baseEnv, key)) continue;
+        if (isPluginRuntimeEnvKeyDenied(key)) continue;
+        copyStringValue(env, key, baseEnv[key]);
+    }
+
+    for (const [key, value] of Object.entries(pluginConfig || {})) {
+        if (isPluginRuntimeEnvKeyDenied(key)) continue;
+        copyStringValue(env, key, value);
+    }
+
+    for (const [key, value] of Object.entries(additionalEnv || {})) {
+        if (!EXTERNAL_RUNTIME_ADDITIONAL_ENV_KEYS.has(key)) continue;
+        if (isPluginRuntimeEnvKeyDenied(key) && !EXTERNAL_RUNTIME_SENSITIVE_ADDITIONAL_ENV_KEYS.has(key)) continue;
+        copyStringValue(env, key, value);
+    }
+
+    return env;
+}
+
+module.exports = {
+    DEFAULT_EXTERNAL_RUNTIME_ENV_KEYS,
+    EXTERNAL_RUNTIME_ADDITIONAL_ENV_KEYS,
+    isPluginRuntimeEnvKeyDenied,
+    buildExternalPluginRuntimeEnv
+};

--- a/tests/externalPluginAllowPolicy.test.js
+++ b/tests/externalPluginAllowPolicy.test.js
@@ -1,0 +1,334 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    parseExternalPluginAllowPolicy,
+    evaluateExternalPluginAllowPolicy
+} = require('../modules/externalPluginAllowPolicy');
+
+function makeProjectRoot() {
+    return path.join(os.tmpdir(), 'vcp-external-plugin-allow-policy');
+}
+
+function makeEvaluationOptions(projectRoot) {
+    return {
+        projectRoot,
+        realpathSync: value => path.resolve(value)
+    };
+}
+
+function makeExternalClassification(overrides = {}) {
+    const projectRoot = makeProjectRoot();
+    const sourceDirectory = path.join(projectRoot, 'reviewed-plugins');
+    return {
+        pluginName: 'ExternalEcho',
+        pluginSource: 'external',
+        basePath: path.join(sourceDirectory, 'ExternalEcho'),
+        isExternal: true,
+        decision: 'would_block',
+        ...overrides
+    };
+}
+
+test('allow policy parser accepts name and reviewed source directory pairs', () => {
+    const projectRoot = makeProjectRoot();
+    const firstSource = path.join(projectRoot, 'reviewed-plugins');
+    const secondSource = path.join(projectRoot, 'other-reviewed-plugins');
+    const result = parseExternalPluginAllowPolicy(
+        [
+            `ExternalEcho@${firstSource}`,
+            `ExternalEcho@${firstSource}`,
+            `ExternalSearch@${secondSource}`
+        ].join(';'),
+        { projectRoot }
+    );
+
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.entries.length, 2);
+    assert.deepEqual(result.entries.map((entry) => entry.pluginName), ['ExternalEcho', 'ExternalSearch']);
+    assert.equal(result.entries[0].sourceDirectory, firstSource);
+    assert.equal(result.entries[0].normalizedSourceDirectory, path.resolve(projectRoot, firstSource));
+});
+
+test('allow policy parser rejects name-only, path-only, wildcard, and dot-only entries', () => {
+    const projectRoot = makeProjectRoot();
+    const result = parseExternalPluginAllowPolicy(
+        [
+            'ExternalEcho',
+            path.join(projectRoot, 'path-only'),
+            '*@reviewed-plugins',
+            'ExternalSearch@*',
+            'ExternalDot@.'
+        ].join(';'),
+        { projectRoot }
+    );
+
+    assert.equal(result.entries.length, 0);
+    assert.deepEqual(
+        result.errors.map((error) => error.reason),
+        [
+            'missing-source-directory',
+            'missing-plugin-name',
+            'wildcard-entry-not-allowed',
+            'wildcard-entry-not-allowed',
+            'broad-source-directory-not-allowed'
+        ]
+    );
+});
+
+test('allow policy parser rejects filesystem root source directories', () => {
+    const projectRoot = makeProjectRoot();
+    const currentPlatformRoot = path.parse(projectRoot).root;
+    const result = parseExternalPluginAllowPolicy(
+        [
+            'ExternalPosixRoot@/',
+            `ExternalCurrentRoot@${currentPlatformRoot}`,
+            'ExternalDriveRoot@C:\\',
+            'ExternalUncRoot@\\\\server\\share\\'
+        ].join(';'),
+        { projectRoot }
+    );
+
+    assert.equal(result.entries.length, 0);
+    assert.deepEqual(
+        result.errors.map((error) => error.reason),
+        [
+            'broad-source-directory-not-allowed',
+            'broad-source-directory-not-allowed',
+            'broad-source-directory-not-allowed',
+            'broad-source-directory-not-allowed'
+        ]
+    );
+});
+
+test('allow policy evaluation observes non-external plugin classifications', () => {
+    const result = evaluateExternalPluginAllowPolicy({
+        pluginName: 'SciCalculator',
+        pluginSource: 'legacy',
+        basePath: 'Plugin/SciCalculator',
+        isExternal: false
+    }, '');
+
+    assert.equal(result.pluginName, 'SciCalculator');
+    assert.equal(result.decision, 'observe');
+    assert.equal(result.matchedPolicy, null);
+    assert.match(result.reasons.join('\n'), /non-external/);
+});
+
+test('allow policy evaluation allows external plugin only when name and source directory match', () => {
+    const projectRoot = makeProjectRoot();
+    const sourceDirectory = path.join(projectRoot, 'reviewed-plugins');
+    const classification = makeExternalClassification({
+        basePath: path.join(sourceDirectory, 'ExternalEcho')
+    });
+    const policy = parseExternalPluginAllowPolicy(`ExternalEcho@${sourceDirectory}`, { projectRoot });
+    const result = evaluateExternalPluginAllowPolicy(classification, policy, makeEvaluationOptions(projectRoot));
+
+    assert.equal(result.decision, 'would_allow');
+    assert.equal(result.baseRealPath, path.resolve(projectRoot, classification.basePath));
+    assert.equal(result.matchedPolicy.pluginName, 'ExternalEcho');
+    assert.equal(result.matchedPolicy.normalizedSourceDirectory, path.resolve(projectRoot, sourceDirectory));
+    assert.equal(result.matchedPolicy.realSourceDirectory, path.resolve(projectRoot, sourceDirectory));
+    assert.match(result.reasons.join('\n'), /matched explicit name and source directory/);
+});
+
+test('allow policy evaluation keeps invalid policy evidence when a valid entry matches', () => {
+    const projectRoot = makeProjectRoot();
+    const sourceDirectory = path.join(projectRoot, 'reviewed-plugins');
+    const policy = parseExternalPluginAllowPolicy(
+        `ExternalEcho@${sourceDirectory};BrokenNameOnly`,
+        { projectRoot }
+    );
+    const result = evaluateExternalPluginAllowPolicy(
+        makeExternalClassification({
+            basePath: path.join(sourceDirectory, 'ExternalEcho')
+        }),
+        policy,
+        makeEvaluationOptions(projectRoot)
+    );
+
+    assert.equal(result.decision, 'would_allow');
+    assert.match(result.reasons.join('\n'), /matched explicit name and source directory/);
+    assert.match(result.reasons.join('\n'), /invalid entries/);
+});
+
+test('allow policy evaluation accepts policy objects with sourceDirectory fallback', () => {
+    const projectRoot = makeProjectRoot();
+    const sourceDirectory = path.join(projectRoot, 'reviewed-plugins');
+    const result = evaluateExternalPluginAllowPolicy(
+        makeExternalClassification({
+            basePath: path.join(sourceDirectory, 'ExternalEcho')
+        }),
+        {
+            entries: [{ pluginName: 'ExternalEcho', sourceDirectory }],
+            errors: []
+        },
+        makeEvaluationOptions(projectRoot)
+    );
+
+    assert.equal(result.decision, 'would_allow');
+    assert.equal(result.matchedPolicy.normalizedSourceDirectory, sourceDirectory);
+    assert.equal(result.matchedPolicy.realSourceDirectory, sourceDirectory);
+});
+
+test('allow policy evaluation blocks same-name external plugin when policy source is a filesystem root', () => {
+    const projectRoot = makeProjectRoot();
+    const result = evaluateExternalPluginAllowPolicy(
+        makeExternalClassification({
+            basePath: path.join(projectRoot, 'reviewed-plugins', 'ExternalEcho')
+        }),
+        `ExternalEcho@${path.parse(projectRoot).root}`,
+        makeEvaluationOptions(projectRoot)
+    );
+
+    assert.equal(result.decision, 'would_block');
+    assert.equal(result.matchedPolicy, null);
+    assert.match(result.reasons.join('\n'), /invalid entries/);
+    assert.match(result.reasons.join('\n'), /requires explicit name and source directory/);
+});
+
+test('allow policy evaluation blocks broad source directories in policy objects', () => {
+    const projectRoot = makeProjectRoot();
+    const result = evaluateExternalPluginAllowPolicy(
+        makeExternalClassification({
+            basePath: path.join(projectRoot, 'reviewed-plugins', 'ExternalEcho')
+        }),
+        {
+            entries: [{ pluginName: 'ExternalEcho', sourceDirectory: path.parse(projectRoot).root }],
+            errors: []
+        },
+        makeEvaluationOptions(projectRoot)
+    );
+
+    assert.equal(result.decision, 'would_block');
+    assert.equal(result.matchedPolicy, null);
+    assert.match(result.reasons.join('\n'), /broad .*source directory entries/);
+    assert.match(result.reasons.join('\n'), /source directory did not match/);
+});
+
+test('allow policy evaluation blocks same plugin name from a different source directory', () => {
+    const projectRoot = makeProjectRoot();
+    const reviewedSource = path.join(projectRoot, 'reviewed-plugins');
+    const unreviewedSource = path.join(projectRoot, 'unreviewed-plugins');
+    const result = evaluateExternalPluginAllowPolicy(
+        makeExternalClassification({
+            basePath: path.join(unreviewedSource, 'ExternalEcho')
+        }),
+        `ExternalEcho@${reviewedSource}`,
+        makeEvaluationOptions(projectRoot)
+    );
+
+    assert.equal(result.decision, 'would_block');
+    assert.equal(result.matchedPolicy, null);
+    assert.match(result.reasons.join('\n'), /source directory did not match/);
+});
+
+test('allow policy evaluation blocks external plugin when no matching name exists', () => {
+    const projectRoot = makeProjectRoot();
+    const sourceDirectory = path.join(projectRoot, 'reviewed-plugins');
+    const result = evaluateExternalPluginAllowPolicy(
+        makeExternalClassification(),
+        `ExternalSearch@${sourceDirectory}`,
+        makeEvaluationOptions(projectRoot)
+    );
+
+    assert.equal(result.decision, 'would_block');
+    assert.match(result.reasons.join('\n'), /requires explicit name and source directory/);
+});
+
+test('allow policy evaluation preserves invalid policy errors without allowing by name alone', () => {
+    const result = evaluateExternalPluginAllowPolicy(
+        makeExternalClassification(),
+        'ExternalEcho',
+        makeEvaluationOptions(makeProjectRoot())
+    );
+
+    assert.equal(result.decision, 'would_block');
+    assert.equal(result.matchedPolicy, null);
+    assert.match(result.reasons.join('\n'), /invalid entries/);
+    assert.match(result.reasons.join('\n'), /requires explicit name and source directory/);
+});
+
+test('allow policy evaluation does not mutate inputs or leak plugin config values', () => {
+    const projectRoot = makeProjectRoot();
+    const sourceDirectory = path.join(projectRoot, 'reviewed-plugins');
+    const classification = makeExternalClassification({
+        pluginSpecificEnvConfig: {
+            API_TOKEN: 'SECRET_VALUE_SHOULD_NOT_APPEAR'
+        }
+    });
+    const policy = parseExternalPluginAllowPolicy(`ExternalEcho@${sourceDirectory}`, { projectRoot });
+    const beforeClassification = JSON.stringify(classification);
+    const beforePolicy = JSON.stringify(policy);
+    const result = evaluateExternalPluginAllowPolicy(classification, policy, makeEvaluationOptions(projectRoot));
+    const serialized = JSON.stringify(result);
+
+    assert.equal(result.decision, 'would_allow');
+    assert.equal(JSON.stringify(classification), beforeClassification);
+    assert.equal(JSON.stringify(policy), beforePolicy);
+    assert.equal(serialized.includes('SECRET_VALUE_SHOULD_NOT_APPEAR'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(result, 'pluginSpecificEnvConfig'), false);
+});
+
+test('allow policy evaluation uses fresh realpath and blocks symlink escape from reviewed source', (t) => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vcp-external-policy-realpath-'));
+    t.after(() => {
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    const reviewedSource = path.join(projectRoot, 'reviewed-plugins');
+    const unreviewedSource = path.join(projectRoot, 'unreviewed-plugins');
+    const escapedLink = path.join(reviewedSource, 'linked-outside');
+    const escapedPluginPath = path.join(escapedLink, 'ExternalEcho');
+
+    fs.mkdirSync(path.join(unreviewedSource, 'ExternalEcho'), { recursive: true });
+    fs.mkdirSync(reviewedSource, { recursive: true });
+    try {
+        fs.symlinkSync(unreviewedSource, escapedLink, 'junction');
+    } catch (error) {
+        t.skip(`symlink unavailable on this filesystem: ${error.code || error.message}`);
+        return;
+    }
+
+    const policy = parseExternalPluginAllowPolicy(`ExternalEcho@${reviewedSource}`, { projectRoot });
+    const result = evaluateExternalPluginAllowPolicy(
+        makeExternalClassification({
+            basePath: escapedPluginPath
+        }),
+        policy,
+        { projectRoot }
+    );
+
+    assert.equal(result.decision, 'would_block');
+    assert.equal(result.matchedPolicy, null);
+    assert.equal(result.baseRealPath, fs.realpathSync(escapedPluginPath));
+    assert.match(result.reasons.join('\n'), /source directory did not match/);
+});
+
+test('allow policy evaluation returns matched source and base realpaths', (t) => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vcp-external-policy-match-'));
+    t.after(() => {
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    const reviewedSource = path.join(projectRoot, 'reviewed-plugins');
+    const pluginPath = path.join(reviewedSource, 'ExternalEcho');
+    fs.mkdirSync(pluginPath, { recursive: true });
+
+    const policy = parseExternalPluginAllowPolicy(`ExternalEcho@${reviewedSource}`, { projectRoot });
+    const result = evaluateExternalPluginAllowPolicy(
+        makeExternalClassification({
+            basePath: pluginPath
+        }),
+        policy,
+        { projectRoot }
+    );
+
+    assert.equal(result.decision, 'would_allow');
+    assert.equal(result.baseRealPath, fs.realpathSync(pluginPath));
+    assert.equal(result.matchedPolicy.realSourceDirectory, fs.realpathSync(reviewedSource));
+    assert.equal(result.matchedPolicy.normalizedSourceDirectory, path.resolve(projectRoot, reviewedSource));
+});

--- a/tests/externalPluginSafetyGate.test.js
+++ b/tests/externalPluginSafetyGate.test.js
@@ -1,0 +1,130 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    classifyExternalPluginManifest,
+    classifyExternalPluginManifests
+} = require('../modules/externalPluginSafetyGate');
+
+function makeManifest(overrides = {}) {
+    return {
+        name: 'ExternalEcho',
+        pluginSource: 'external',
+        basePath: 'external/ExternalEcho',
+        pluginType: 'synchronous',
+        entryPoint: { command: 'node external-echo.js' },
+        communication: { protocol: 'stdio', timeout: 1000 },
+        ...overrides
+    };
+}
+
+test('classifier observes built-in legacy manifests without changing behavior', () => {
+    const result = classifyExternalPluginManifest(makeManifest({
+        name: 'SciCalculator',
+        pluginSource: 'legacy',
+        basePath: 'Plugin/SciCalculator'
+    }), {
+        projectRoot: 'A:/repo',
+        builtInPluginNames: ['SciCalculator']
+    });
+
+    assert.equal(result.pluginName, 'SciCalculator');
+    assert.equal(result.pluginSource, 'legacy');
+    assert.equal(result.isExternal, false);
+    assert.equal(result.duplicateOfBuiltIn, false);
+    assert.equal(result.decision, 'observe');
+    assert.equal(result.risk, 'executes_process');
+});
+
+test('classifier would block external command plugins pending explicit allow policy', () => {
+    const result = classifyExternalPluginManifest(makeManifest(), {
+        projectRoot: 'A:/repo'
+    });
+
+    assert.equal(result.isExternal, true);
+    assert.equal(result.decision, 'would_block');
+    assert.equal(result.risk, 'executes_process');
+    assert.equal(result.entryPointKind, 'command');
+    assert.equal(result.basePath, path.resolve('A:/repo', 'external/ExternalEcho'));
+    assert.match(result.reasons.join('\n'), /explicit allow policy/);
+});
+
+test('classifier keeps forced external source evidence internally consistent', () => {
+    const result = classifyExternalPluginManifest(makeManifest({
+        pluginSource: undefined
+    }), {
+        isExternal: true
+    });
+
+    assert.equal(result.pluginSource, 'external');
+    assert.equal(result.isExternal, true);
+    assert.equal(result.decision, 'would_block');
+});
+
+test('classifier identifies direct script entrypoints as code-load risk', () => {
+    const result = classifyExternalPluginManifest(makeManifest({
+        pluginType: 'messagePreprocessor',
+        entryPoint: { script: 'index.js' },
+        communication: { protocol: 'direct' }
+    }));
+
+    assert.equal(result.entryPointKind, 'script');
+    assert.equal(result.risk, 'loads_code');
+    assert.equal(result.decision, 'would_block');
+    assert.match(result.reasons.join('\n'), /load plugin code/);
+});
+
+test('classifier flags external names that duplicate built-in plugins', () => {
+    const result = classifyExternalPluginManifest(makeManifest({
+        name: 'SciCalculator'
+    }), {
+        builtInPluginNames: new Set(['SciCalculator'])
+    });
+
+    assert.equal(result.duplicateOfBuiltIn, true);
+    assert.equal(result.decision, 'would_block');
+    assert.match(result.reasons.join('\n'), /duplicates a built-in plugin/);
+});
+
+test('classifier reports missing or unsupported entrypoints as unknown risk', () => {
+    const result = classifyExternalPluginManifest(makeManifest({
+        entryPoint: {},
+        communication: {}
+    }));
+
+    assert.equal(result.entryPointKind, 'unknown');
+    assert.equal(result.risk, 'unknown');
+    assert.equal(result.decision, 'would_block');
+    assert.match(result.reasons.join('\n'), /entrypoint is missing or unsupported/);
+});
+
+test('classification evidence does not leak plugin config or secret-like values', () => {
+    const result = classifyExternalPluginManifest(makeManifest({
+        pluginSpecificEnvConfig: {
+            API_TOKEN: 'SECRET_VALUE_SHOULD_NOT_APPEAR',
+            harmless: 'VISIBLE_VALUE_SHOULD_NOT_APPEAR'
+        }
+    }));
+    const serialized = JSON.stringify(result);
+
+    assert.equal(serialized.includes('SECRET_VALUE_SHOULD_NOT_APPEAR'), false);
+    assert.equal(serialized.includes('VISIBLE_VALUE_SHOULD_NOT_APPEAR'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(result, 'pluginSpecificEnvConfig'), false);
+});
+
+test('classifier supports batch classification without mutating manifests', () => {
+    const manifests = [
+        makeManifest({ name: 'ExternalEcho' }),
+        makeManifest({ name: 'BuiltInTool', pluginSource: 'legacy' })
+    ];
+    const before = JSON.stringify(manifests);
+    const results = classifyExternalPluginManifests(manifests, {
+        builtInPluginNames: ['BuiltInTool']
+    });
+
+    assert.equal(results.length, 2);
+    assert.equal(results[0].decision, 'would_block');
+    assert.equal(results[1].decision, 'observe');
+    assert.equal(JSON.stringify(manifests), before);
+});

--- a/tests/plugin-external-dirs.test.js
+++ b/tests/plugin-external-dirs.test.js
@@ -1,0 +1,598 @@
+const { after, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const pluginManager = require('../Plugin.js');
+const { classifyExternalPluginManifest } = require('../modules/externalPluginSafetyGate');
+const {
+    createPluginRootResolver,
+    splitPathList
+} = require('../modules/pluginRootResolver');
+
+after(() => {
+    if (pluginManager.toolApprovalManager && typeof pluginManager.toolApprovalManager.shutdown === 'function') {
+        pluginManager.toolApprovalManager.shutdown();
+    }
+});
+
+function makeTempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'vcp-plugin-dirs-'));
+}
+
+function writeLegacyManifest(root, folderName, manifest) {
+    const pluginDir = path.join(root, folderName);
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(pluginDir, 'plugin-manifest.json'),
+        JSON.stringify(manifest, null, 2),
+        'utf8'
+    );
+    return pluginDir;
+}
+
+test('VCP_PLUGIN_DIRS parser tolerates missing, empty, semicolon, and duplicate entries', () => {
+    assert.deepEqual(pluginManager._parseExternalLegacyPluginDirs(''), []);
+    assert.deepEqual(pluginManager._parseExternalLegacyPluginDirs('  ;  '), []);
+
+    const first = path.resolve(__dirname, '..', 'external-one');
+    const second = path.resolve(__dirname, '..', 'external-two');
+    assert.deepEqual(
+        pluginManager._parseExternalLegacyPluginDirs('external-one; external-two ; external-one'),
+        [first, second]
+    );
+    assert.deepEqual(
+        pluginManager._parseExternalLegacyPluginDirs('external-one:external-two:external-one'),
+        [first, second]
+    );
+});
+
+test('legacy external discovery ignores missing and empty directories without changing built-in loading', async () => {
+    const missingRoot = path.join(os.tmpdir(), `vcp-missing-${Date.now()}`);
+    const emptyRoot = makeTempDir();
+
+    try {
+        assert.deepEqual(
+            await pluginManager._discoverLegacyPluginManifestsFromDir(missingRoot, 'external'),
+            []
+        );
+        assert.deepEqual(
+            await pluginManager._discoverLegacyPluginManifestsFromDir(emptyRoot, 'external'),
+            []
+        );
+    } finally {
+        fs.rmSync(emptyRoot, { recursive: true, force: true });
+    }
+});
+
+test('legacy external discovery reads plugin-manifest.json without executing plugin code', async () => {
+    const root = makeTempDir();
+    const pluginDir = writeLegacyManifest(root, 'ExternalEcho', {
+        name: 'ExternalEcho',
+        displayName: 'External Echo',
+        pluginType: 'synchronous',
+        entryPoint: { command: 'node external-echo.js' },
+        communication: { protocol: 'stdio', timeout: 1000 }
+    });
+    fs.writeFileSync(
+        path.join(pluginDir, 'external-echo.js'),
+        'throw new Error("should not execute during discovery");\n',
+        'utf8'
+    );
+
+    try {
+        const manifests = await pluginManager._discoverLegacyPluginManifestsFromDir(root, 'external');
+        assert.equal(manifests.length, 1);
+        assert.equal(manifests[0].name, 'ExternalEcho');
+        assert.equal(manifests[0].pluginSource, 'external');
+        assert.equal(manifests[0].basePath, pluginDir);
+        assert.deepEqual(manifests[0].pluginSpecificEnvConfig, {});
+
+        const safetyDecision = classifyExternalPluginManifest(manifests[0]);
+        assert.equal(safetyDecision.pluginName, 'ExternalEcho');
+        assert.equal(safetyDecision.isExternal, true);
+        assert.equal(safetyDecision.decision, 'would_block');
+        assert.equal(safetyDecision.risk, 'executes_process');
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('PluginManager discovers resolver legacy roots in core-first order', () => {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'Plugin.js'), 'utf8');
+
+    assert.match(source, /for \(const rootInfo of rootSnapshot\.legacyLoadRoots\)/);
+    assert.match(source, /_discoverLegacyPluginManifestsFromDir\(\s+rootInfo\.rootPath,\s+rootInfo\.source,\s+rootInfo\s+\)/s);
+    assert.match(source, /if \(this\.plugins\.has\(manifest\.name\)\) \{\s+this\._warnDuplicateLocalPluginSkipped\(manifest, this\.plugins\.get\(manifest\.name\)\);\s+continue;\s+\}\s+await this\._registerLocalPlugin\(manifest/s);
+
+    const firstExternalRoot = makeTempDir();
+    const secondExternalRoot = makeTempDir();
+    const previousDirs = process.env.VCP_PLUGIN_DIRS;
+    const previousAllowedRoots = process.env.VCP_PLUGIN_ALLOWED_ROOTS;
+
+    try {
+        process.env.VCP_PLUGIN_ALLOWED_ROOTS = [firstExternalRoot, secondExternalRoot].join(path.delimiter);
+        process.env.VCP_PLUGIN_DIRS = [secondExternalRoot, firstExternalRoot].join(path.delimiter);
+
+        const snapshot = pluginManager.pluginRootResolver.getPluginRootSnapshotSync();
+        assert.equal(snapshot.legacyLoadRoots[0].source, 'core');
+        assert.equal(snapshot.legacyLoadRoots[0].rootId, 'core:legacy');
+        assert.deepEqual(
+            snapshot.legacyLoadRoots.slice(1).map(rootInfo => rootInfo.rootPath),
+            [secondExternalRoot, firstExternalRoot]
+        );
+        assert.deepEqual(
+            snapshot.legacyLoadRoots.slice(1).map(rootInfo => rootInfo.source),
+            ['external', 'external']
+        );
+    } finally {
+        if (previousDirs === undefined) delete process.env.VCP_PLUGIN_DIRS;
+        else process.env.VCP_PLUGIN_DIRS = previousDirs;
+
+        if (previousAllowedRoots === undefined) delete process.env.VCP_PLUGIN_ALLOWED_ROOTS;
+        else process.env.VCP_PLUGIN_ALLOWED_ROOTS = previousAllowedRoots;
+
+        fs.rmSync(firstExternalRoot, { recursive: true, force: true });
+        fs.rmSync(secondExternalRoot, { recursive: true, force: true });
+    }
+});
+
+test('Jenn adapter root contract keeps external legacy roots default-off', () => {
+    const projectRoot = makeTempDir();
+
+    try {
+        const resolver = createPluginRootResolver({
+            projectRoot,
+            env: {}
+        });
+
+        const snapshot = resolver.getPluginRootSnapshotSync();
+
+        assert.equal(snapshot.coreLegacyRoot.source, 'core');
+        assert.equal(snapshot.coreLegacyRoot.rootId, 'core:legacy');
+        assert.equal(snapshot.coreLegacyRoot.rootPath, path.join(projectRoot, 'Plugin'));
+        assert.equal(snapshot.coreModernRoot.source, 'core-modern');
+        assert.equal(snapshot.coreModernRoot.rootId, 'core:modern');
+        assert.equal(snapshot.coreModernRoot.rootPath, path.join(projectRoot, 'plugins'));
+        assert.deepEqual(snapshot.externalLegacyRoots, []);
+        assert.deepEqual(
+            snapshot.legacyLoadRoots.map(rootInfo => rootInfo.rootId),
+            ['core:legacy']
+        );
+        assert.deepEqual(
+            snapshot.watchRoots,
+            [path.join(projectRoot, 'Plugin'), path.join(projectRoot, 'plugins')]
+        );
+        assert.deepEqual(snapshot.diagnostics, []);
+    } finally {
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+});
+
+test('Jenn adapter root contract requires VCP_PLUGIN_ALLOWED_ROOTS for VCP_PLUGIN_DIRS', () => {
+    const projectRoot = makeTempDir();
+    const externalRoot = path.join(projectRoot, 'VCPToolBox-JENN-Extensions');
+    fs.mkdirSync(externalRoot, { recursive: true });
+
+    try {
+        const resolver = createPluginRootResolver({
+            projectRoot,
+            env: {
+                VCP_PLUGIN_DIRS: externalRoot
+            }
+        });
+
+        const snapshot = resolver.getPluginRootSnapshotSync();
+
+        assert.deepEqual(snapshot.externalLegacyRoots, []);
+        assert.equal(snapshot.legacyLoadRoots.length, 1);
+        assert.equal(snapshot.legacyLoadRoots[0].rootId, 'core:legacy');
+        assert.equal(snapshot.diagnostics.length, 1);
+        assert.equal(snapshot.diagnostics[0].code, 'external_roots_require_allowlist');
+        assert.equal(snapshot.diagnostics[0].rootId, 'external:1');
+    } finally {
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+});
+
+test('Jenn adapter root contract rejects unsafe external roots', () => {
+    const projectRoot = makeTempDir();
+    const gitRoot = path.join(projectRoot, '.git');
+    const nodeModulesRoot = path.join(projectRoot, 'node_modules');
+    fs.mkdirSync(gitRoot, { recursive: true });
+    fs.mkdirSync(nodeModulesRoot, { recursive: true });
+
+    try {
+        const resolver = createPluginRootResolver({
+            projectRoot,
+            env: {
+                VCP_PLUGIN_ALLOWED_ROOTS: projectRoot,
+                VCP_PLUGIN_DIRS: [
+                    projectRoot,
+                    gitRoot,
+                    nodeModulesRoot
+                ].join(path.delimiter)
+            }
+        });
+
+        const snapshot = resolver.getPluginRootSnapshotSync();
+
+        assert.deepEqual(snapshot.externalLegacyRoots, []);
+        assert.deepEqual(
+            snapshot.diagnostics.map(item => item.code),
+            ['unsafe_external_root', 'unsafe_external_root', 'unsafe_external_root']
+        );
+        assert.match(snapshot.diagnostics[0].message, /project root/);
+        assert.match(snapshot.diagnostics[1].message, /\.git/);
+        assert.match(snapshot.diagnostics[2].message, /node_modules/);
+    } finally {
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+});
+
+test('Jenn adapter root contract keeps core roots before external legacy roots', () => {
+    const projectRoot = makeTempDir();
+    const extensionsRoot = path.join(projectRoot, '..', 'VCPToolBox-JENN-Extensions');
+    const localStateRoot = path.join(projectRoot, '..', 'VCPToolBox-JENN-LocalState');
+    fs.mkdirSync(extensionsRoot, { recursive: true });
+    fs.mkdirSync(localStateRoot, { recursive: true });
+
+    try {
+        const resolver = createPluginRootResolver({
+            projectRoot,
+            env: {
+                VCP_PLUGIN_ALLOWED_ROOTS: [extensionsRoot, localStateRoot].join(path.delimiter),
+                VCP_PLUGIN_DIRS: [localStateRoot, extensionsRoot].join(path.delimiter)
+            }
+        });
+
+        const snapshot = resolver.getPluginRootSnapshotSync();
+
+        assert.equal(snapshot.coreLegacyRoot.rootId, 'core:legacy');
+        assert.equal(snapshot.coreModernRoot.rootId, 'core:modern');
+        assert.deepEqual(
+            snapshot.legacyLoadRoots.map(rootInfo => rootInfo.rootId),
+            ['core:legacy', 'external:1', 'external:2']
+        );
+        assert.deepEqual(
+            snapshot.legacyLoadRoots.map(rootInfo => rootInfo.source),
+            ['core', 'external', 'external']
+        );
+        assert.equal(snapshot.externalLegacyRoots[0].rootPath, path.resolve(localStateRoot));
+        assert.equal(snapshot.externalLegacyRoots[1].rootPath, path.resolve(extensionsRoot));
+        assert.deepEqual(
+            snapshot.watchRoots,
+            [
+                path.join(projectRoot, 'Plugin'),
+                path.join(projectRoot, 'plugins'),
+                path.resolve(localStateRoot),
+                path.resolve(extensionsRoot)
+            ]
+        );
+    } finally {
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+});
+
+test('Jenn adapter root contract keeps Windows-style path parsing stable', () => {
+    assert.deepEqual(splitPathList('C:\\Jenn\\VCPToolBox-JENN-Extensions'), [
+        'C:\\Jenn\\VCPToolBox-JENN-Extensions'
+    ]);
+    assert.deepEqual(
+        splitPathList('C:\\Jenn\\VCPToolBox-JENN-Extensions;D:\\Jenn\\VCPToolBox-JENN-LocalState'),
+        ['C:\\Jenn\\VCPToolBox-JENN-Extensions', 'D:\\Jenn\\VCPToolBox-JENN-LocalState']
+    );
+});
+
+test('Jenn adapter install root must match an allowlisted external legacy root', async () => {
+    const projectRoot = makeTempDir();
+    const externalRoot = path.join(projectRoot, '..', 'VCPToolBox-JENN-Extensions');
+    const unmanagedRoot = path.join(projectRoot, '..', 'VCPToolBox-JENN-LocalState');
+    fs.mkdirSync(externalRoot, { recursive: true });
+    fs.mkdirSync(unmanagedRoot, { recursive: true });
+
+    try {
+        const defaultRoot = await createPluginRootResolver({
+            projectRoot,
+            env: {}
+        }).getPluginStoreInstallRoot();
+        assert.equal(defaultRoot.source, 'core');
+        assert.equal(defaultRoot.rootId, 'core:legacy');
+
+        await assert.rejects(
+            () => createPluginRootResolver({
+                projectRoot,
+                env: {
+                    VCP_PLUGIN_INSTALL_DIR: externalRoot
+                }
+            }).getPluginStoreInstallRoot(),
+            { code: 'plugin_install_root_allowlist_required' }
+        );
+
+        await assert.rejects(
+            () => createPluginRootResolver({
+                projectRoot,
+                env: {
+                    VCP_PLUGIN_ALLOWED_ROOTS: [externalRoot, unmanagedRoot].join(path.delimiter),
+                    VCP_PLUGIN_DIRS: externalRoot,
+                    VCP_PLUGIN_INSTALL_DIR: unmanagedRoot
+                }
+            }).getPluginStoreInstallRoot(),
+            { code: 'plugin_install_root_not_managed' }
+        );
+
+        const externalInstallRoot = await createPluginRootResolver({
+            projectRoot,
+            env: {
+                VCP_PLUGIN_ALLOWED_ROOTS: externalRoot,
+                VCP_PLUGIN_DIRS: externalRoot,
+                VCP_PLUGIN_INSTALL_DIR: externalRoot
+            }
+        }).getPluginStoreInstallRoot();
+
+        assert.equal(externalInstallRoot.mode, 'external');
+        assert.equal(externalInstallRoot.source, 'external');
+        assert.equal(externalInstallRoot.rootId, 'external:1');
+        assert.equal(externalInstallRoot.rootPath, fs.realpathSync(externalRoot));
+        assert.equal(externalInstallRoot.allowConfigEnv, false);
+    } finally {
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+});
+
+test('Gate 10 no-op Jenn external fixture package is discovered from the Plugin subdirectory only', async () => {
+    const projectRoot = makeTempDir();
+    const externalPackageRoot = path.join(projectRoot, 'VCPToolBox-JENN-Extensions');
+    const externalPluginRoot = path.join(externalPackageRoot, 'Plugin');
+    const localStateRoot = path.join(projectRoot, 'VCPToolBox-JENN-LocalState');
+    const fixtureManifest = {
+        name: 'NoopJennExternalFixture',
+        displayName: 'No-op Jenn External Fixture',
+        pluginType: 'synchronous',
+        entryPoint: { command: 'node noop-jenn-external-fixture.js' },
+        communication: { protocol: 'stdio', timeout: 1000 }
+    };
+
+    fs.mkdirSync(externalPluginRoot, { recursive: true });
+    fs.mkdirSync(localStateRoot, { recursive: true });
+    writeLegacyManifest(externalPluginRoot, 'NoopJennExternalFixture', fixtureManifest);
+    writeLegacyManifest(localStateRoot, 'NoopJennExternalFixture', fixtureManifest);
+
+    try {
+        const resolver = createPluginRootResolver({
+            projectRoot,
+            env: {
+                VCP_PLUGIN_ALLOWED_ROOTS: externalPackageRoot,
+                VCP_PLUGIN_DIRS: externalPluginRoot,
+                VCP_PLUGIN_INSTALL_DIR: externalPluginRoot
+            }
+        });
+        const snapshot = resolver.getPluginRootSnapshotSync();
+
+        assert.deepEqual(
+            snapshot.legacyLoadRoots.map(rootInfo => rootInfo.rootId),
+            ['core:legacy', 'external:1']
+        );
+        assert.equal(snapshot.externalLegacyRoots[0].rootPath, fs.realpathSync(externalPluginRoot));
+        assert.ok(snapshot.externalLegacyRoots[0].rootPath.endsWith(`${path.sep}VCPToolBox-JENN-Extensions${path.sep}Plugin`));
+        assert.ok(!snapshot.legacyLoadRoots.some(rootInfo => rootInfo.rootPath === fs.realpathSync(localStateRoot)));
+
+        const manifests = await pluginManager._discoverLegacyPluginManifestsFromDir(
+            snapshot.externalLegacyRoots[0].rootPath,
+            'external',
+            snapshot.externalLegacyRoots[0]
+        );
+
+        assert.equal(manifests.length, 1);
+        assert.equal(manifests[0].name, 'NoopJennExternalFixture');
+        assert.equal(manifests[0].pluginSource, 'external');
+        assert.equal(manifests[0].pluginRootId, 'external:1');
+        assert.equal(
+            manifests[0].basePath,
+            path.join(fs.realpathSync(externalPluginRoot), 'NoopJennExternalFixture')
+        );
+
+        const externalInstallRoot = await resolver.getPluginStoreInstallRoot();
+        assert.equal(externalInstallRoot.mode, 'external');
+        assert.equal(externalInstallRoot.rootPath, fs.realpathSync(externalPluginRoot));
+
+        const packageRootResolver = createPluginRootResolver({
+            projectRoot,
+            env: {
+                VCP_PLUGIN_ALLOWED_ROOTS: externalPackageRoot,
+                VCP_PLUGIN_DIRS: externalPackageRoot
+            }
+        });
+        const packageRootSnapshot = packageRootResolver.getPluginRootSnapshotSync();
+        const packageRootManifests = await pluginManager._discoverLegacyPluginManifestsFromDir(
+            packageRootSnapshot.externalLegacyRoots[0].rootPath,
+            'external',
+            packageRootSnapshot.externalLegacyRoots[0]
+        );
+
+        assert.deepEqual(packageRootManifests, []);
+
+        writeLegacyManifest(path.join(projectRoot, 'Plugin'), 'NoopJennExternalFixture', fixtureManifest);
+        const originalResolver = pluginManager.pluginRootResolver;
+        const originalSnapshot = pluginManager.lastPluginRootSnapshot;
+        try {
+            pluginManager.pluginRootResolver = {
+                getPluginRootSnapshot: async () => ({
+                    diagnostics: [],
+                    legacyLoadRoots: [
+                        {
+                            rootId: 'core:legacy',
+                            source: 'core',
+                            rootPath: path.join(projectRoot, 'Plugin'),
+                            displayPath: 'Plugin',
+                            allowConfigEnv: true
+                        },
+                        snapshot.externalLegacyRoots[0]
+                    ]
+                })
+            };
+
+            const duplicateManifests = await pluginManager._discoverLegacyPluginManifests();
+            assert.equal(duplicateManifests.length, 2);
+            assert.equal(duplicateManifests[0].pluginSource, 'core');
+            assert.equal(duplicateManifests[0].pluginRootId, 'core:legacy');
+            assert.equal(duplicateManifests[1].pluginSource, 'external');
+            assert.equal(duplicateManifests[1].pluginRootId, 'external:1');
+
+            const pluginManagerSource = fs.readFileSync(path.join(__dirname, '..', 'Plugin.js'), 'utf8');
+            assert.match(pluginManagerSource, /if \(this\.plugins\.has\(manifest\.name\)\) \{\s+this\._warnDuplicateLocalPluginSkipped\(manifest, this\.plugins\.get\(manifest\.name\)\);\s+continue;\s+\}/s);
+        } finally {
+            pluginManager.pluginRootResolver = originalResolver;
+            pluginManager.lastPluginRootSnapshot = originalSnapshot;
+        }
+
+        const fixtureFiles = [];
+        const pendingDirs = [projectRoot];
+        while (pendingDirs.length > 0) {
+            const currentDir = pendingDirs.pop();
+            for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+                const entryPath = path.join(currentDir, entry.name);
+                if (entry.isDirectory()) {
+                    pendingDirs.push(entryPath);
+                } else {
+                    fixtureFiles.push(path.relative(projectRoot, entryPath));
+                }
+            }
+        }
+
+        assert.ok(fixtureFiles.length > 0);
+        assert.ok(fixtureFiles.every(filePath => filePath.endsWith('plugin-manifest.json')));
+        assert.ok(fixtureFiles.every(filePath => !/config\.env|\.env|log|cache|image|ToolConfigs|operator/i.test(filePath)));
+    } finally {
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+});
+
+test('PluginManager duplicate runtime warning is path-safe and includes root identity', () => {
+    const root = makeTempDir();
+    const externalRoot = path.join(root, 'external');
+    const originalWarn = console.warn;
+    const warnings = [];
+
+    console.warn = (...args) => warnings.push(args.map(String).join(' '));
+
+    try {
+        pluginManager._warnDuplicateLocalPluginSkipped(
+            {
+                name: 'SharedLegacyPlugin',
+                pluginSource: 'external',
+                pluginRootId: `external:${externalRoot}`,
+                pluginRootDisplayPath: externalRoot,
+                basePath: path.join(externalRoot, 'SharedLegacyPlugin')
+            },
+            {
+                name: 'SharedLegacyPlugin',
+                pluginSource: 'core',
+                pluginRootId: 'core:legacy',
+                pluginRootDisplayPath: 'Plugin',
+                basePath: path.join(root, 'core', 'SharedLegacyPlugin')
+            }
+        );
+
+        const logText = warnings.join('\n');
+        assert.match(logText, /duplicate_plugin_name/);
+        assert.match(logText, /SharedLegacyPlugin/);
+        assert.match(logText, /existing core\/core:legacy/);
+        assert.match(logText, /skipped external\/external:/);
+        assert.equal(logText.includes(path.resolve(root)), false);
+        assert.equal(logText.includes(path.resolve(externalRoot)), false);
+        assert.doesNotMatch(logText, /[A-Za-z]:\\/);
+    } finally {
+        console.warn = originalWarn;
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('PluginManager duplicate runtime warning redacts POSIX path-style external root ids', () => {
+    const originalWarn = console.warn;
+    const warnings = [];
+
+    console.warn = (...args) => warnings.push(args.map(String).join(' '));
+
+    try {
+        pluginManager._warnDuplicateLocalPluginSkipped(
+            {
+                name: 'SharedLegacyPlugin',
+                pluginSource: 'external',
+                pluginRootId: 'external:/tmp/vcp-plugin-dirs-ci/external',
+                pluginRootDisplayPath: '/tmp/vcp-plugin-dirs-ci/external',
+                basePath: '/tmp/vcp-plugin-dirs-ci/external/SharedLegacyPlugin'
+            },
+            {
+                name: 'SharedLegacyPlugin',
+                pluginSource: 'core',
+                pluginRootId: 'core:legacy',
+                pluginRootDisplayPath: 'Plugin',
+                basePath: '/tmp/vcp-plugin-dirs-ci/core/SharedLegacyPlugin'
+            }
+        );
+
+        const logText = warnings.join('\n');
+        assert.match(logText, /skipped external\/external:path/);
+        assert.equal(logText.includes('/tmp/vcp-plugin-dirs-ci'), false);
+    } finally {
+        console.warn = originalWarn;
+    }
+});
+
+test('PluginManager discovers duplicate legacy plugin manifests in resolver order', async () => {
+    const root = makeTempDir();
+    const coreRoot = path.join(root, 'core');
+    const externalRoot = path.join(root, 'external');
+    const manifest = {
+        name: 'SharedLegacyPlugin',
+        displayName: 'Shared Legacy Plugin',
+        pluginType: 'synchronous',
+        entryPoint: { command: 'node plugin.js' },
+        communication: { protocol: 'stdio', timeout: 1000 }
+    };
+    writeLegacyManifest(coreRoot, 'SharedLegacyPlugin', manifest);
+    writeLegacyManifest(externalRoot, 'SharedLegacyPlugin', manifest);
+
+    const originalResolver = pluginManager.pluginRootResolver;
+    const originalSnapshot = pluginManager.lastPluginRootSnapshot;
+
+    try {
+        pluginManager.pluginRootResolver = {
+            getPluginRootSnapshot: async () => ({
+                diagnostics: [],
+                legacyLoadRoots: [
+                    {
+                        rootId: 'core:legacy',
+                        source: 'core',
+                        rootPath: coreRoot,
+                        displayPath: 'Plugin',
+                        allowConfigEnv: true
+                    },
+                    {
+                        rootId: 'external:1',
+                        source: 'external',
+                        rootPath: externalRoot,
+                        displayPath: '[external]/plugins',
+                        allowConfigEnv: false
+                    }
+                ]
+            })
+        };
+
+        const manifests = await pluginManager._discoverLegacyPluginManifests();
+
+        assert.equal(manifests.length, 2);
+        assert.equal(manifests[0].name, 'SharedLegacyPlugin');
+        assert.equal(manifests[0].pluginSource, 'core');
+        assert.equal(manifests[0].pluginRootId, 'core:legacy');
+        assert.equal(manifests[1].name, 'SharedLegacyPlugin');
+        assert.equal(manifests[1].pluginSource, 'external');
+        assert.equal(manifests[1].pluginRootId, 'external:1');
+    } finally {
+        pluginManager.pluginRootResolver = originalResolver;
+        pluginManager.lastPluginRootSnapshot = originalSnapshot;
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});

--- a/tests/plugin-external-runtime-direct-policy.test.js
+++ b/tests/plugin-external-runtime-direct-policy.test.js
@@ -1,0 +1,203 @@
+const { after, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const pluginManager = require('../Plugin.js');
+
+after(() => {
+    if (pluginManager.toolApprovalManager && typeof pluginManager.toolApprovalManager.shutdown === 'function') {
+        pluginManager.toolApprovalManager.shutdown();
+    }
+});
+
+function makeTempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'vcp-runtime-direct-policy-'));
+}
+
+function makeExternalManifest(root, overrides = {}) {
+    const name = overrides.name || 'ExternalDirectRuntimeFixture';
+    const pluginDir = path.join(root, name);
+    fs.mkdirSync(pluginDir, { recursive: true });
+    return {
+        name,
+        displayName: name,
+        pluginSource: 'external',
+        pluginRoot: root,
+        pluginRootId: `external:${root}`,
+        pluginRootDisplayPath: root,
+        basePath: pluginDir,
+        pluginType: 'hybridservice',
+        entryPoint: { script: 'direct-fixture.js' },
+        communication: { protocol: 'direct', timeout: 1000 },
+        configSchema: {},
+        ...overrides
+    };
+}
+
+function withPluginManagerState(run) {
+    const originalPlugins = pluginManager.plugins;
+    const originalServiceModules = pluginManager.serviceModules;
+    const originalMessagePreprocessors = pluginManager.messagePreprocessors;
+    const originalAllowlist = process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST;
+    const originalWarn = console.warn;
+    const warnings = [];
+
+    pluginManager.plugins = new Map();
+    pluginManager.serviceModules = new Map();
+    pluginManager.messagePreprocessors = new Map();
+    console.warn = (...args) => {
+        warnings.push(args.map(String).join(' '));
+    };
+
+    return run({ warnings }).finally(() => {
+        pluginManager.plugins = originalPlugins;
+        pluginManager.serviceModules = originalServiceModules;
+        pluginManager.messagePreprocessors = originalMessagePreprocessors;
+        console.warn = originalWarn;
+        if (originalAllowlist === undefined) {
+            delete process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST;
+        } else {
+            process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST = originalAllowlist;
+        }
+    });
+}
+
+test('external direct/hybrid plugins are denied even when allowlist matches', async () => {
+    await withPluginManagerState(async ({ warnings }) => {
+        const root = makeTempDir();
+        try {
+            const manifest = makeExternalManifest(root);
+            process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST = `${manifest.name}@${manifest.pluginRoot}`;
+
+            const registered = await pluginManager._registerLocalPlugin(manifest, new Map(), []);
+
+            assert.equal(registered, false);
+            assert.equal(pluginManager.plugins.has(manifest.name), false);
+            assert.equal(pluginManager.serviceModules.has(manifest.name), false);
+            assert.equal(pluginManager.messagePreprocessors.has(manifest.name), false);
+            const logText = warnings.join('\n');
+            assert.match(logText, /external_direct_runtime_denied|external_hybrid_runtime_denied/);
+            assert.match(logText, /\[external\]/);
+            assert.equal(logText.includes(root), false);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+test('external direct/hybrid with requiresAdmin stays denied', async () => {
+    await withPluginManagerState(async ({ warnings }) => {
+        const root = makeTempDir();
+        try {
+            const manifest = makeExternalManifest(root, { requiresAdmin: true });
+            process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST = `${manifest.name}@${manifest.pluginRoot}`;
+
+            const registered = await pluginManager._registerLocalPlugin(manifest, new Map(), []);
+
+            assert.equal(registered, false);
+            assert.match(warnings.join('\n'), /external_direct_requires_admin_denied/);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+test('denied external direct plugin is not required, initialized, or routed', async () => {
+    await withPluginManagerState(async () => {
+        const root = makeTempDir();
+        const modulesToInitialize = [];
+        const discoveredPreprocessors = new Map();
+
+        try {
+            const manifest = makeExternalManifest(root, {
+                pluginType: 'messagePreprocessor',
+                entryPoint: { script: 'direct-fixture.js' },
+                communication: { protocol: 'direct', timeout: 1000 }
+            });
+            process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST = `${manifest.name}@${manifest.pluginRoot}`;
+            fs.writeFileSync(
+                path.join(manifest.basePath, 'direct-fixture.js'),
+                'throw new Error("direct fixture should never be required");\n',
+                'utf8'
+            );
+
+            const registered = await pluginManager._registerLocalPlugin(manifest, discoveredPreprocessors, modulesToInitialize);
+
+            assert.equal(registered, false);
+            assert.equal(modulesToInitialize.length, 0);
+            assert.equal(discoveredPreprocessors.size, 0);
+            assert.equal(pluginManager.serviceModules.has(manifest.name), false);
+            assert.equal(pluginManager.messagePreprocessors.has(manifest.name), false);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+test('external stdio plugin remains allowed under external allowlist', async () => {
+    await withPluginManagerState(async () => {
+        const root = makeTempDir();
+        try {
+            const manifest = makeExternalManifest(root, {
+                pluginType: 'synchronous',
+                entryPoint: { command: 'node fixture.js' },
+                communication: { protocol: 'stdio', timeout: 1000 },
+                pluginRootDisplayPath: '[external]/direct-policy-stdio'
+            });
+            process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST = `${manifest.name}@${manifest.pluginRoot}`;
+
+            const registered = await pluginManager._registerLocalPlugin(manifest, new Map(), []);
+
+            assert.equal(registered, true);
+            assert.equal(pluginManager.plugins.get(manifest.name), manifest);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+test('core direct/hybrid runtime registration unchanged', async () => {
+    await withPluginManagerState(async () => {
+        const root = makeTempDir();
+        const pluginDir = path.join(root, 'CoreDirectFixture');
+        const fixturePath = path.join(pluginDir, 'direct-fixture.js');
+        const modulesToInitialize = [];
+        const discoveredPreprocessors = new Map();
+        fs.mkdirSync(pluginDir, { recursive: true });
+
+        try {
+            const manifest = {
+                name: 'CoreDirectFixture',
+                displayName: 'Core Direct Fixture',
+                pluginSource: 'legacy',
+                pluginRoot: root,
+                pluginRootId: 'core:legacy',
+                pluginRootDisplayPath: '[core]/Plugin',
+                basePath: pluginDir,
+                pluginType: 'hybridservice',
+                entryPoint: { script: 'direct-fixture.js' },
+                communication: { protocol: 'direct', timeout: 1000 },
+                configSchema: {}
+            };
+
+            fs.writeFileSync(
+                fixturePath,
+                'exports.processMessages = () => ({ called: true });\n' +
+                'exports.processToolCall = () => ({ called: true });\n',
+                'utf8'
+            );
+
+            const registered = await pluginManager._registerLocalPlugin(manifest, discoveredPreprocessors, modulesToInitialize);
+
+            assert.equal(registered, true);
+            assert.equal(pluginManager.plugins.get(manifest.name), manifest);
+            assert.equal(modulesToInitialize.length, 1);
+            assert.equal(discoveredPreprocessors.has(manifest.name), true);
+            assert.equal(pluginManager.serviceModules.has(manifest.name), true);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/plugin-external-runtime-env-sandbox.test.js
+++ b/tests/plugin-external-runtime-env-sandbox.test.js
@@ -1,0 +1,507 @@
+const { after, test } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+
+const pluginManager = require('../Plugin.js');
+const {
+    buildExternalPluginRuntimeEnv,
+    isPluginRuntimeEnvKeyDenied
+} = require('../modules/pluginRuntimeEnvSandbox');
+
+after(() => {
+    if (pluginManager.toolApprovalManager && typeof pluginManager.toolApprovalManager.shutdown === 'function') {
+        pluginManager.toolApprovalManager.shutdown();
+    }
+});
+
+function makeBaseEnv(overrides = {}) {
+    return {
+        PATH: '/usr/bin',
+        Path: 'C:\\Windows\\System32',
+        HOME: '/home/operator',
+        USERPROFILE: 'C:\\Users\\operator',
+        TEMP: 'C:\\Temp',
+        TMP: 'C:\\Tmp',
+        TMPDIR: '/tmp',
+        SystemRoot: 'C:\\Windows',
+        windir: 'C:\\Windows',
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+        NO_COLOR: '1',
+        CI: 'true',
+        AdminPassword: 'admin-secret',
+        Key: 'generic-key',
+        OPENAI_API_KEY: 'openai-secret',
+        GITHUB_TOKEN: 'github-token',
+        GH_TOKEN: 'gh-token',
+        COOKIE: 'cookie-secret',
+        SESSION_TOKEN: 'session-secret',
+        PRIVATE_KEY: 'private-key',
+        CUSTOM_BASE_FLAG: 'drop-me',
+        ...overrides
+    };
+}
+
+function makeExternalPlugin(name, overrides = {}) {
+    return {
+        name,
+        displayName: name,
+        pluginSource: 'external',
+        pluginRootId: 'external:test',
+        pluginRootDisplayPath: '[external]/runtime-env',
+        pluginType: 'synchronous',
+        communication: { protocol: 'stdio', timeout: 1000 },
+        entryPoint: { command: 'node fixture.js' },
+        basePath: __dirname,
+        configSchema: {
+            SAFE_SETTING: 'string',
+            SECRET_TOKEN: 'string',
+            CALLBACK_BASE_URL: 'string'
+        },
+        pluginSpecificEnvConfig: {
+            SAFE_SETTING: 'enabled',
+            SECRET_TOKEN: 'plugin-secret',
+            CALLBACK_BASE_URL: 'https://callback.example.test'
+        },
+        ...overrides
+    };
+}
+
+function makeCorePlugin(name, overrides = {}) {
+    return {
+        ...makeExternalPlugin(name, overrides),
+        pluginSource: 'legacy',
+        pluginRootId: 'core:legacy',
+        pluginRootDisplayPath: '[core]/Plugin'
+    };
+}
+
+function makeFakeChild(stdoutPayload = '', options = {}) {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = {
+        write() {},
+        end() {}
+    };
+    child.kill = () => {};
+    child.stdout.setEncoding = () => {};
+    child.stderr.setEncoding = () => {};
+    process.nextTick(() => {
+        if (options.errorMessage) {
+            child.emit('error', new Error(options.errorMessage));
+            return;
+        }
+        if (stdoutPayload) child.stdout.emit('data', stdoutPayload);
+        if (options.stderrPayload) child.stderr.emit('data', options.stderrPayload);
+        child.emit('exit', options.exitCode ?? 0, options.signal ?? null);
+    });
+    return child;
+}
+
+async function withPluginManagerState(run) {
+    const originalPlugins = pluginManager.plugins;
+    const originalSpawn = pluginManager._spawnPluginProcess;
+    const originalGetDecryptedAuthCode = pluginManager._getDecryptedAuthCode;
+    const originalProjectBasePath = pluginManager.projectBasePath;
+    const originalDebugMode = pluginManager.debugMode;
+    const originalEnv = {
+        PATH: process.env.PATH,
+        CUSTOM_BASE_FLAG: process.env.CUSTOM_BASE_FLAG,
+        OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+        GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+        Key: process.env.Key,
+        PLUGIN_CALLBACK_SECRET: process.env.PLUGIN_CALLBACK_SECRET,
+        PORT: process.env.PORT
+    };
+
+    pluginManager.plugins = new Map();
+    pluginManager.projectBasePath = 'A:\\ProjectBase';
+    process.env.CUSTOM_BASE_FLAG = 'drop-me';
+    process.env.OPENAI_API_KEY = 'openai-secret';
+    process.env.GITHUB_TOKEN = 'github-secret';
+    process.env.Key = 'global-key';
+    process.env.PLUGIN_CALLBACK_SECRET = 'callback-secret';
+    process.env.PORT = '5890';
+
+    try {
+        await run();
+    } finally {
+        pluginManager.plugins = originalPlugins;
+        pluginManager._spawnPluginProcess = originalSpawn;
+        pluginManager._getDecryptedAuthCode = originalGetDecryptedAuthCode;
+        pluginManager.projectBasePath = originalProjectBasePath;
+        pluginManager.debugMode = originalDebugMode;
+        for (const [key, value] of Object.entries(originalEnv)) {
+            if (value === undefined) delete process.env[key];
+            else process.env[key] = value;
+        }
+    }
+}
+
+test('runtime env sandbox preserves operational keys and removes base secrets', () => {
+    const env = buildExternalPluginRuntimeEnv(makeBaseEnv(), {}, {});
+
+    assert.equal(env.PATH, '/usr/bin');
+    assert.equal(env.Path, 'C:\\Windows\\System32');
+    assert.equal(env.HOME, '/home/operator');
+    assert.equal(env.USERPROFILE, 'C:\\Users\\operator');
+    assert.equal(env.TEMP, 'C:\\Temp');
+    assert.equal(env.TMP, 'C:\\Tmp');
+    assert.equal(env.TMPDIR, '/tmp');
+    assert.equal(env.SystemRoot, 'C:\\Windows');
+    assert.equal(env.windir, 'C:\\Windows');
+    assert.equal(env.ComSpec, 'C:\\Windows\\System32\\cmd.exe');
+    assert.equal(env.NO_COLOR, '1');
+    assert.equal(env.CI, 'true');
+
+    assert.equal(Object.prototype.hasOwnProperty.call(env, 'CUSTOM_BASE_FLAG'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(env, 'OPENAI_API_KEY'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(env, 'GITHUB_TOKEN'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(env, 'Key'), false);
+});
+
+test('runtime env sandbox filters plugin config and runtime injected secrets', () => {
+    const env = buildExternalPluginRuntimeEnv(
+        makeBaseEnv(),
+        {
+            SAFE_SETTING: 'enabled',
+            SECRET_TOKEN: 'plugin-secret',
+            API_KEY: 'plugin-api-key'
+        },
+        {
+            PROJECT_BASE_PATH: 'A:\\ProjectBase',
+            SERVER_PORT: '5890',
+            VCP_REQUEST_SOURCE: 'node-test',
+            PYTHONIOENCODING: 'utf-8',
+            DECRYPTED_AUTH_CODE: 'auth-secret',
+            IMAGESERVER_IMAGE_KEY: 'image-secret',
+            SSH_MANAGER_TOKEN: 'ssh-secret'
+        }
+    );
+
+    assert.equal(env.SAFE_SETTING, 'enabled');
+    assert.equal(env.PROJECT_BASE_PATH, 'A:\\ProjectBase');
+    assert.equal(env.SERVER_PORT, '5890');
+    assert.equal(env.VCP_REQUEST_SOURCE, 'node-test');
+    assert.equal(env.PYTHONIOENCODING, 'utf-8');
+    assert.equal(Object.prototype.hasOwnProperty.call(env, 'SECRET_TOKEN'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(env, 'API_KEY'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(env, 'DECRYPTED_AUTH_CODE'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(env, 'IMAGESERVER_IMAGE_KEY'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(env, 'SSH_MANAGER_TOKEN'), false);
+});
+
+test('runtime env deny matcher covers secret-like names', () => {
+    for (const key of ['AdminPassword', 'OPENAI_API_KEY', 'SESSION_TOKEN', 'PRIVATE_KEY', 'DECRYPTED_AUTH_CODE']) {
+        assert.equal(isPluginRuntimeEnvKeyDenied(key), true, `${key} should be denied`);
+    }
+    assert.equal(isPluginRuntimeEnvKeyDenied('SAFE_SETTING'), false);
+});
+
+test('external stdio plugin spawn receives sanitized env', async () => {
+    await withPluginManagerState(async () => {
+        const pluginName = 'ExternalRuntimeEnvFixture';
+        const plugin = makeExternalPlugin(pluginName);
+        let spawnCall = null;
+
+        pluginManager.plugins.set(pluginName, plugin);
+        pluginManager._spawnPluginProcess = (command, args, options) => {
+            spawnCall = { command, args, options };
+            return makeFakeChild('{"status":"success","result":"ok"}\n');
+        };
+
+        const result = await pluginManager.executePlugin(pluginName, '{}', '127.0.0.1', {
+            requestSource: 'node-test',
+            agentAlias: 'agent-a'
+        });
+
+        assert.equal(result.status, 'success');
+        assert.ok(spawnCall);
+        assert.equal(spawnCall.options.env.SAFE_SETTING, 'enabled');
+        assert.equal(spawnCall.options.env.CALLBACK_BASE_URL, 'https://callback.example.test');
+        assert.equal(spawnCall.options.env.PROJECT_BASE_PATH, 'A:\\ProjectBase');
+        assert.equal(spawnCall.options.env.SERVER_PORT, '5890');
+        assert.equal(spawnCall.options.env.VCP_REQUEST_IP, '127.0.0.1');
+        assert.equal(spawnCall.options.env.VCP_REQUEST_SOURCE, 'node-test');
+        assert.equal(spawnCall.options.env.VCP_AGENT_ALIAS, 'agent-a');
+        assert.equal(spawnCall.options.env.PYTHONIOENCODING, 'utf-8');
+        assert.equal(Object.prototype.hasOwnProperty.call(spawnCall.options.env, 'OPENAI_API_KEY'), false);
+        assert.equal(Object.prototype.hasOwnProperty.call(spawnCall.options.env, 'GITHUB_TOKEN'), false);
+        assert.equal(Object.prototype.hasOwnProperty.call(spawnCall.options.env, 'Key'), false);
+        assert.equal(Object.prototype.hasOwnProperty.call(spawnCall.options.env, 'SECRET_TOKEN'), false);
+    });
+});
+
+test('external async plugin keeps configured callback base without inheriting base secrets', async () => {
+    await withPluginManagerState(async () => {
+        const pluginName = 'ExternalAsyncRuntimeEnvFixture';
+        const plugin = makeExternalPlugin(pluginName, {
+            pluginType: 'asynchronous'
+        });
+        let spawnCall = null;
+
+        pluginManager.plugins.set(pluginName, plugin);
+        pluginManager._spawnPluginProcess = (command, args, options) => {
+            spawnCall = { command, args, options };
+            return makeFakeChild('{"status":"success","result":"ok"}\n');
+        };
+
+        const result = await pluginManager.executePlugin(pluginName, '{"requestId":"async-req-1"}');
+
+        assert.equal(result.status, 'success');
+        assert.ok(spawnCall);
+        assert.equal(spawnCall.options.env.CALLBACK_BASE_URL, 'https://callback.example.test');
+        assert.equal(spawnCall.options.env.PLUGIN_NAME_FOR_CALLBACK, pluginName);
+        assert.equal(Object.prototype.hasOwnProperty.call(spawnCall.options.env, 'CALLBACK_AUTH_SECRET'), false);
+        assert.equal(Object.prototype.hasOwnProperty.call(spawnCall.options.env, 'PLUGIN_CALLBACK_URL'), false);
+        assert.equal(Object.prototype.hasOwnProperty.call(spawnCall.options.env, 'Key'), false);
+    });
+});
+
+test('external static plugin spawn receives sanitized env', async () => {
+    await withPluginManagerState(async () => {
+        const plugin = makeExternalPlugin('ExternalStaticRuntimeEnvFixture', {
+            pluginType: 'static',
+            entryPoint: { command: 'node static-fixture.js' }
+        });
+        let spawnCall = null;
+
+        pluginManager._spawnPluginProcess = (command, args, options) => {
+            spawnCall = { command, args, options };
+            return makeFakeChild('static output');
+        };
+
+        const output = await pluginManager._executeStaticPluginCommand(plugin);
+
+        assert.equal(output, 'static output');
+        assert.ok(spawnCall);
+        assert.equal(spawnCall.options.env.SAFE_SETTING, 'enabled');
+        assert.equal(spawnCall.options.env.PROJECT_BASE_PATH, 'A:\\ProjectBase');
+        assert.equal(Object.prototype.hasOwnProperty.call(spawnCall.options.env, 'OPENAI_API_KEY'), false);
+        assert.equal(Object.prototype.hasOwnProperty.call(spawnCall.options.env, 'SECRET_TOKEN'), false);
+    });
+});
+
+test('core stdio plugin keeps legacy full process env behavior', async () => {
+    await withPluginManagerState(async () => {
+        const pluginName = 'CoreRuntimeEnvFixture';
+        const plugin = makeCorePlugin(pluginName);
+        let spawnCall = null;
+
+        pluginManager.plugins.set(pluginName, plugin);
+        pluginManager._spawnPluginProcess = (command, args, options) => {
+            spawnCall = { command, args, options };
+            return makeFakeChild('{"status":"success","result":"ok"}\n');
+        };
+
+        const result = await pluginManager.executePlugin(pluginName, '{}');
+
+        assert.equal(result.status, 'success');
+        assert.ok(spawnCall);
+        assert.equal(spawnCall.options.env.OPENAI_API_KEY, 'openai-secret');
+        assert.equal(spawnCall.options.env.GITHUB_TOKEN, 'github-secret');
+        assert.equal(spawnCall.options.env.Key, 'global-key');
+        assert.equal(spawnCall.options.env.SECRET_TOKEN, 'plugin-secret');
+    });
+});
+
+test('core async plugin debug log never prints runtime env secret values', async () => {
+    await withPluginManagerState(async () => {
+        const pluginName = 'CoreAsyncRuntimeEnvFixture';
+        const plugin = makeCorePlugin(pluginName, { pluginType: 'asynchronous' });
+        const logs = [];
+        const originalLog = console.log;
+
+        pluginManager.debugMode = true;
+        pluginManager.plugins.set(pluginName, plugin);
+        pluginManager._spawnPluginProcess = () => makeFakeChild('{"status":"success","result":"ok"}\n');
+        console.log = (...args) => logs.push(args.map(arg => String(arg)).join(' '));
+
+        try {
+            const result = await pluginManager.executePlugin(pluginName, '{}');
+            assert.equal(result.status, 'success');
+        } finally {
+            console.log = originalLog;
+        }
+
+        const logText = logs.join('\n');
+        assert.match(logText, /Core async plugin CoreAsyncRuntimeEnvFixture runtime env keys:/);
+        assert.doesNotMatch(logText, /Final ENV/);
+        for (const forbidden of [
+            'openai-secret',
+            'github-secret',
+            'global-key',
+            'plugin-secret',
+            'OPENAI_API_KEY',
+            'GITHUB_TOKEN',
+            'SECRET_TOKEN'
+        ]) {
+            assert.equal(logText.includes(forbidden), false, `${forbidden} should not be logged`);
+        }
+        assert.match(logText, /redacted \d+ sensitive keys/);
+    });
+});
+
+test('stdio plugin diagnostic errors and debug logs scrub secrets and paths', async () => {
+    await withPluginManagerState(async () => {
+        const pluginName = 'CoreRuntimeDiagnosticFixture';
+        const plugin = makeCorePlugin(pluginName);
+        const logs = [];
+        const warnings = [];
+        const originalLog = console.log;
+        const originalWarn = console.warn;
+
+        pluginManager.debugMode = true;
+        pluginManager.plugins.set(pluginName, plugin);
+        pluginManager._spawnPluginProcess = () => makeFakeChild(
+            'not json token=stdout-secret A:\\private\\stdout.txt',
+            {
+                stderrPayload: 'api_key=stderr-secret /home/operator/stderr.txt',
+                exitCode: 1
+            }
+        );
+        console.log = (...args) => logs.push(args.map(arg => String(arg)).join(' '));
+        console.warn = (...args) => warnings.push(args.map(arg => String(arg)).join(' '));
+
+        try {
+            await assert.rejects(
+                () => pluginManager.executePlugin(pluginName, '{}'),
+                (error) => {
+                    assert.match(error.message, /exited with code 1/);
+                    assert.match(error.message, /token=\[redacted\]/);
+                    assert.match(error.message, /api_key=\[redacted\]/);
+                    assert.equal(error.message.includes('stdout-secret'), false);
+                    assert.equal(error.message.includes('stderr-secret'), false);
+                    assert.equal(error.message.includes('A:\\private'), false);
+                    assert.equal(error.message.includes('/home/operator'), false);
+                    return true;
+                }
+            );
+        } finally {
+            console.log = originalLog;
+            console.warn = originalWarn;
+        }
+
+        const diagnosticText = `${logs.join('\n')}\n${warnings.join('\n')}`;
+        assert.equal(diagnosticText.includes('stdout-secret'), false);
+        assert.equal(diagnosticText.includes('stderr-secret'), false);
+        assert.equal(diagnosticText.includes('A:\\private'), false);
+        assert.equal(diagnosticText.includes('/home/operator'), false);
+        assert.match(diagnosticText, /token=\[redacted\]/);
+        assert.match(diagnosticText, /api_key=\[redacted\]/);
+    });
+});
+
+test('stdio plugin startup errors scrub secrets and paths', async () => {
+    await withPluginManagerState(async () => {
+        const pluginName = 'CoreRuntimeStartupErrorFixture';
+        const plugin = makeCorePlugin(pluginName);
+
+        pluginManager.plugins.set(pluginName, plugin);
+        pluginManager._spawnPluginProcess = () => makeFakeChild('', {
+            errorMessage: 'spawn failed token=start-secret A:\\private\\spawn.exe'
+        });
+
+        await assert.rejects(
+            () => pluginManager.executePlugin(pluginName, '{}'),
+            (error) => {
+                assert.match(error.message, /Failed to start plugin/);
+                assert.match(error.message, /token=\[redacted\]/);
+                assert.equal(error.message.includes('start-secret'), false);
+                assert.equal(error.message.includes('A:\\private'), false);
+                return true;
+            }
+        );
+    });
+});
+
+test('static plugin stderr diagnostics scrub secrets and paths', async () => {
+    await withPluginManagerState(async () => {
+        const plugin = makeExternalPlugin('ExternalStaticDiagnosticFixture', {
+            pluginType: 'static',
+            entryPoint: { command: 'node static-fixture.js' }
+        });
+        const errors = [];
+        const originalError = console.error;
+
+        pluginManager._spawnPluginProcess = () => makeFakeChild('', {
+            stderrPayload: 'password=static-secret C:\\private\\static.txt',
+            exitCode: 1
+        });
+        console.error = (...args) => errors.push(args.map(arg => String(arg)).join(' '));
+
+        try {
+            await assert.rejects(
+                () => pluginManager._executeStaticPluginCommand(plugin),
+                (error) => {
+                    assert.match(error.message, /password=\[redacted\]/);
+                    assert.equal(error.message.includes('static-secret'), false);
+                    assert.equal(error.message.includes('C:\\private'), false);
+                    return true;
+                }
+            );
+        } finally {
+            console.error = originalError;
+        }
+
+        const errorText = errors.join('\n');
+        assert.match(errorText, /password=\[redacted\]/);
+        assert.equal(errorText.includes('static-secret'), false);
+        assert.equal(errorText.includes('C:\\private'), false);
+    });
+});
+
+test('static plugin startup errors scrub secrets and paths', async () => {
+    await withPluginManagerState(async () => {
+        const plugin = makeExternalPlugin('ExternalStaticStartupErrorFixture', {
+            pluginType: 'static',
+            entryPoint: { command: 'node static-fixture.js' }
+        });
+        const errors = [];
+        const originalError = console.error;
+
+        pluginManager._spawnPluginProcess = () => makeFakeChild('', {
+            errorMessage: 'spawn failed secret=static-start-secret C:\\private\\static.exe'
+        });
+        console.error = (...args) => errors.push(args.map(arg => String(arg)).join(' '));
+
+        try {
+            await assert.rejects(
+                () => pluginManager._executeStaticPluginCommand(plugin),
+                (error) => {
+                    assert.match(error.message, /secret=\[redacted\]/);
+                    assert.equal(error.message.includes('static-start-secret'), false);
+                    assert.equal(error.message.includes('C:\\private'), false);
+                    return true;
+                }
+            );
+        } finally {
+            console.error = originalError;
+        }
+
+        const errorText = errors.join('\n');
+        assert.match(errorText, /secret=\[redacted\]/);
+        assert.equal(errorText.includes('static-start-secret'), false);
+        assert.equal(errorText.includes('C:\\private'), false);
+    });
+});
+
+test('external admin-required stdio plugin is denied before auth env injection', async () => {
+    await withPluginManagerState(async () => {
+        const pluginName = 'ExternalAdminRuntimeEnvFixture';
+        const plugin = makeExternalPlugin(pluginName, { requiresAdmin: true });
+        let authRead = false;
+
+        pluginManager.plugins.set(pluginName, plugin);
+        pluginManager._getDecryptedAuthCode = async () => {
+            authRead = true;
+            return 'auth-secret';
+        };
+
+        await assert.rejects(
+            () => pluginManager.executePlugin(pluginName, '{}'),
+            /cannot receive admin authentication/
+        );
+        assert.equal(authRead, false);
+    });
+});

--- a/tests/plugin-external-runtime-registration-gate.test.js
+++ b/tests/plugin-external-runtime-registration-gate.test.js
@@ -1,0 +1,205 @@
+const { after, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const pluginManager = require('../Plugin.js');
+
+after(() => {
+    if (pluginManager.toolApprovalManager && typeof pluginManager.toolApprovalManager.shutdown === 'function') {
+        pluginManager.toolApprovalManager.shutdown();
+    }
+});
+
+function makeTempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'vcp-runtime-gate-'));
+}
+
+function makeExternalManifest(root, overrides = {}) {
+    const name = overrides.name || 'ExternalRuntimeFixture';
+    const pluginDir = path.join(root, name);
+    fs.mkdirSync(pluginDir, { recursive: true });
+    return {
+        name,
+        displayName: name,
+        pluginSource: 'external',
+        pluginRoot: root,
+        pluginRootId: 'external:test',
+        pluginRootDisplayPath: '[external]/runtime-gate',
+        basePath: pluginDir,
+        pluginType: 'synchronous',
+        entryPoint: { command: 'node fixture.js' },
+        communication: { protocol: 'stdio', timeout: 1000 },
+        configSchema: {},
+        ...overrides
+    };
+}
+
+async function withPluginManagerState(run) {
+    const originalPlugins = pluginManager.plugins;
+    const originalServiceModules = pluginManager.serviceModules;
+    const originalMessagePreprocessors = pluginManager.messagePreprocessors;
+    const originalAllowlist = process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST;
+    const originalWarn = console.warn;
+    const warnings = [];
+
+    pluginManager.plugins = new Map();
+    pluginManager.serviceModules = new Map();
+    pluginManager.messagePreprocessors = new Map();
+    console.warn = (...args) => {
+        warnings.push(args.map(String).join(' '));
+    };
+
+    try {
+        delete process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST;
+        await run({ warnings });
+    } finally {
+        pluginManager.plugins = originalPlugins;
+        pluginManager.serviceModules = originalServiceModules;
+        pluginManager.messagePreprocessors = originalMessagePreprocessors;
+        console.warn = originalWarn;
+        if (originalAllowlist === undefined) {
+            delete process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST;
+        } else {
+            process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST = originalAllowlist;
+        }
+    }
+}
+
+test('external plugin discovery does not imply runtime registration without allowlist', async () => {
+    await withPluginManagerState(async ({ warnings }) => {
+        const root = makeTempDir();
+        try {
+            const manifest = makeExternalManifest(root, {
+                pluginRootId: `external:${root}`,
+                pluginRootDisplayPath: root
+            });
+            const registered = await pluginManager._registerLocalPlugin(manifest, new Map(), []);
+
+            assert.equal(registered, false);
+            assert.equal(pluginManager.plugins.has(manifest.name), false);
+            assert.match(warnings.join('\n'), /external_runtime_allowlist_required/);
+            assert.equal(warnings.join('\n').includes(root), false);
+            assert.match(warnings.join('\n'), /\[external\]/);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+test('explicit name and source root policy allows external stdio registration', async () => {
+    await withPluginManagerState(async () => {
+        const root = makeTempDir();
+        try {
+            const manifest = makeExternalManifest(root);
+            process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST = `${manifest.name}@${root}`;
+
+            const registered = await pluginManager._registerLocalPlugin(manifest, new Map(), []);
+
+            assert.equal(registered, true);
+            assert.equal(pluginManager.plugins.get(manifest.name), manifest);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+test('name-only and path-only policies do not register external plugin', async () => {
+    await withPluginManagerState(async ({ warnings }) => {
+        const root = makeTempDir();
+        try {
+            const manifest = makeExternalManifest(root);
+
+            process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST = manifest.name;
+            assert.equal(await pluginManager._registerLocalPlugin(manifest, new Map(), []), false);
+            assert.equal(pluginManager.plugins.has(manifest.name), false);
+
+            process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST = root;
+            assert.equal(await pluginManager._registerLocalPlugin(manifest, new Map(), []), false);
+            assert.equal(pluginManager.plugins.has(manifest.name), false);
+
+            assert.match(warnings.join('\n'), /external_runtime_invalid_policy/);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+test('external same-name plugin cannot override an existing core plugin', async () => {
+    await withPluginManagerState(async ({ warnings }) => {
+        const root = makeTempDir();
+        try {
+            const coreManifest = {
+                name: 'CoreNameFixture',
+                displayName: 'Core Name Fixture',
+                pluginSource: 'legacy',
+                pluginType: 'synchronous',
+                entryPoint: { command: 'node core.js' },
+                communication: { protocol: 'stdio' },
+                basePath: path.join(__dirname, '..', 'Plugin', 'CoreNameFixture')
+            };
+            pluginManager.plugins.set(coreManifest.name, coreManifest);
+
+            const externalManifest = makeExternalManifest(root, { name: coreManifest.name });
+            process.env.VCP_EXTERNAL_PLUGIN_ALLOWLIST = `${externalManifest.name}@${root}`;
+
+            const registered = await pluginManager._registerLocalPlugin(externalManifest, new Map(), []);
+
+            assert.equal(registered, false);
+            assert.equal(pluginManager.plugins.get(coreManifest.name), coreManifest);
+            assert.match(warnings.join('\n'), /external_runtime_duplicate_core_name/);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+test('blocked external direct plugin is not required during registration', async () => {
+    await withPluginManagerState(async () => {
+        const root = makeTempDir();
+        try {
+            const manifest = makeExternalManifest(root, {
+                name: 'ExternalDirectFixture',
+                pluginType: 'hybridservice',
+                entryPoint: { script: 'direct-fixture.js' },
+                communication: { protocol: 'direct', timeout: 1000 }
+            });
+            fs.writeFileSync(
+                path.join(manifest.basePath, 'direct-fixture.js'),
+                'throw new Error("direct fixture should not be required");\n',
+                'utf8'
+            );
+
+            const registered = await pluginManager._registerLocalPlugin(manifest, new Map(), []);
+
+            assert.equal(registered, false);
+            assert.equal(pluginManager.plugins.has(manifest.name), false);
+            assert.equal(pluginManager.serviceModules.has(manifest.name), false);
+            assert.equal(pluginManager.messagePreprocessors.has(manifest.name), false);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+test('core plugin registration remains unchanged by external runtime gate', async () => {
+    await withPluginManagerState(async () => {
+        const root = makeTempDir();
+        try {
+            const manifest = {
+                ...makeExternalManifest(root, { name: 'CoreRuntimeFixture' }),
+                pluginSource: 'legacy',
+                pluginRootId: 'core:legacy',
+                pluginRootDisplayPath: '[core]/Plugin'
+            };
+
+            const registered = await pluginManager._registerLocalPlugin(manifest, new Map(), []);
+
+            assert.equal(registered, true);
+            assert.equal(pluginManager.plugins.get(manifest.name), manifest);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Add the Phase 1 clean-core external plugin root resolver and required allowed-root contract gate.
- Add runtime registration allowlist, external plugin safety classification, and env sandbox modules.
- Wire the narrow `Plugin.js` discovery/registration/env integration path without enabling Jenn runtime or changing execution dispatch.

## Validation
- Server Node runtime: `/mnt/datadisk0/apps/AGENTS_OS_Workspace/tools/nodejs/current`, Node `v22.23.0`.
- Syntax checks passed: `node --check Plugin.js` and the four new module files.
- PR-preflight targeted test command passed on the server: 6 files, 61 pass / 0 fail.

## Notes
- No service was started.
- No env, secret, config, runtime state, cache, or debug files are included.
- Direct push from the server to upstream was unavailable over HTTPS; this PR is opened from the `JENN2046` fork branch.