### PR TITLE
fix(LinuxShellExecutor): fix RLIMIT_AS/NOFILE defaults causing Node.js V8 OOM

### DIFF
--- a/Plugin/LinuxShellExecutor/LinuxShellExecutor.js
+++ b/Plugin/LinuxShellExecutor/LinuxShellExecutor.js
@@ -1540,8 +1540,8 @@ class RlimitManager {
             cpu: parseInt(process.env.RLIMIT_CPU) || 30,           // CPU 时间（秒）
             fsize: parseInt(process.env.RLIMIT_FSIZE) || 10485760, // 文件大小（字节，10MB）
             nproc: parseInt(process.env.RLIMIT_NPROC) || 10,       // 最大进程数
-            nofile: parseInt(process.env.RLIMIT_NOFILE) || 64,     // 最大文件描述符
-            as: parseInt(process.env.RLIMIT_AS) || 536870912       // 虚拟内存（字节，512MB）
+            nofile: parseInt(process.env.RLIMIT_NOFILE) || 0,      // 最大文件描述符（0=继承系统默认，通常为1024）
+            as: parseInt(process.env.RLIMIT_AS) || 0               // 虚拟内存（0=不限制；512MB 默认值会导致 Node.js V8 OOM）
         };
         
         this.enabled = process.env.ENABLE_RLIMIT !== 'false';
@@ -1565,10 +1565,17 @@ class RlimitManager {
         const parts = [
             `-t ${this.limits.cpu}`,
             `-f ${Math.floor(this.limits.fsize / 512)}`,
-            `-u ${this.limits.nproc}`,
-            `-n ${this.limits.nofile}`,
-            `-v ${Math.floor(this.limits.as / 1024)}`
+            `-u ${this.limits.nproc}`
         ];
+        // nofile=0 → 继承父进程限制（系统默认通常为1024）
+        if (this.limits.nofile > 0) {
+            parts.push(`-n ${this.limits.nofile}`);
+        }
+        // as=0 → 不限制虚拟内存。Node.js V8 启动需要约 4GB 虚拟地址空间，
+        // 512MB 默认值会触发 "Fatal process out of memory: SegmentedTable::InitializeTable"
+        if (this.limits.as > 0) {
+            parts.push(`-v ${Math.floor(this.limits.as / 1024)}`);
+        }
         
         return `ulimit ${parts.join(' ')} 2>/dev/null; `;
     }

