### PR TITLE
fix(messageProcessor): add {{}} boundaries to static placeholder matching

### DIFF
--- a/modules/messageProcessor.js
+++ b/modules/messageProcessor.js
@@ -719,11 +719,14 @@ async function replaceOtherVariables(text, model, role, context) {
         if (staticPlaceholderValues && staticPlaceholderValues.size > 0) {
             for (const [placeholder, entry] of staticPlaceholderValues.entries()) {
                 // 修复上下文折叠漏洞：如果当前文本压根没有这个占位符，直接跳过，避免触发不必要的向量化和计算
-                if (!processedText.includes(placeholder)) {
+                // 修复占位符前缀包含冲突：使用 {{}} 边界精确匹配，防止短名称吞噬长名称（如 VCPClawMailInbox ⊂ VCPClawMailInboxMail1）
+                const fullPlaceholder = `{{${placeholder}}}`;
+                if (!processedText.includes(fullPlaceholder)) {
                     continue;
                 }
 
-                const placeholderRegex = new RegExp(placeholder.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g');
+                const escapedPlaceholder = placeholder.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+                const placeholderRegex = new RegExp('\\{\\{' + escapedPlaceholder + '\\}\\}', 'g');
 
                 let valueToInject = entry;
                 if (typeof entry === 'object' && entry !== null && entry.hasOwnProperty('value')) {


### PR DESCRIPTION
问题
当两个静态占位符名存在子串包含关系时（如 VCPClawMailInbox ⊂ VCPClawMailInboxMail1），短占位符的 includes() 检测和无边界正则会匹配到长占位符内部，导致长占位符被破坏。

根因
Plugin.js 的 getAllPlaceholderValues() 猴补丁返回去掉 {{}} 的裸key。messageProcessor.js 消费端直接用裸key做 includes() 子串检测和 new RegExp(key, 'g') 无边界匹配。

修复
在消费端重新拼接 {{}} 边界：

includes(placeholder) → includes(\{{${placeholder}}}`)`
new RegExp(escaped, 'g') → new RegExp('\\{\\{' + escaped + '\\}\\}', 'g')
影响范围
vcp_dynamic_fold 分支：使用同一个 regex 做替换，加边界后同样精确匹配 ✅
日记避让系统（commit 287fff3）：本身依赖 {{}} 边界匹配，无冲突 ✅
分布式占位符同步：仅改消费端匹配逻辑，存储端不受影响 ✅

没来得及仔细测试。另外，{{}}花括号在改动后也不会残留了。