### PR TITLE
AICodeWorker v1.6.1: 修复免费模型模式下误用宿主付费 key

### DIFF
--- a/Plugin/AICodeWorker/AICodeWorker.js
+++ b/Plugin/AICodeWorker/AICodeWorker.js
@@ -38,7 +38,9 @@ function loadConfig() {
         enableMimocode:   (raw.ENABLE_MIMOCODE   || "false") !== "false",
         opencodeBin:      raw.OPENCODE_BIN       || "opencode",
         opencodeBaseUrl:  raw.OPENCODE_BASE_URL  || "",
-        opencodeApiKey:   raw.OPENCODE_API_KEY   || process.env.ANTHROPIC_API_KEY || "",
+        // 不回退 process.env.ANTHROPIC_API_KEY：留空即走 opencode 免费模型，
+        // 避免无意中把宿主的 key 注入、误用付费通道。
+        opencodeApiKey:   raw.OPENCODE_API_KEY   || "",
         opencodeModel:    raw.OPENCODE_MODEL      || "",
         allowedRoots:     (raw.ALLOWED_PROJECT_ROOTS || "/app/VCPToolBox_new,/app/ZhongZhuan,/app/claud")
                               .split(",").map(s => s.trim()).filter(Boolean),

--- a/Plugin/AICodeWorker/README.md
+++ b/Plugin/AICodeWorker/README.md
@@ -26,10 +26,15 @@ OPENCODE_BIN=opencode
 # 允许操作的项目根目录白名单（逗号分隔），projectPath 必须在其中
 ALLOWED_PROJECT_ROOTS=/app/VCPToolBox_new,/app/myproject
 
-# 进阶：把 opencode 的模型请求路由到 VCP 主链路（留空使用 opencode 内置模型）
+# 模型：BASE_URL/API_KEY 都留空 = 用 opencode 自带【免费】模型（不烧你的 token）。
+# 但 OPENCODE_MODEL 别留空（留空会回退到付费默认模型），填一个 opencode/ 开头的免费模型：
+#   opencode/deepseek-v4-flash-free（推荐，代码强）/ opencode/north-mini-code-free（轻量）
+#   / opencode/mimo-v2.5-free / opencode/big-pickle
+# 用 `opencode models | grep opencode/` 看最新清单。
+# 若要改用自有模型：把 BASE_URL 和 API_KEY 都填上即切换（会消耗你的 token，且别用推理模型）。
 OPENCODE_BASE_URL=
 OPENCODE_API_KEY=
-OPENCODE_MODEL=opencode/north-mini-code-free
+OPENCODE_MODEL=opencode/deepseek-v4-flash-free
 
 # 单次任务最大字符数（默认 20000）
 MAX_TASK_CHARS=20000

--- a/Plugin/AICodeWorker/config.env.example
+++ b/Plugin/AICodeWorker/config.env.example
@@ -11,21 +11,34 @@ OPENCODE_BIN=opencode
 
 # 模型路由（两种模式，二选一）
 #
-# 【模式A - 推荐】让 opencode 使用自己的内置免费模型（两行都留空即可）
-# opencode 会自动用它内置的 Anthropic 免费额度，不需要任何配置
+# 【模式A - 推荐】用 opencode 自带的【免费】模型，不消耗你自己的 token
+#   规则：OPENCODE_BASE_URL 和 OPENCODE_API_KEY 必须【都留空】，
+#         在 OPENCODE_MODEL 填一个 opencode/ 开头的免费模型。
+#   注意：opencode 免费模型走它官方的远程网关，服务器需要能访问外网（必要时挂代理）。
+#   ⚠️ 不要把 OPENCODE_MODEL 也留空——留空会回退到 opencode 的付费默认模型
+#      （如 gpt-5.x，需要 OpenAI key），并非免费。
+#
+#   可用免费模型（用 `opencode models | grep opencode/` 查看最新清单）：
+#     opencode/deepseek-v4-flash-free   # 推荐，代码能力强、速度快、综合均衡
+#     opencode/north-mini-code-free     # 代码专用轻量模型，适合简单分析/小 patch
+#     opencode/mimo-v2.5-free           # 通用对话型
+#     opencode/big-pickle               # opencode 实验模型
+#   （免费模型由官方提供，可能有速率/并发限制，繁忙时换一个再试）
 OPENCODE_BASE_URL=
 OPENCODE_API_KEY=
-OPENCODE_MODEL=
+OPENCODE_MODEL=opencode/deepseek-v4-flash-free
 #
-# 【模式B - 进阶】把 opencode 的模型请求路由到 VCP 主链路（走 RAG/插件）
-# 取消注释下面三行，并填入 VCP 里已配置好的模型名
-# OPENCODE_BASE_URL=http://127.0.0.1:6005
-# OPENCODE_API_KEY=sunfuwei521
-# OPENCODE_MODEL=kimi-k2.6
+# 【模式B - 进阶】把 opencode 的模型请求路由到你自己的模型（会消耗你的 token）
+#   规则：OPENCODE_BASE_URL 和 OPENCODE_API_KEY 都填上即自动切到模式B。
+#   ⚠️ 别用"推理模型"（正式输出为空、内容全在 reasoning 里），opencode 会一直等内容卡死；
+#      要用直接出内容的模型。
+# OPENCODE_BASE_URL=http://127.0.0.1:6005/v1
+# OPENCODE_API_KEY=your_api_key_here
+# OPENCODE_MODEL=your-model-name
 
 # ── 安全配置 ────────────────────────────────────────
 # 允许操作的项目根目录白名单（逗号分隔），projectPath 必须在其中
-ALLOWED_PROJECT_ROOTS=/app/VCPToolBox_new,/app/ZhongZhuan,/app/claud,/app,/home/kasm_user
+ALLOWED_PROJECT_ROOTS=/app/VCPToolBox_new
 
 # 任务输出目录（output/logs/patches/meta 均在此目录下）
 JOB_ROOT=/app/VCPToolBox_new/Plugin/AICodeWorker/jobs

--- a/Plugin/AICodeWorker/plugin-manifest.json
+++ b/Plugin/AICodeWorker/plugin-manifest.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": "1.0.0",
   "name": "AICodeWorker",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "displayName": "AI 代码工程 Worker",
   "description": "AICodeWorker v1.5 — 规范化报告输出：三模式强制输出【读取文件清单】+【执行结果摘要】锚点，buildResult 精准提取，新增 fileReadList 字段。省 token 与工作质量双保证。",
   "author": "Local",

--- a/Plugin/AICodeWorker/runner.js
+++ b/Plugin/AICodeWorker/runner.js
@@ -64,7 +64,15 @@ async function run() {
             OPENAI_BASE_URL:   cfg.OPENCODE_BASE_URL.replace(/\/v1\/?$/, "") + "/v1",
             ANTHROPIC_API_KEY:  "",
             ANTHROPIC_BASE_URL: "",
-        } : {})
+        } : {
+            // 不路由：显式清空上游 key，强制 opencode 用自带免费模型。
+            // 否则 VCP 主进程环境里的 OPENAI_API_KEY 会被子进程继承，
+            // 导致本想用免费模型却误走了付费 OpenAI 通道。
+            OPENAI_API_KEY:    "",
+            OPENAI_BASE_URL:   "",
+            ANTHROPIC_API_KEY:  "",
+            ANTHROPIC_BASE_URL: "",
+        })
     };
 
     // 有指定模型时注入 -m，无论是否走 VCP 路由


