### PR TITLE
fix(LinuxShellExecutor): quote-aware pipe/redirect detection in security layer

### DIFF
--- a/Plugin/LinuxShellExecutor/LinuxShellExecutor.js
+++ b/Plugin/LinuxShellExecutor/LinuxShellExecutor.js
@@ -882,6 +882,52 @@ class SecurityLevelValidator {
         this.globalSettings = config.globalSettings || {};}
     
     /**
+     * Strip quoted content for safe pattern matching.
+     * Replaces characters inside single/double quotes with underscores so that
+     * pipe symbols (|), redirects (><), etc. inside quoted strings do not
+     * trigger false positives in security checks.
+     * Example: grep "Error:|init" f.log  =>  grep "_________" f.log
+     */
+    _stripQuotedContent(str) {
+        let result = '';
+        let inSingle = false;
+        let inDouble = false;
+        let escaped = false;
+        for (let i = 0; i < str.length; i++) {
+            const c = str[i];
+            if (escaped) { result += '_'; escaped = false; continue; }
+            if (c === '\\' && (inSingle || inDouble)) { result += '_'; escaped = true; continue; }
+            if (c === "'" && !inDouble) { inSingle = !inSingle; result += c; continue; }
+            if (c === '"' && !inSingle) { inDouble = !inDouble; result += c; continue; }
+            result += (inSingle || inDouble) ? '_' : c;
+        }
+        return result;
+    }
+
+    /**
+     * Split a string by delimiter while respecting single/double-quoted sections.
+     * Prevents grep "a|b" from being split into two segments at the | inside quotes.
+     */
+    _splitUnquoted(str, delimiter) {
+        const parts = [];
+        let current = '';
+        let inSingle = false;
+        let inDouble = false;
+        let escaped = false;
+        for (let i = 0; i < str.length; i++) {
+            const c = str[i];
+            if (escaped) { current += c; escaped = false; continue; }
+            if (c === '\\' && (inSingle || inDouble)) { current += c; escaped = true; continue; }
+            if (c === "'" && !inDouble) { inSingle = !inSingle; current += c; continue; }
+            if (c === '"' && !inSingle) { inDouble = !inDouble; current += c; continue; }
+            if (!inSingle && !inDouble && c === delimiter) { parts.push(current); current = ''; continue; }
+            current += c;
+        }
+        parts.push(current);
+        return parts;
+    }
+
+    /**
      * 获取命令的安全级别
      */
     getCommandLevel(command) {
@@ -930,9 +976,12 @@ class SecurityLevelValidator {
             }
         }
 
-        const hasRedirect = /[><]/.test(command);
-        const hasPipe = command.includes('|');
-        let segments = hasPipe ? command.split('|').map(s => s.trim()).filter(s => s.length > 0) : [command.trim()];
+        // Quote-aware pipe/redirect detection: ignore | and > inside quoted strings
+        // e.g. grep "Error:|Warning:" file.log should NOT be treated as a pipeline
+        const strippedForOp = this._stripQuotedContent(command);
+        const hasRedirect = /[><]/.test(strippedForOp);
+        const hasPipe = strippedForOp.includes('|');
+        let segments = hasPipe ? this._splitUnquoted(command, '|').map(s => s.trim()).filter(s => s.length > 0) : [command.trim()];
         
         let highestRiskLevel = 'read';
         const levelPriority = { 'read': 0, 'safe': 1, 'write': 2, 'danger': 3, 'unknown': 4 };


### PR DESCRIPTION
## Problem

The security layer in `SecurityLevelValidator.validate()` splits commands on `|` (pipe) and checks for `>`/`<` (redirect) using naive string operations. This causes commands with quoted grep patterns to be incorrectly flagged as piped/redirected commands.

**Example that fails without this fix:**
```bash
grep "Error:|Warning:" /var/log/app.log
```
Rejected with: *命令 "Warning:" 不在任何安全级别中* — because the `|` inside the double-quoted argument was treated as a shell pipe operator, splitting the command into two segments.

## Root Cause

In `validate()`:
```js
const hasPipe = command.includes('|');          // naive: can't tell quoted | from real pipe
let segments = hasPipe ? command.split('|')...  // naive: splits inside quoted strings too
```

## Fix

Add two helper methods to `SecurityLevelValidator`:

- **`_stripQuotedContent(str)`** — replaces all characters inside single/double quotes with underscores before running operator checks. Handles backslash escapes inside quotes.
- **`_splitUnquoted(str, delimiter)`** — splits by a delimiter while ignoring delimiter occurrences inside quoted strings.

Use these in `validate()` so `hasRedirect`, `hasPipe`, and segment-splitting all use the quote-stripped version of the command. The original command string is still passed to `getCommandLevel()` so arguments remain intact.

## Impact

- Commands with quoted grep/awk patterns no longer cause false-positive security rejections.
- Actual shell pipes between commands (e.g. `ps aux | grep nginx`) continue to work correctly.
- No behavior change for commands that do not use quotes around operator characters.
