### PR TITLE
日记创建时，若无`Date`字段，则使用系统时间

### DIFF
--- a/Plugin/DailyNote/dailynote.js
+++ b/Plugin/DailyNote/dailynote.js
@@ -271,14 +271,19 @@ async function handleCreateCommand(args) {
     // 额外兼容 fold，降低模型误拼写导致目录未生效的概率。
     const maid = args.maid || args.maidName || args.Maid || args.MAID;
     const folder = args.folder || args.Folder || args.folderName || args.FolderName || args.fold || args.Fold;
-    const dateString = args.dateString || args.Date;
+    let dateString = args.dateString || args.Date;
     const contentText = args.contentText || args.Content || args.content;
+    // 如果没有传入 Date，则使用系统当前日期
+    if (!dateString) {
+        const d = new Date();
+        dateString = `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+    }
     const tag = args.Tag || args.tag;
     const fileName = args.fileName || args.FileName;
 
     debugLog(`Processing 'create' for Maid: ${maid}, Folder: ${folder || 'Not specified'}, Date: ${dateString}, fileName: ${fileName}`);
-    if (!maid || !dateString || !contentText) {
-        return { status: "error", error: 'Invalid input for create: Missing maid/maidName, dateString/Date, or contentText/Content/content.' };
+    if (!maid || !contentText) {
+        return { status: "error", error: 'Invalid input for create: Missing maid/maidName or contentText/Content/content.' };
     }
 
     try {
@@ -362,7 +367,8 @@ async function handleCreateCommand(args) {
         }
 
         debugLog(`Target file path: ${filePath}`);
-        const fileContent = `[${datePart}] - ${actualMaidName}\n${processedContent}`;
+        const timeStringForContent = `${hours}:${minutes}`;
+        const fileContent = `[${datePart}] - ${actualMaidName}\n[${timeStringForContent}]\n${processedContent}`;
         await fs.writeFile(filePath, fileContent);
         debugLog(`Successfully wrote file (length: ${fileContent.length})`);
         return {


### PR DESCRIPTION
因为大部分时候都不是创建未来日记，所以兼容了无`Date`字段模式，所有时间戳都使用系统时间，格式不变。

另外，日记开头的 [HH:MM] 时间戳现在直接由系统创建，无需 AI 写入。

主要是为了让AI不用把注意力放在时间创建上。

因为我总是遇到 AI 把时间戳同样写入 filename 字段，导致文件名时间戳有双份。