### PR TITLE
docs: 刷新根目录/modules/routes 三个 AGENTS.md 文件

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,85 +1,66 @@
 # 项目知识库
 
-**生成时间：** 2026-02-13 16:34:00 Asia/Shanghai
-**提交：** 3d54cad
-**分支：** xxbb
-
 ## 📚 完整文档体系
 
-**VCPToolBox 现已拥有完整的全景文档（12个文档，331KB，10,395行）：**
-
-从 **[docs/DOCUMENTATION_INDEX.md](./docs/DOCUMENTATION_INDEX.md)** 开始浏览完整文档体系，包括：
-- 系统架构与启动序列
-- 插件生态完整规范（79个活跃插件）
-- 配置系统与参数语义
-- API路由与认证机制
-- TagMemo算法与RAG系统（V3.7）
-- WebSocket分布式架构
-- Rust N-API向量引擎
-- 前端组件与集成
-- 文件清单与职责映射
-- 功能矩阵与处理流程
-- 运维部署与故障排查
-
-**所有文档特点：**
-- ✅ 高保真、全覆盖、可追溯
-- ✅ 所有结论附证据定位（文件路径 + 行号）
-- ✅ 已确认事实、推断结论、不确定项明确标注
-- ✅ 保留边界条件、异常分支、兼容性处理
+VCPToolBox 拥有完整的全景文档体系，从 **[docs/DOCUMENTATION_INDEX.md](./docs/DOCUMENTATION_INDEX.md)** 开始浏览。
 
 ---
 
 ## 概览
-VCPToolBox 是一个以 Node.js 为核心的 AI 中间层，包含大型插件运行时（`Plugin/` - 87个插件目录）、内嵌管理前端（`AdminPanel/`）以及 Rust N-API 向量组件（`rust-vexus-lite/`）。项目采用根目录扁平化运行结构（无 `src/` 分层），定位代码时应按职责找文件而不是按目录深度找。
 
-**项目规模**：673文件，76,448行代码，37个大文件(>500行)，最大深度11层。
+VCPToolBox 是一个以 Node.js 为核心的 AI 中间层，包含大型插件运行时（`Plugin/`）、内嵌管理前端（`AdminPanel/`）以及 Rust N-API 向量组件（`rust-vexus-lite/`）。项目采用根目录扁平化运行结构（无 `src/` 分层），定位代码时应按职责找文件而不是按目录深度找。
 
 ## 目录结构