### PR DESCRIPTION
## 问题

当不路由到 VCP（模式A，期望用 opencode 自带免费模型）时，`runner.js` 的 childEnv 没有清空上游 key。若宿主 VCP 进程环境里带有 `OPENAI_API_KEY`（很常见），会被 opencode 子进程继承，导致**本想用免费模型却误走了付费 OpenAI 通道**，违背本插件"用免费模型省 token"的初衷。

## 修复

- **runner.js**：`useVCPRouting=false` 分支显式清空 `OPENAI_API_KEY/OPENAI_BASE_URL/ANTHROPIC_API_KEY/ANTHROPIC_BASE_URL`
- **AICodeWorker.js**：`opencodeApiKey` 去掉 `process.env.ANTHROPIC_API_KEY` 回退，留空就是留空
- **config.env.example**：纠正"留空用 Anthropic 免费额度"的错误说明（实际会回退到付费默认模型）；补充 `opencode/` 免费模型清单；模式B示例去掉真实值；`ALLOWED_PROJECT_ROOTS` 改为通用示例
- **README.md**：补充免费模型清单与"`OPENCODE_MODEL` 别留空"提示

版本 1.6.0 → 1.6.1，仅改动 AICodeWorker 插件目录，已自查无私人信息。

🤖 Generated with [Claude Code](https://claude.com/claude-code)