### PR TITLE
fix(LinuxShellExecutor): 移除 getUlimitPrefix() 中的全局 -u nproc 进程数限制

### DIFF
--- a/Plugin/LinuxShellExecutor/LinuxShellExecutor.js
+++ b/Plugin/LinuxShellExecutor/LinuxShellExecutor.js
@@ -1559,13 +1559,14 @@ class RlimitManager {
         // ulimit 参数说明：
         // -t: CPU 时间（秒）
         // -f: 文件大小（块，1块=512字节，所以需要除以512）
-        // -u: 用户进程数
         // -n: 文件描述符数
         // -v: 虚拟内存（KB）
+        // 注意：不设置 -u (nproc)。ulimit -u 限制的是当前用户的全局进程数，
+        // 当 VCP 系统已运行大量进程时（通常 100+），设为 10 会导致所有后续
+        // fork() 立即失败，报 "Resource temporarily unavailable"。
         const parts = [
             `-t ${this.limits.cpu}`,
             `-f ${Math.floor(this.limits.fsize / 512)}`,
-            `-u ${this.limits.nproc}`,
             `-n ${this.limits.nofile}`,
             `-v ${Math.floor(this.limits.as / 1024)}`
         ];


### PR DESCRIPTION
## 问题描述

`getUlimitPrefix()` 中包含 `ulimit -u ${RLIMIT_NPROC}`（默认值 10）。

`ulimit -u` 设置的是**当前 Linux 用户的全局进程数上限**，而非单次命令的子进程数。当 VCP 系统已运行 100+ 个进程时，执行 `ulimit -u 10` 会导致该用户所有后续 `fork()` 立即失败：

```
fork: retry: Resource temporarily unavailable
```

此时 LinuxShellExecutor 的所有命令完全不可用，且错误信息与参数配置无关，极难定位根因。

## 修复

从 `getUlimitPrefix()` 的 `parts` 数组中移除 `` -u ${this.limits.nproc} `` 一项，并补充解释注释。

其余四项限制（`-t` cpu / `-f` fsize / `-n` nofile / `-v` as）保持不变。

## 变更范围

- **修改文件**：`Plugin/LinuxShellExecutor/LinuxShellExecutor.js`
- **修改行数**：3 行（删 1 行废注释 + 1 行 ulimit 参数，加 3 行解释注释）
- **无破坏性变更**

## 备注

若需限制子进程数量，应改用 cgroup，而非 `ulimit -u`（后者是用户级全局限制，影响范围远超预期）。