--- a/Plugin/LinuxShellExecutor/plugin-manifest.json
+++ b/Plugin/LinuxShellExecutor/plugin-manifest.json
@@ -1,29 +1,33 @@
 {
-    "manifestVersion": "1.0.0",
-    "name": "LinuxShellExecutor",
-    "version": "1.2.0",
-    "displayName": "Linux Shell 安全执行器",
-    "description": "六层安全防护的 Linux Shell 命令执行器。支持多发行版静默安装、异步任务托管、交互阻塞探测及跨插件联动监控。",
-    "author": "VCP Team",
-    "pluginType": "hybridservice",
-    "requiresAdmin": true,
-    "entryPoint": {
-        "type": "nodejs",
-        "script": "LinuxShellExecutor.js",
-        "command": "node LinuxShellExecutor.js"
-    },
-    "communication": {
-        "protocol": "direct",
-        "timeout": 60000
-    },
-    "dependencies": {
-        "npm": ["ssh2", "dotenv"]
-    },
-    "capabilities": {
-        "invocationCommands": [
-            {
-                "commandIdentifier": "LinuxShellExecutor",
-                "description": "在安全沙箱中执行 Linux Shell 命令，支持本地和远程 SSH 执行。\n\n🆕 v1.1.7 审计加固版:\n- 异步闭环：修复 isLongRunning 逻辑，确保 yum/apt/tail 等指令真实托管。\n- 资产引导修复：修正 Discovery 状态透传，引导 hostId 自动发现。\n- 安全逃逸支持：授权码 (authCode) 可绕过白名单及安全层级限制。\n- 鲁棒性增强：新增特殊操作符 (; && |) 校验及全局 1MB/5MB 输出截断防护。\n\n参数:\n- command (字符串, 必需): 要执行的 Shell 命令，或 preset:预设名?参数 格式。\n- hostId (字符串, 可选): 目标主机ID，默认 'local'。\n- isLongRunning (布尔, 可选): 是否为长待机指令，设为 true 时任务将转入后台并返回 taskId。\n- requireAdmin (字符串, 可选): 管理员验证码/授权码。用于 write/danger 级别确认，或强制执行不在白名单内的命令。\n- timeout (数字, 可选): 超时时间（毫秒）。\n- outputFormat (字符串, 可选): 输出格式 'raw'|'formatted'|'json'。\n\n授权码执行示例:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\ncommand:「始」unknown-tool --args「末」,\nrequireAdmin:「始」123456「末」\n<<<[END_TOOL_REQUEST]>>>\n\n长待机指令调用:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\ncommand:「始」yum install -y nginx「末」,\nisLongRunning:「始」true「末」\n<<<[END_TOOL_REQUEST]>>>\n\n列出主机列表:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\naction:「始」listHosts「末」\n<<<[END_TOOL_REQUEST]>>>"}
-        ]
-    }
+  "manifestVersion": "1.0.0",
+  "name": "LinuxShellExecutor",
+  "version": "1.2.0",
+  "displayName": "Linux Shell 安全执行器",
+  "description": "六层安全防护的 Linux Shell 命令执行器。支持多发行版静默安装、异步任务托管、交互阻塞探测及跨插件联动监控。",
+  "author": "VCP Team",
+  "pluginType": "hybridservice",
+  "requiresAdmin": true,
+  "entryPoint": {
+    "type": "nodejs",
+    "script": "LinuxShellExecutor.js",
+    "command": "node LinuxShellExecutor.js"
+  },
+  "communication": {
+    "protocol": "direct",
+    "timeout": 60000
+  },
+  "dependencies": {
+    "npm": [
+      "ssh2",
+      "dotenv"
+    ]
+  },
+  "capabilities": {
+    "invocationCommands": [
+      {
+        "commandIdentifier": "LinuxShellExecutor",
+        "description": "在安全沙箱中执行 Linux Shell 命令，支持本地和远程 SSH 执行。\n\n🆕 v1.1.7 审计加固版:\n- 异步闭环：修复 isLongRunning 逻辑，确保 yum/apt/tail 等指令真实托管。\n- 资产引导修复：修正 Discovery 状态透传，引导 hostId 自动发现。\n- 安全逃逸支持：授权码 (authCode) 可绕过白名单及安全层级限制。\n- 鲁棒性增强：分号(;)被安全层禁止，请改用 && 进行命令链式执行；管道(|)正常支持；全局输出截断防护。\n\n参数:\n- command (字符串, 必需): 要执行的 Shell 命令，或 preset:预设名?参数 格式。\n- hostId (字符串, 可选): 目标主机ID，默认 'local'。\n- isLongRunning (布尔, 可选): 是否为长待机指令，设为 true 时任务将转入后台并返回 taskId。\n- requireAdmin (字符串, 可选): 管理员验证码/授权码。用于 write/danger 级别确认，或强制执行不在白名单内的命令。\n- timeout (数字, 可选): 超时时间（毫秒）。\n- outputFormat (字符串, 可选): 输出格式 'raw'|'formatted'|'json'。\n\n⚠️ 命令编写规范:\n- 禁用 ; 作为分隔符（安全层拦截）\n- 多命令链式：使用 &&（如 cmd1 && cmd2）\n- 引号内分号合法：grep \"pattern;\" file\n\n授权码执行示例:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\ncommand:「始」unknown-tool --args「末」,\nrequireAdmin:「始」123456「末」\n<<<[END_TOOL_REQUEST]>>>\n\n长待机指令调用:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\ncommand:「始」yum install -y nginx「末」,\nisLongRunning:「始」true「末」\n<<<[END_TOOL_REQUEST]>>>\n\n列出主机列表:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\naction:「始」listHosts「末」\n<<<[END_TOOL_REQUEST]>>>"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Problem

When running shell commands via LinuxShellExecutor, the default resource limits cause Node.js child processes to crash with:
```
Fatal process out of memory: SegmentedTable::InitializeTable (subspace allocation)
Trace/breakpoint trap (core dumped)
```

**Root cause**: `RLIMIT_AS=536870912` (512MB virtual address space) is set as the default. Node.js V8 with pointer compression requires **~4GB of virtual address space** just to initialize.

Additionally, `RLIMIT_NOFILE=64` (64 file descriptors) is too low for Node.js (system default ~1024).

## Diagnosis

Confirmed with:
```bash
# OLD 512MB: Node.js crashes silently
ulimit -v 524288; node -e "console.log(42)"  # no output, killed

# With fix (0 = no limit): works
ulimit -t 30 -f 20480 -u 10; node -e "console.log(42)"  # 42
```

This caused false perception that plugins (LightMemo, PaperReader, RAGDiaryPlugin, UrlFetch) were dead. They work normally when spawned by VCP directly.

## Changes

1. `RLIMIT_AS` default: `536870912` (512MB) → `0` (no restriction)
2. `RLIMIT_NOFILE` default: `64` → `0` (inherit system default ~1024)
3. `-v` and `-n` ulimit flags: now conditional — only emitted when limit > 0
4. `plugin-manifest.json`: clarify `;` is blocked, guide AI to use `&&` instead

## Backward Compatibility

Users with explicit `RLIMIT_AS`/`RLIMIT_NOFILE` values in `config.env` are unaffected.

🤖 Generated with Claude Code