+
 ```text
 VCPToolBox/
 |- server.js               # 主 HTTP/SSE 入口与启动编排
 |- Plugin.js               # 插件生命周期、加载与执行总控
 |- WebSocketServer.js      # 分布式节点与工具桥接
 |- KnowledgeBaseManager.js # RAG/标签/向量索引总控
-|- modules/                # 复用后端内部模块
-|- routes/                 # Express 路由层
-|- Plugin/                 # 79个活跃插件 + 8个禁用插件（Node/Python/Rust）
+|- modules/                # 复用后端内部模块（见 modules/AGENTS.md）
+|- routes/                 # Express 路由层（见 routes/AGENTS.md）
+|- Plugin/                 # 活跃插件 + 禁用插件（见 Plugin/AGENTS.md）
 |- AdminPanel/             # 内嵌静态管理前端
-|- rust-vexus-lite/        # Rust N-API 向量索引子项目
+|- rust-vexus-lite/        # Rust N-API 向量索引子项目（见其 AGENTS.md）
 |- dailynote/              # 运行数据/知识内容（非核心源码）
 `- image/                  # 运行期媒体资源（非核心源码）
 ```
 
 ## 快速定位
+
 | 任务 | 位置 | 说明 |
 |------|------|------|
 | 启动与初始化 | `server.js` | 环境加载、中间件、路由挂载、启动顺序 |
 | 插件执行链路 | `Plugin.js` | manifest 解析、同步/异步/静态执行 |
-| 分布式工具 | `WebSocketServer.js`, `FileFetcherServer.js` | 节点注册、远程执行、跨节点取文件 |
+| 分布式工具 | `WebSocketServer.js`, `FileFetcherServer.js` | 节点注册、远程执行、跨节点文件透明预处理 |
 | 安全敏感面 | `server.js`, `Plugin.js`, `routes/adminPanelRoutes.js` | 鉴权、shell 执行、管理控制接口 |
-| 变量替换流程 | `modules/messageProcessor.js` | 提示词与占位符注入管线 |
+| 变量替换流程 | `modules/messageProcessor.js` | 提示词与占位符多阶段注入管线 |
 | Agent 文件映射 | `modules/agentManager.js` | `agent_map.json` 与热更新监听 |
-| 管理面板后端 | `routes/adminPanelRoutes.js` | 面板配置/系统控制类接口 |
+| 多协议适配 | `routes/protocolBridge.js` | OpenAI/Anthropic/Gemini → 统一格式 |
+| 管理面板后端 | `routes/adminPanelRoutes.js` + `routes/admin/` | 面板配置/系统控制类接口 |
 | 特殊模型路由 | `routes/specialModelRouter.js` | 图像/向量白名单透传 |
 | 插件协议样例 | `Plugin/*/plugin-manifest.json` | 各类插件本地约定 |
 | 容器行为 | `Dockerfile`, `docker-compose.yml` | 运行用户、挂载策略、依赖安装方式 |
 
 ## 代码映射
+
 | 符号/文件 | 类型 | 位置 | 作用 |
 |-----------|------|------|------|
 | `startServer` | 函数 | `server.js` | 最终启动门控（`app.listen` 前） |
 | `PluginManager` | 类 | `Plugin.js` | 插件注册、配置合并与执行分发 |
 | `initialize` | 函数 | `WebSocketServer.js` | 分布式 WebSocket 桥初始化 |
-| `fetchFile` | 函数 | `FileFetcherServer.js` | 工具执行时的跨节点文件回退 |
+| `fetchFile` | 函数 | `FileFetcherServer.js` | 工具执行时的跨节点文件透明预处理 |
 | `KnowledgeBaseManager` | 类/单例 | `KnowledgeBaseManager.js` | 向量库与 RAG 管线总控 |
+| `ChatCompletionHandler` | 类 | `modules/chatCompletionHandler.js` | 对话主流程 23 步编排 |
 | `AgentManager` | 类 | `modules/agentManager.js` | 别名映射、缓存与热更新监听 |
-| `ChatCompletionHandler` | 类 | `modules/chatCompletionHandler.js` | 对话主流程编排 |
-| `router` | Express Router | `routes/specialModelRouter.js` | 特殊模型请求接管 |
+| `DynamicToolRegistry` | 类 | `modules/dynamicToolRegistry.js` | 动态工具注册、分类与按需注入 |
 
 ## 约定
-- **扁平根目录**：运行时目录刻意保持根层扁平（24个可执行文件），不要假设存在 `src/` 体系。
+
+- **扁平根目录**：运行时目录刻意保持根层扁平，不要假设存在 `src/` 体系。
 - **配置层级**：全局配置来自 `config.env`（模板 `config.env.example`）；插件可在各自目录覆盖配置。
-- **插件契约**：插件契约文件固定为 `plugin-manifest.json`；禁用插件用 `plugin-manifest.json.block`（8个禁用插件）。
+- **插件契约**：插件契约文件固定为 `plugin-manifest.json`；禁用插件用 `.json.block` 后缀。
 - **六种插件类型**：static, messagePreprocessor, synchronous, asynchronous, service, hybridservice。
 - **静态插件占位符**：通过 `systemPromptPlaceholders` 暴露能力，通常以 `{{VCP...}}` 注入。
 - **VCP工具协议**：使用中文分隔符 `「始」「末」` 的自定义块语法（`<<<[TOOL_REQUEST]>>>`），不是 OpenAI function-calling。
@@ -87,33 +68,39 @@ VCPToolBox/
 - **多运行时**：Node.js + Python + Rust 混合架构，插件可用任意语言实现。
 - **无正式测试**：根 `package.json` 的 `npm test` 是占位脚本，项目采用生产验证而非单元测试。
 
-## 反模式（本项目）
-- **密钥安全**：不要提交真实密钥（`config.env`、插件私有配置等）。
-- **运行时数据**：不要把 `dailynote/`、`image/`、插件 `state/` 当作稳定源码模块。
-- **Manifest完整性**：不要随意改动 plugin manifest 关键字段，加载器依赖该 schema。
-- **测试假设**：不要假设 CI 会跑单测；当前 CI 主要验证安装与 Docker 构建。
-- **插件启用**：不要直接去掉 `.block` 来启用插件，先确认依赖与配置完整（8个禁用插件）。
-- **Shell执行**：不要新增 `spawn(..., shell: true)` 类执行路径，除非有严格输入约束和鉴权门禁。
-- **数据修改**：使用文件修改工具前务必备份（参考 DIARY_TAG_BATCH_PROCESSOR 警告）。
-- **Docker根用户**：容器以root运行是已知权衡（卷挂载权限问题），已文档化风险。
+## 开发规范与常见陷阱
+
+- 如需使用密钥或敏感配置，写入 `config.env` 或插件级 `config.env`；
+  不要提交真实密钥到仓库。
+- 如需引用运行数据（`dailynote/`、`image/`、插件 `state/`），将其作为运行时 I/O 对象处理；
+  不要把它们当作稳定源码模块依赖。
+- 如需修改 plugin-manifest 字段，先查 `Plugin.js` 的解析逻辑确认字段被消费；
+  不要随意变更关键字段（加载器依赖 schema 稳定性）。
+- 如需验证改动效果，在真实环境运行并观察日志；
+  不要假设 CI 会跑单测（当前 CI 主要验证安装与 Docker 构建）。
+- 如需启用禁用插件（`.block` 文件），先核对该插件的 `config.env.example` 和依赖是否就绪；
+  不要直接重命名文件盲目启用。
+- 如需新增 shell 执行路径，须配备严格输入约束和鉴权门禁（参照 PowerShellExecutor 模式）；
+  不要新增不受约束的 `spawn(..., shell: true)` 调用。
+- 如需修改文件数据，先备份或确认可回退；
+  不要对 dailynote 等运行数据执行不可逆批量操作。
 
 ## 项目特性风格
+
 - 单仓多运行时插件生态（Node + Python + 原生/Rust）。
 - 以 manifest 驱动插件生命周期，禁用态通过文件命名表达。
 - 提示词工程高度依赖占位符与配置注入。
 - 管理前端以内嵌静态资源方式存在于 `AdminPanel/`，不是独立前端工程。
 
 ## 常用命令
+
 ```bash
 # 开发环境设置
 npm install
 pip install -r requirements.txt
 
 # 构建 Rust N-API 向量引擎（必需）
-cd rust-vexus-lite
-npm run build                    # Release 构建
-npm run build:debug              # Debug 构建
-cd ..
+cd rust-vexus-lite && npm run build && cd ..
 
 # 配置
 cp config.env.example config.env
@@ -122,60 +109,46 @@ cp config.env.example config.env
 # 运行
 node server.js                   # 直接运行
 pm2 start server.js              # PM2 生产模式
-pm2 logs                         # 查看日志
 
-# Docker（推荐生产环境）
+# Docker
 docker-compose up --build -d
 docker-compose logs -f
-docker-compose down
 ```
 
-## 复杂插件子目录
-以下插件因复杂度高（文件数>10或有多层子目录），可能需要专门文档：
-- **Plugin/DailyHot/** (71文件) - 56+热点源聚合器，dist/routes/包含各平台爬虫
-- **Plugin/RAGDiaryPlugin/** (8文件, 4,652行) - 语义分组、向量管理、元思考系统
-- **Plugin/LinuxShellExecutor/** (12文件, 3,000行) - 安全关键，13+验证器类，SSH管理
-- **Plugin/LinuxLogMonitor/** (8文件, 2,945行) - core/架构：AnomalyDetector, MonitorManager, MonitorTask
-- **Plugin/ComfyUIGen/** (18文件) - JS+Python双语言工作流系统
-- **Plugin/IMAPIndex/** (15文件) - 3个子系统：proxy, storkapp_dailynote, storkapp_dailynote_pubmed
-- **Plugin/PaperReader/** (11文件) - lib/库架构：chunker, ingest, deep-reader, query管线
+## 复杂插件说明
 
-## 备注
-- **CI工作流**：`.github/workflows/ci.yml` 执行 `npm ci` + Docker 构建（不推送镜像，且不做有效根层测试）。
-- **容器运行**：采用 `pm2-runtime`，`docker-compose.yml` 默认大范围 bind mount。
-- **继续深入**：请看子级文档：`Plugin/AGENTS.md`、`AdminPanel/AGENTS.md`、`modules/AGENTS.md`、`routes/AGENTS.md`、`rust-vexus-lite/AGENTS.md`。
+Plugin/ 目录中部分插件因规模或复杂度较高（多文件、多层子目录、多语言混合），在开发或审计时可能需要单独深入理解。典型特征包括：
+- 文件数 >10 或含多层子目录
+- 多语言混合（JS + Python）
+- 拥有独立的内部路由或服务架构
 
----
+遇到此类插件时，建议先阅读其目录下的 README.md（如有），再查阅 `plugin-manifest.json` 了解入口和类型。
 
 ## 📖 深度学习资源
 
-**对于需要深入理解系统的 Agent，强烈推荐按以下顺序阅读完整文档：**
+**首次接触 VCPToolBox：**
+1. [docs/DOCUMENTATION_INDEX.md](./docs/DOCUMENTATION_INDEX.md) — 文档导航总览
+2. [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) — 系统架构与启动序列
+3. [docs/PLUGIN_ECOSYSTEM.md](./docs/PLUGIN_ECOSYSTEM.md) — 插件生态完整规范
 
-1. **首次接触**：
-   - [docs/DOCUMENTATION_INDEX.md](./docs/DOCUMENTATION_INDEX.md) - 文档导航总览
-   - [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) - 系统架构与启动序列
-   - [docs/PLUGIN_ECOSYSTEM.md](./docs/PLUGIN_ECOSYSTEM.md) - 插件生态完整规范
+**开发新功能：**
+1. [docs/VCP同步异步插件开发手册.md](./docs/VCP同步异步插件开发手册.md) — 插件开发全流程教程
+2. [docs/FEATURE_MATRIX.md](./docs/FEATURE_MATRIX.md) — 查找类似功能实现
+3. [docs/CONTEXT_BRIDGE.md](./docs/CONTEXT_BRIDGE.md) — 插件间向量能力共享
 
-2. **开发新功能**：
-   - [docs/FEATURE_MATRIX.md](./docs/FEATURE_MATRIX.md) - 查找类似功能
-   - [docs/FILE_INVENTORY.md](./docs/FILE_INVENTORY.md) - 定位相关文件
-   - 对应专项文档查阅实现细节
+**排查问题：**
+1. [docs/OPERATIONS.md](./docs/OPERATIONS.md) — 运维部署与故障排查
+2. [docs/CONFIGURATION.md](./docs/CONFIGURATION.md) — 配置参数与风险警告
+3. [docs/API_ROUTES.md](./docs/API_ROUTES.md) — HTTP 端点与认证机制
 
-3. **排查问题**：
-   - [docs/OPERATIONS.md](./docs/OPERATIONS.md) - 常见故障排查
-   - [docs/CONFIGURATION.md](./docs/CONFIGURATION.md) - 配置项检查
-   - [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) - 追踪调用链
+**记忆/RAG 系统：**
+1. [docs/VCP记忆管理系统.md](./docs/VCP记忆管理系统.md) — 记忆系统上手指南
+2. [docs/TagMemo_Wave_Algorithm_Deep_Dive.md](./docs/TagMemo_Wave_Algorithm_Deep_Dive.md) — 浪潮算法数学原理
+3. [docs/MEMORY_SYSTEM.md](./docs/MEMORY_SYSTEM.md) — 记忆系统架构概览
 
-**完整文档列表：**
-- [DOCUMENTATION_INDEX.md](./docs/DOCUMENTATION_INDEX.md) - 文档导航与使用指南
-- [ARCHITECTURE.md](./docs/ARCHITECTURE.md) - 系统架构、启动序列、模块依赖
-- [PLUGIN_ECOSYSTEM.md](./docs/PLUGIN_ECOSYSTEM.md) - 插件类型、manifest schema、执行模式
-- [CONFIGURATION.md](./docs/CONFIGURATION.md) - 配置参数、优先级规则、风险警告
-- [API_ROUTES.md](./docs/API_ROUTES.md) - HTTP端点、认证机制、处理逻辑
-- [MEMORY_SYSTEM.md](./docs/MEMORY_SYSTEM.md) - TagMemo算法、EPA模块、向量索引
-- [DISTRIBUTED_ARCHITECTURE.md](./docs/DISTRIBUTED_ARCHITECTURE.md) - WebSocket协议、分布式工具执行
-- [RUST_VECTOR_ENGINE.md](./docs/RUST_VECTOR_ENGINE.md) - N-API接口、向量操作、性能特性
-- [FRONTEND_COMPONENTS.md](./docs/FRONTEND_COMPONENTS.md) - AdminPanel、VCPChrome、OpenWebUISub
-- [FILE_INVENTORY.md](./docs/FILE_INVENTORY.md) - 文件清单、职责、依赖关系
-- [FEATURE_MATRIX.md](./docs/FEATURE_MATRIX.md) - 功能入口、触发条件、处理流程
-- [OPERATIONS.md](./docs/OPERATIONS.md) - 运维部署、故障排查、性能监控
+**其他专项：**
+- [docs/DISTRIBUTED_ARCHITECTURE.md](./docs/DISTRIBUTED_ARCHITECTURE.md) — 分布式 WebSocket 协议
+- [docs/RUST_VECTOR_ENGINE.md](./docs/RUST_VECTOR_ENGINE.md) — N-API 向量引擎
+- [docs/FRONTEND_COMPONENTS.md](./docs/FRONTEND_COMPONENTS.md) — AdminPanel 与前端集成
+- [docs/SEMANTIC_MODEL_ROUTER.md](./docs/SEMANTIC_MODEL_ROUTER.md) — 语义模型路由
+- [docs/TECHNICAL_LITE.md](./docs/TECHNICAL_LITE.md) — README 与完整文档之间的轻量技术地图

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -1,26 +1,56 @@
 # modules 目录知识库
 
 ## 概览
-`modules/` 存放被 `server.js`、路由层和核心执行链复用的后端内部模块，是可复用编排逻辑的主要承载层。
+
+`modules/` 存放被 `server.js`、路由层和核心执行链复用的后端内部模块，是可复用编排逻辑的主要承载层。采用 CommonJS 导出，部分模块作为单例/服务注册中心运行。
 
 ## 快速定位
-| 任务 | 位置 | 说明 |
-|------|------|------|
-| Agent 别名与文件管理 | `modules/agentManager.js` | `agent_map.json` 读取、缓存、文件监听 |
-| 对话主流程编排 | `modules/chatCompletionHandler.js` | Chat 请求主循环与 handler 调度 |
-| 变量替换管线 | `modules/messageProcessor.js` | 多阶段占位符解析 |
-| 日志初始化 | `modules/logger.js` | 控制台重定向与日志输出 |
-| 角色分割转换 | `modules/roleDivider.js` | role 拆分与过滤 |
+
+| 模块 | 职责 |
+|------|------|
+| `chatCompletionHandler.js` | 对话主流程编排（23 步管线），请求全生命周期控制器 |
+| `messageProcessor.js` | 多阶段变量替换（Agent/Toolbox/TVS/System）、Detector 后置、占位符注入 |
+| `dynamicToolRegistry.js` | 动态工具注册表、分类缓存、`{{VCPDynamicTools}}` 注入构建 |
+| `agentManager.js` | Agent 别名映射、人格文件缓存、`agent_map.json` 热监听 |
+| `roleDivider.js` | `<<<[ROLE_DIVIDE_*]>>>` 标签解析，单条消息拆分为多角色消息 |
+| `semanticModelRouter.js` | VCPModelAuto 语义路由，基于对话内容自动选模型 |
+| `contextManager.js` | 上下文 token 预算裁剪（pruneMessages） |
+| `finalContextStore.js` | 存储最终上游请求 body 供调试复现 |
+| `multiModalConfigStore.js` | 多模态配置热加载（`multimodal-config.json` 优先于 env） |
+| `toolApprovalManager.js` | Human-in-the-loop 工具审批，规则来自 `toolApprovalConfig.json` |
+| `toolboxManager.js` | Toolbox 文档管理，`toolbox_map.json` + foldProtocol 动态折叠 |
+| `tvsManager.js` | TVS 变量系统，读取 `TVStxt/` 目录的静态文档块 |
+| `sarPromptManager.js` | 模型级 SAR 提示词注入，基于目标模型名匹配 |
+| `foldProtocol.js` | 语义折叠协议解析/构建（配合 toolboxManager 按相关度展开文档） |
+| `associativeDiscovery.js` | 联想发现引擎，被 DailyNoteManager 的 associate 命令调用 |
+| `distributedMusicDiarySync.js` | 分布式音乐播放列表同步到本地日记目录 |
+| `captchaDecoder.js` | 管理员 6 位验证码解码（从 `Plugin/UserAuth/code.bin` 读取） |
+| `dotenvPatch.js` | dotenv 加载补丁（环境变量预处理） |
+| `sensitiveEnv.js` | 敏感环境变量白名单控制（仅允许特定插件访问） |
+| `logger.js` | 控制台重定向与日志格式化输出 |
+
+| 子目录 | 职责 |
+|--------|------|
+| `handlers/` | 流式/非流式响应处理器（streamHandler / nonStreamHandler） |
+| `vcpLoop/` | VCP 工具调用循环（toolCallParser 解析 + toolExecutor 执行） |
+| `SSHManager/` | SSH 连接池服务，通过 UDS 提供 RPC |
+| `LogMonitor/` | 日志监控核心模块（AnomalyDetector / MonitorManager） |
 
 ## 约定
+
 - 默认采用 CommonJS 导出（`module.exports`）。
 - 环境变量解析常见防御式处理（`try/catch` + 回退默认值）。
-- 缓存与监听是显式策略（典型见 `agentManager`）。
+- 缓存与监听是显式策略（典型见 `agentManager` 的 chokidar/fs.watch）。
 - `DebugMode` 作为附加日志门控，不要绕过。
-- Handler 主链路保持稳定：解析 tool call -> 分离 archery/normal -> 执行 -> 递归/继续。
-- 导出风格按职责区分：handler 多为类导出，manager 多为单例导出，工具模块多为函数对象导出。
+- Handler 主链路保持稳定：解析 tool call → 分离 archery/normal → 执行 → 递归/继续。
+- 导出风格按职责区分：handler 为类导出，manager 为单例导出，工具模块为函数对象导出。
+- messagePreprocessors Map 同时充当轻量级服务定位器（如 `.get('RAGDiaryPlugin')` 获取 embedding 能力）。
 
-## 反模式
-- 不要在 watcher/缓存链路里吞错（静默失败）。
-- 不要绕开已有 manager 直接在 `server.js` 中复制状态逻辑。
-- 不要无保护地引入 ESM-only 依赖破坏当前 CommonJS 运行约定。
+## 开发规范与常见陷阱
+
+- 如需添加新模块，在模块内实现错误边界（try/catch + 日志），并在 watcher/缓存链路中确保异常可观测；
+  不要静默吞错导致状态不一致。
+- 如需访问已有状态（Agent 映射、工具列表、配置缓存），通过对应 manager 的公开接口调用；
+  不要在 server.js 中复制状态逻辑绕开 manager。
+- 如需引入新 npm 依赖，确认其同时支持 CommonJS require()；
+  不要引入 ESM-only 包破坏当前运行约定（无 `"type": "module"`）。

--- a/routes/AGENTS.md
+++ b/routes/AGENTS.md
@@ -1,25 +1,37 @@
 # routes 目录知识库
 
 ## 概览
-`routes/` 是主要的 Express API 入口层，覆盖管理面板、日记管理、论坛接口与特殊模型转发。安全强度并不完全一致：`dailyNotesRoutes.js` 和 `forumApi.js` 的输入/路径校验更严格。
+
+`routes/` 是 Express API 入口层，覆盖管理面板、日记管理、论坛接口、多协议适配与特殊模型转发。安全强度按模块分级：`dailyNotesRoutes.js` 和 `forumApi.js` 具有最严格的输入/路径校验。
 
 ## 快速定位
+
 | 任务 | 位置 | 说明 |
 |------|------|------|
-| 管理面板 API | `routes/adminPanelRoutes.js` | 配置/文件/插件控制，变更影响面最大 |
-| 日记与文件安全样例 | `routes/dailyNotesRoutes.js` | 路径穿越与符号链接防护、队列与大小限制 |
-| 论坛输入校验样例 | `routes/forumApi.js` | 参数约束与锁机制并发控制 |
-| 特殊模型透传 | `routes/specialModelRouter.js` | 白名单条件接管转发 |
-| 调度行为模块 | `routes/taskScheduler.js` | 放在 routes 下，但并非 HTTP Router |
+| 管理面板 API 总入口 | `adminPanelRoutes.js` | 初始化并 mount admin/ 下所有子模块 |
+| 管理面板子路由 | `admin/` | 25+ 独立模块（system/config/plugins/agents/rag/schedules 等） |
+| 日记与文件安全样例 | `dailyNotesRoutes.js` | 路径穿越防护、符号链接检测、队列与大小限制 |
+| 论坛输入校验样例 | `forumApi.js` | 参数约束、锁机制并发控制 |
+| 多协议适配 | `protocolBridge.js` | OpenAI Responses / Anthropic Messages / Gemini → 统一 /v1/chat/completions |
+| 特殊模型透传 | `specialModelRouter.js` | 白名单条件接管转发 |
+| 并行搜索 | `searchWorker.js` | Worker Thread，被 dailyNotesRoutes 调用执行并行文件搜索 |
+| 调度编排 | `taskScheduler.js` | 非 HTTP Router，是定时任务编排模块 |
 
 ## 约定
-- 路由鉴权主要在 `server.js` 挂载层处理（`/admin_api`、`/AdminPanel`、bearer 鉴权链）。
-- 每个 endpoint 使用显式 `try/catch` 和明确状态码（`400/403/404/500`，按需使用 `429/503/504`）。
-- 涉及文件路径时优先使用规范化与根目录前缀校验（参照 `dailyNotesRoutes.js`）。
-- 扩展接口时保持同模块内错误响应结构一致。
 
-## 反模式
-- 不要新增缺少规范化路径校验的管理端写文件接口。
-- 不要在鉴权与输入边界不足时暴露重启/命令执行类接口。
-- 不要只依赖前端做权限或参数校验。
-- 不要假设 `routes/` 下所有文件都是 Express Router（`taskScheduler.js` 是编排模块）。
+- 路由鉴权主要在 `server.js` 挂载层处理（`/admin_api`、`/AdminPanel`、bearer 鉴权链）。
+- 每个 endpoint 使用显式 `try/catch` 和明确状态码（`400/403/404/500`，按需 `429/503/504`）。
+- 涉及文件路径时优先使用 `path.resolve()` + `startsWith(allowedRoot)` 规范化校验。
+- 扩展接口时保持同模块内错误响应结构一致。
+- `admin/` 子目录的每个模块由 `adminPanelRoutes.js` 统一注册，接收 options 依赖注入。
+
+## 开发规范与常见陷阱
+
+- 如需新增写文件接口，参照 `dailyNotesRoutes.js` 的路径规范化校验（`path.resolve` + 白名单根目录前缀检测）；
+  不要跳过路径校验直接拼接用户输入。
+- 如需暴露命令执行类接口，须通过 `requiresAdmin` 验证码 + 白名单命令约束；
+  不要在鉴权与输入边界不足时暴露此类端点。
+- 如需校验参数，后端路由层必须独立做完整校验（req.body/req.params）；
+  不要只依赖前端做权限或参数校验。
+- 如需确认某文件是否是路由，检查其是否导出 Express Router 实例；
+  注意 `taskScheduler.js` 和 `searchWorker.js` 是工具模块，不是路由。


### PR DESCRIPTION
## 改动概要

刷新三个 AGENTS.md 文件，移除过时的时间快照数据，补充遗漏的模块，统一反模式为 if-switch 格式。

### 根目录 AGENTS.md（大改）
- 移除所有数字快照（插件数量、文件行数、TagMemo 版本号、commit hash）
- 反模式全部改为 if-switch 格式（"如需 X，做 Y；不要 Z"）
- 删除对已不存在的 AdminPanel/AGENTS.md 的引用
- "复杂插件子目录"从固定列表改为特征描述（插件日益增多，固定列表无法维护）
- FileFetcherServer 描述修正为"透明预处理"（旧版超栈追踪已废弃）
- 代码映射补入 ChatCompletionHandler 和 DynamicToolRegistry
- docs 路由表按场景重构（首次接触/开发/排查/RAG/专项）

### modules/AGENTS.md（补充）
- 快速定位表从 5 行扩充到 20+ 行，覆盖目录内全部 .js 文件和 4 个子目录
- 新增约定：messagePreprocessors Map 充当服务定位器
- 反模式改为 if-switch 格式

### routes/AGENTS.md（补充）
- 补入 protocolBridge.js、searchWorker.js、admin/ 子目录
- 新增约定：admin/ 子目录统一由 adminPanelRoutes.js 注册
- 反模式改为 if-switch 格式

## 测试
纯文档改动，无运行时影响。
