### PR TITLE
polish AdminPanel Agent 文件编辑器与表情图库布局

### DIFF
--- a/AdminPanel-Vue/src/views/AgentFilesEditor.vue
+++ b/AdminPanel-Vue/src/views/AgentFilesEditor.vue
@@ -83,7 +83,6 @@
 
     <div class="agent-editor-shell" :class="'mobile-view-' + activeTab">
       <aside class="agent-map-pane" aria-label="Agent 映射表">
-        <div class="agent-pane-label">Agent 映射表</div>
         <div class="agent-map-list">
           <article
             v-for="(entry, index) in agentMap"
@@ -193,9 +192,13 @@
 
       <main class="agent-file-pane" aria-label="Agent 文件内容">
         <header class="agent-file-pane-header">
-          <div>
+          <div class="agent-file-title">
             <span class="agent-pane-label">Agent 文件内容</span>
-            <p>{{ editingFile || "从左侧选择一个 Agent 以编辑其关联文件。" }}</p>
+            <span class="agent-file-name">
+              <span class="material-symbols-outlined">description</span>
+              {{ editingFile || "未选择文件" }}
+            </span>
+            <UiBadge v-if="fileDirty" variant="warning">未保存</UiBadge>
           </div>
           <div v-if="editingFile" class="agent-file-actions">
             <UiButton
@@ -226,13 +229,6 @@
 
         <div class="agent-file-workspace">
           <div class="agent-file-editor">
-            <div class="agent-editor-controls">
-              <span class="editing-file-display">
-                <span class="material-symbols-outlined">description</span>
-                {{ editingFile || "未选择文件" }}
-                <span v-if="fileDirty" class="dirty-indicator">（未保存）</span>
-              </span>
-            </div>
             <UiTextarea
               ref="fileContentEditorRef"
               v-model="fileContent"
@@ -253,27 +249,41 @@
 
       <aside class="placeholder-sidebar" aria-label="常用占位符">
         <header class="placeholder-sidebar-header">
-          <span class="eyebrow">Quick Insert</span>
-          <h4>常用占位符</h4>
-        </header>
+          <div class="placeholder-source-tabs" role="tablist" aria-label="占位符类型">
+            <button
+              v-for="group in placeholderGroups"
+              :key="group.key"
+              type="button"
+              class="placeholder-source-tab"
+              :class="{ 'is-active': activePlaceholderSource === group.key }"
+              role="tab"
+              :aria-selected="activePlaceholderSource === group.key"
+              @click="activePlaceholderSource = group.key"
+            >
+              <span class="material-symbols-outlined">{{ group.icon }}</span>
+              <span>{{ group.shortTitle }}</span>
+              <span class="placeholder-count">{{ group.items.length }}</span>
+            </button>
+          </div>
 
-        <div class="placeholder-search">
-          <span class="material-symbols-outlined search-icon">search</span>
-          <UiInput
-            v-model="placeholderQuery"
-            type="text"
-            placeholder="搜索占位符…"
-          />
-          <UiIconButton
-            v-if="placeholderQuery"
-            class="search-clear"
-            label="清除搜索"
-            title="清除搜索"
-            @click="placeholderQuery = ''"
-          >
-            <span class="material-symbols-outlined">close</span>
-          </UiIconButton>
-        </div>
+          <div class="placeholder-search">
+            <span class="material-symbols-outlined search-icon">search</span>
+            <UiInput
+              v-model="placeholderQuery"
+              type="text"
+              placeholder="搜索占位符…"
+            />
+            <UiIconButton
+              v-if="placeholderQuery"
+              class="search-clear"
+              label="清除搜索"
+              title="清除搜索"
+              @click="placeholderQuery = ''"
+            >
+              <span class="material-symbols-outlined">close</span>
+            </UiIconButton>
+          </div>
+        </header>
 
         <div
           v-if="isLoadingCommonPlaceholders"
@@ -293,33 +303,18 @@
           {{ placeholderLoadError }}
         </div>
 
-        <template v-else>
+        <div v-else class="placeholder-scroll">
           <section
             v-for="group in filteredPlaceholderGroups"
             :key="group.key"
             class="placeholder-group"
           >
-            <button
-              type="button"
-              class="placeholder-group-title"
-              :aria-expanded="!collapsedPlaceholderGroups[group.key]"
-              @click="togglePlaceholderGroup(group.key)"
-            >
-              <span class="material-symbols-outlined">{{ group.icon }}</span>
-              <span>{{ group.title }}</span>
-              <span class="placeholder-count">{{ group.items.length }}</span>
-              <span class="material-symbols-outlined group-chevron">expand_more</span>
-            </button>
-
-            <div
-              v-show="!collapsedPlaceholderGroups[group.key]"
-              class="placeholder-chip-list"
-            >
+            <div class="placeholder-command-list">
               <button
                 v-for="item in group.items"
                 :key="`${group.key}-${item.token}`"
                 type="button"
-                class="placeholder-chip"
+                class="placeholder-command-item"
                 :title="item.description || item.token"
                 @click="insertPlaceholderAtCursor(item.token)"
               >
@@ -335,7 +330,7 @@
           >
             没有匹配的占位符。
           </div>
-        </template>
+        </div>
       </aside>
     </div>
 
@@ -396,6 +391,7 @@ interface QuickPlaceholderItem {
 interface QuickPlaceholderGroup {
   key: "toolbox" | "env";
   title: string;
+  shortTitle: string;
   icon: string;
   items: QuickPlaceholderItem[];
 }
@@ -438,13 +434,10 @@ const isDiarySyntaxEditorOpen = ref(false);
 const isLoadingCommonPlaceholders = ref(false);
 const placeholderLoadError = ref("");
 const placeholderQuery = ref("");
+const activePlaceholderSource = ref<QuickPlaceholderGroup["key"]>("toolbox");
 const toolboxPlaceholders = ref<QuickPlaceholderItem[]>([]);
 const envPlaceholders = ref<QuickPlaceholderItem[]>([]);
 const fileContentEditorRef = ref<InstanceType<typeof UiTextarea> | null>(null);
-const collapsedPlaceholderGroups = ref<Record<string, boolean>>({
-  toolbox: false,
-  env: false,
-});
 
 const agentFilesDatalistId = "agent-file-options";
 const AGENT_FILE_EXTENSION_PATTERN = /\.(txt|md)$/i;
@@ -642,12 +635,14 @@ const placeholderGroups = computed<QuickPlaceholderGroup[]>(() => [
   {
     key: "toolbox",
     title: "Toolbox 占位符",
+    shortTitle: "Toolbox",
     icon: "inventory_2",
     items: toolboxPlaceholders.value,
   },
   {
     key: "env",
     title: "Tar / Var / Sar 变量",
+    shortTitle: "Tar 变量",
     icon: "tune",
     items: envPlaceholders.value,
   },
@@ -657,19 +652,13 @@ const filteredPlaceholderGroups = computed<QuickPlaceholderGroup[]>(() => {
   const query = placeholderQuery.value.trim().toLowerCase();
 
   return placeholderGroups.value
+    .filter((group) => group.key === activePlaceholderSource.value)
     .map((group) => ({
       ...group,
       items: group.items.filter((item) => matchesPlaceholderQuery(item, query)),
     }))
     .filter((group) => group.items.length > 0);
 });
-
-function togglePlaceholderGroup(groupKey: string): void {
-  collapsedPlaceholderGroups.value = {
-    ...collapsedPlaceholderGroups.value,
-    [groupKey]: !collapsedPlaceholderGroups.value[groupKey],
-  };
-}
 
 async function loadCommonPlaceholders(): Promise<void> {
   isLoadingCommonPlaceholders.value = true;
@@ -1069,7 +1058,7 @@ onBeforeRouteLeave(async () => {
 
 <style scoped>
 .agent-files-page {
-  --agent-workspace-height: calc(var(--app-viewport-height, 100vh) - 236px);
+  --agent-workspace-height: calc(var(--app-viewport-height, 100vh) - 150px);
   --agent-workspace-min-height: 520px;
 }
 
@@ -1083,7 +1072,7 @@ onBeforeRouteLeave(async () => {
 
 .agent-editor-shell {
   display: grid;
-  grid-template-columns: minmax(292px, 340px) minmax(0, 1fr) minmax(240px, 284px);
+  grid-template-columns: minmax(292px, 340px) minmax(360px, 1fr) minmax(320px, 360px);
   gap: var(--space-4);
   min-height: var(--agent-workspace-min-height);
   height: max(var(--agent-workspace-height), var(--agent-workspace-min-height));
@@ -1125,31 +1114,44 @@ onBeforeRouteLeave(async () => {
   text-transform: uppercase;
 }
 
-.agent-map-pane > .agent-pane-label {
-  min-height: 65px;
-  align-items: flex-start;
-  padding-top: var(--space-4);
-}
-
 .agent-file-pane-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
+  min-height: 58px;
   padding: var(--space-3) var(--space-4);
-  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 86%, transparent);
+}
+
+.agent-file-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
 }
 
 .agent-file-pane-header .agent-pane-label {
   min-height: 0;
   padding: 0;
+  flex: 0 0 auto;
 }
 
-.agent-file-pane-header p {
-  margin: 4px 0 0;
+.agent-file-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
   color: var(--secondary-text);
   font-size: var(--font-size-helper);
-  line-height: 1.45;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-file-name .material-symbols-outlined {
+  flex: 0 0 auto;
+  font-size: 16px !important;
 }
 
 .agent-file-actions {
@@ -1294,7 +1296,7 @@ onBeforeRouteLeave(async () => {
   display: flex;
   min-height: 0;
   flex: 1;
-  padding: var(--space-3);
+  padding: 0 var(--space-3) var(--space-3);
 }
 
 .agent-file-editor {
@@ -1303,36 +1305,6 @@ onBeforeRouteLeave(async () => {
   flex: 1;
   min-width: 0;
   min-height: 0;
-}
-
-.agent-editor-controls {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  margin-bottom: var(--space-2);
-  padding: var(--space-2) var(--space-3);
-  min-height: 36px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 86%, transparent);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--primary-text) 1.2%, transparent);
-}
-
-.editing-file-display {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  color: var(--secondary-text);
-  font-size: var(--font-size-body);
-  font-weight: 500;
-}
-
-.editing-file-display .material-symbols-outlined {
-  font-size: var(--font-size-emphasis) !important;
-}
-
-.dirty-indicator {
-  color: var(--highlight-text);
-  font-size: var(--font-size-helper);
 }
 
 .file-content-editor {
@@ -1349,10 +1321,26 @@ onBeforeRouteLeave(async () => {
   height: 100%;
   max-height: none;
   min-height: 240px;
+  border-color: transparent;
+  background: transparent;
+  border-radius: 0;
   resize: none;
   font-family: "Consolas", "Monaco", monospace;
   font-size: var(--font-size-body);
   line-height: 1.6;
+}
+
+.file-content-editor :deep(.ui-textarea:hover:not(:disabled)),
+.file-content-editor.ui-textarea:hover:not(:disabled) {
+  border-color: transparent;
+  background: transparent;
+}
+
+.file-content-editor :deep(.ui-textarea:focus-visible),
+.file-content-editor.ui-textarea:focus-visible {
+  border-color: transparent;
+  background: transparent;
+  outline-offset: -2px;
 }
 
 .editor-actions {
@@ -1377,35 +1365,68 @@ onBeforeRouteLeave(async () => {
 
 .placeholder-sidebar-header {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: stretch;
   gap: var(--space-2);
-  min-height: 65px;
-  padding: var(--space-3) var(--space-4);
-  border-bottom: 1px solid var(--border-color);
-  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
+  padding: var(--space-3);
 }
 
-.placeholder-sidebar-header h4 {
-  margin: 0;
-  color: var(--primary-text);
-  font-size: var(--font-size-body);
-  line-height: 1.25;
+.placeholder-source-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  width: 100%;
+  padding: 3px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 76%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary-text) 1.6%, transparent);
 }
 
-.placeholder-sidebar-header .eyebrow {
+.placeholder-source-tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 0;
+  min-height: 30px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
   color: var(--secondary-text);
-  font-size: var(--font-size-caption);
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  white-space: nowrap;
+  font-size: var(--font-size-helper);
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.placeholder-source-tab:hover {
+  background: var(--accent-bg);
+  color: var(--primary-text);
+}
+
+.placeholder-source-tab.is-active {
+  background: color-mix(in srgb, var(--button-bg) 12%, transparent);
+  color: var(--primary-text);
+}
+
+.placeholder-source-tab .material-symbols-outlined {
+  flex: 0 0 auto;
+  font-size: 16px !important;
+}
+
+.placeholder-source-tab .placeholder-count {
+  margin-left: 0;
+  background: color-mix(in srgb, var(--primary-text) 5%, transparent);
 }
 
 .placeholder-search {
   position: relative;
-  padding: var(--space-3);
-  border-bottom: 1px solid var(--border-color);
+  width: 100%;
 }
 
 .placeholder-search :deep(.ui-input) {
@@ -1416,7 +1437,7 @@ onBeforeRouteLeave(async () => {
 .placeholder-search .search-icon {
   position: absolute;
   top: 50%;
-  left: 22px;
+  left: 10px;
   transform: translateY(-50%);
   color: var(--secondary-text);
   font-size: 18px !important;
@@ -1426,7 +1447,7 @@ onBeforeRouteLeave(async () => {
 .placeholder-search .search-clear {
   position: absolute;
   top: 50%;
-  right: 18px;
+  right: 6px;
   transform: translateY(-50%);
 }
 
@@ -1451,8 +1472,35 @@ onBeforeRouteLeave(async () => {
   color: var(--primary-text);
 }
 
+.placeholder-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0 2px var(--space-2);
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--secondary-text) 26%, transparent) transparent;
+}
+
+.placeholder-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.placeholder-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.placeholder-scroll::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: var(--radius-full);
+  background-color: color-mix(in srgb, var(--secondary-text) 28%, transparent);
+  background-clip: padding-box;
+}
+
 .placeholder-group {
-  border-bottom: 1px solid var(--border-color);
+  flex: 0 0 auto;
+  padding: var(--space-2);
 }
 
 .placeholder-group:last-child {
@@ -1464,80 +1512,73 @@ onBeforeRouteLeave(async () => {
   align-items: center;
   gap: var(--space-2);
   width: 100%;
-  min-height: 36px;
-  padding: var(--space-2) var(--space-3);
-  border: none;
-  background: transparent;
-  color: var(--primary-text);
-  cursor: pointer;
-  text-align: left;
-}
-
-.placeholder-group-title:hover {
-  background: color-mix(in srgb, var(--primary-text) 3%, transparent);
+  min-height: 28px;
+  padding: 0 var(--space-2);
+  color: color-mix(in srgb, var(--secondary-text) 78%, transparent);
+  font-size: var(--font-size-caption);
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 .placeholder-group-title .material-symbols-outlined {
-  color: var(--highlight-text);
-  font-size: 18px !important;
+  color: var(--secondary-text);
+  font-size: 15px !important;
 }
 
 .placeholder-count {
   margin-left: auto;
-  padding: 1px 8px;
+  padding: 0 6px;
   border-radius: var(--radius-full);
-  background: var(--button-bg);
-  color: var(--on-accent-text);
+  background: color-mix(in srgb, var(--primary-text) 4%, transparent);
+  color: var(--secondary-text);
   font-size: var(--font-size-caption);
-  font-weight: 700;
+  font-weight: 600;
 }
 
-.group-chevron {
-  transition: transform 0.2s ease;
-}
-
-.placeholder-group-title[aria-expanded="false"] .group-chevron {
-  transform: rotate(-90deg);
-}
-
-.placeholder-chip-list {
+.placeholder-command-list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-  max-height: 280px;
-  overflow-y: auto;
-  padding: 0 var(--space-3) var(--space-3);
+  gap: 6px;
 }
 
-.placeholder-chip {
+.placeholder-command-item {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: 3px;
   width: 100%;
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
+  min-height: 0;
+  padding: 7px 8px;
+  border: 0;
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--primary-text);
   cursor: pointer;
   text-align: left;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
 }
 
-.placeholder-chip:hover {
-  background: color-mix(in srgb, var(--primary-text) 3%, transparent);
+.placeholder-command-item:hover {
+  background: var(--accent-bg);
 }
 
-.placeholder-chip code {
+.placeholder-command-item code {
+  min-width: 0;
   color: var(--highlight-text);
   font-family: "Consolas", "Monaco", monospace;
   font-size: var(--font-size-helper);
-  word-break: break-all;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
-.placeholder-chip span {
+.placeholder-command-item span {
+  min-width: 0;
   color: var(--secondary-text);
   font-size: var(--font-size-caption);
   line-height: 1.4;
+  white-space: normal;
 }
 
 /* .empty-state 已在全局 layout.css 中统一定义 */

--- a/AdminPanel-Vue/src/views/EmojiGallery.vue
+++ b/AdminPanel-Vue/src/views/EmojiGallery.vue
@@ -24,130 +24,60 @@
         >
           新建目录
         </UiButton>
+
+        <UiButton
+          variant="outline"
+          :disabled="isUploading"
+          @click="triggerFileSelect"
+        >
+          选择图片
+        </UiButton>
+
+        <UiButton
+          variant="outline"
+          :disabled="isUploading"
+          @click="triggerFolderSelect"
+        >
+          文件夹
+        </UiButton>
+
+        <UiButton
+          variant="outline"
+          :disabled="isUploading"
+          @click="triggerArchiveSelect"
+        >
+          压缩包
+        </UiButton>
       </UiPageActions>
     </Teleport>
-
-    <header class="gallery-topbar">
-      <div class="gallery-heading-panel">
-        <div class="gallery-heading-copy">
-          <span class="gallery-kicker">Image Workspace</span>
-          <div>
-            <h2>表情包画廊</h2>
-            <p class="description">
-              浏览并整理 `image` 目录中的表情包资源，支持检索、目录筛选、上传导入、分页浏览与大图预览。
-            </p>
-          </div>
-        </div>
-
-        <div class="gallery-toolbar">
-          <label class="search-field gallery-search-field">
-            <span class="material-symbols-outlined">search</span>
-            <UiInput
-              v-model.trim="searchInput"
-              type="search"
-              aria-label="搜索表情包"
-              placeholder="搜索文件名、路径或目录…"
-              :disabled="isLoading"
-              @keydown.enter.prevent="applySearch"
-            />
-          </label>
-
-          <UiButton
-            variant="primary"
-            :disabled="isLoading"
-            @click="applySearch"
-          >
-            搜索
-          </UiButton>
-
-          <UiButton
-            v-if="activeKeyword"
-            variant="outline"
-            :disabled="isLoading"
-            @click="clearSearch"
-          >
-            清空
-          </UiButton>
-
-          <label class="page-size-control">
-            <span>每页</span>
-            <UiSelect
-              v-model.number="pageSize"
-              :disabled="isLoading"
-              @change="handlePageSizeChange"
-            >
-              <option
-                v-for="size in PAGE_SIZE_OPTIONS"
-                :key="size"
-                :value="size"
-              >
-                {{ size }}
-              </option>
-            </UiSelect>
-          </label>
-        </div>
-
-        <div class="gallery-filter-summary">
-          <span class="filter-pill" :class="{ active: selectedCategory === '' }">
-            {{ selectedCategory ? `目录：${selectedCategory}` : "全部目录" }}
-          </span>
-          <span v-if="activeKeyword" class="filter-pill active">
-            关键词：{{ activeKeyword }}
-          </span>
-          <span class="filter-pill">{{ paginationSummary }}</span>
-        </div>
-      </div>
-
-      <aside class="gallery-summary-card" aria-live="polite">
-        <div class="gallery-summary-grid">
-          <span class="gallery-summary-item">
-            <strong>{{ matchedEmojiCount }}</strong>
-            <span>命中</span>
-          </span>
-          <span class="gallery-summary-item">
-            <strong>{{ categories.length }}</strong>
-            <span>目录</span>
-          </span>
-          <span class="gallery-summary-item">
-            <strong>{{ items.length }}</strong>
-            <span>当前页</span>
-          </span>
-        </div>
-        <p>{{ refreshStateText }}</p>
-      </aside>
-    </header>
 
     <div class="gallery-workspace">
       <aside class="operations-column">
         <section class="operations-console" aria-label="表情包操作台">
           <div class="operations-console__section">
-            <div class="quick-actions">
-              <UiButton
-                variant="outline"
-                size="sm"
-                :disabled="isLoading"
-                @click="refreshCurrentPage"
-              >
-                刷新
-              </UiButton>
+            <span class="operations-console__label">操作台</span>
 
-              <UiButton
-                variant="outline"
-                size="sm"
-                :disabled="isLoading || isUploading"
-                @click="createCategory"
+            <div class="gallery-search-field">
+              <span class="material-symbols-outlined search-icon">search</span>
+              <UiInput
+                v-model.trim="searchInput"
+                type="search"
+                aria-label="搜索表情包"
+                placeholder="搜索文件名、路径或目录…"
+                :disabled="isLoading"
+              />
+              <UiIconButton
+                v-if="searchInput"
+                class="search-clear"
+                label="清除搜索"
+                title="清除搜索"
+                :disabled="isLoading"
+                @click="clearSearch"
               >
-                新建目录
-              </UiButton>
-              <UiButton
-                variant="outline"
-                size="sm"
-                :disabled="isRebuildingList"
-                @click="rebuildGeneratedEmojiLists"
-              >
-                重建列表
-              </UiButton>
+                <span class="material-symbols-outlined">close</span>
+              </UiIconButton>
             </div>
+
           </div>
 
           <div class="operations-console__section">
@@ -173,38 +103,46 @@
       </aside>
 
       <section class="content-column">
-        <section class="upload-console">
-          <div class="upload-console__header">
-            <div class="upload-console__title">
-              <span class="upload-console__label">本地上传</span>
-              <h3>上传图片、文件夹或压缩包</h3>
-            </div>
-            <div class="upload-console__meta">
-              <p class="panel-hint">
-                支持图片文件、文件夹与压缩包上传。若目录名以“表情包”结尾，可同步生成 EmojiListGenerator 列表。
-              </p>
-              <p
-                v-if="uploadMode === 'files'"
-                class="upload-target-tip"
-              >
-                上传到：{{ effectiveUploadCategory }}
-              </p>
-              <p
-                v-else-if="uploadMode === 'folder'"
-                class="upload-target-tip"
-              >
-                保留文件夹原始目录结构
-              </p>
-              <p
-                v-else-if="uploadMode === 'archive'"
-                class="upload-target-tip"
-              >
-                解压后保留内部结构
-              </p>
-            </div>
-          </div>
+        <input
+          ref="fileInputRef"
+          class="upload-file-input"
+          type="file"
+          :accept="IMAGE_UPLOAD_ACCEPT"
+          multiple
+          @change="handleFileSelected"
+        />
 
-          <div class="upload-console__body">
+        <input
+          ref="folderInputRef"
+          class="upload-file-input"
+          type="file"
+          :accept="IMAGE_UPLOAD_ACCEPT"
+          webkitdirectory
+          directory
+          multiple
+          @change="handleFolderSelected"
+        />
+
+        <input
+          ref="archiveInputRef"
+          class="upload-file-input"
+          type="file"
+          :accept="ARCHIVE_UPLOAD_ACCEPT"
+          @change="handleArchiveSelected"
+        />
+
+        <section
+          v-if="selectedFiles.length > 0 || lastRejectedItems.length > 0"
+          class="upload-queue-panel"
+        >
+          <div v-if="selectedFiles.length > 0" class="upload-queue">
+            <div class="upload-summary">
+              <span>模式：{{ selectedUploadModeLabel }}</span>
+              <span>文件：{{ selectedFiles.length }}</span>
+              <span>总大小：{{ formatFileSize(selectedUploadTotalSize) }}</span>
+              <span v-if="uploadMode === 'files'">上传到：{{ effectiveUploadCategory }}</span>
+            </div>
+
             <AppCheckbox
               v-model="uploadSyncList"
               class="upload-sync-option"
@@ -212,68 +150,6 @@
             >
               上传后同步重建 generated_lists
             </AppCheckbox>
-
-            <div class="upload-entry-actions">
-              <UiButton
-                variant="outline"
-                :disabled="isUploading"
-                @click="triggerFileSelect"
-              >
-                选择图片文件
-              </UiButton>
-
-              <UiButton
-                variant="outline"
-                :disabled="isUploading"
-                @click="triggerFolderSelect"
-              >
-                选择文件夹
-              </UiButton>
-
-              <UiButton
-                variant="outline"
-                :disabled="isUploading"
-                @click="triggerArchiveSelect"
-              >
-                选择压缩包
-              </UiButton>
-            </div>
-          </div>
-
-          <input
-            ref="fileInputRef"
-            class="upload-file-input"
-            type="file"
-            :accept="IMAGE_UPLOAD_ACCEPT"
-            multiple
-            @change="handleFileSelected"
-          />
-
-          <input
-            ref="folderInputRef"
-            class="upload-file-input"
-            type="file"
-            :accept="IMAGE_UPLOAD_ACCEPT"
-            webkitdirectory
-            directory
-            multiple
-            @change="handleFolderSelected"
-          />
-
-          <input
-            ref="archiveInputRef"
-            class="upload-file-input"
-            type="file"
-            :accept="ARCHIVE_UPLOAD_ACCEPT"
-            @change="handleArchiveSelected"
-          />
-
-          <div v-if="selectedFiles.length > 0" class="upload-queue">
-            <div class="upload-summary">
-              <span>模式：{{ selectedUploadModeLabel }}</span>
-              <span>文件：{{ selectedFiles.length }}</span>
-              <span>总大小：{{ formatFileSize(selectedUploadTotalSize) }}</span>
-            </div>
 
             <ul class="upload-file-list">
               <li
@@ -307,18 +183,20 @@
             <div class="upload-actions">
               <UiButton
                 variant="outline"
+                size="sm"
                 :disabled="isUploading || selectedFiles.length === 0"
                 @click="clearSelectedFiles"
               >
-                清空待上传
+                清空
               </UiButton>
 
               <UiButton
                 variant="primary"
+                size="sm"
                 :disabled="isUploading || selectedFiles.length === 0"
                 @click="uploadSelectedFiles"
               >
-                {{ isUploading ? "上传中…" : `开始上传（${selectedFiles.length}）` }}
+                {{ isUploading ? "上传中…" : `上传（${selectedFiles.length}）` }}
               </UiButton>
             </div>
           </div>
@@ -330,7 +208,7 @@
               @click="showRejectedList = !showRejectedList"
             >
               <span>
-                最近一次校验有 {{ lastRejectedItems.length }} 个文件被过滤
+                {{ lastRejectedItems.length }} 个文件被过滤
               </span>
               <span>{{ showRejectedList ? "收起" : "展开" }}</span>
             </button>
@@ -351,10 +229,23 @@
 
         <section class="overview-card" aria-live="polite">
           <div class="content-header">
-            <h3>
-              {{ selectedCategory ? `${selectedCategory} · 表情包` : "全部目录 · 表情包" }}
-            </h3>
-            <p>{{ paginationSummary }}</p>
+            <div>
+              <h3>
+                {{ selectedCategory ? `${selectedCategory} · 表情包` : "全部目录 · 表情包" }}
+              </h3>
+              <p>{{ refreshStateText }}</p>
+            </div>
+
+            <span class="pagination-summary">{{ paginationSummary }}</span>
+          </div>
+
+          <div class="gallery-filter-summary">
+            <span class="filter-pill" :class="{ active: selectedCategory === '' }">
+              {{ selectedCategory ? `目录：${selectedCategory}` : "全部目录" }}
+            </span>
+            <span v-if="activeKeyword" class="filter-pill active">
+              关键词：{{ activeKeyword }}
+            </span>
           </div>
 
           <section class="stats-strip">
@@ -399,69 +290,89 @@
           </div>
 
           <section class="emoji-grid" aria-label="表情包列表">
-          <article
-            v-for="(item, index) in items"
-            :key="item.relativePath"
-            class="emoji-card"
-            v-memo="[item.relativePath, deletingPaths.has(item.relativePath)]"
-            :style="{ '--stagger-delay': `${Math.min(index, 24) * 22}ms` }"
-          >
-            <button
-              type="button"
-              class="preview-shell"
-              :aria-label="`预览 ${item.name}`"
-              @click="openPreview(item)"
+            <article
+              v-for="(item, index) in items"
+              :key="item.relativePath"
+              class="emoji-card"
+              v-memo="[item.relativePath, deletingPaths.has(item.relativePath)]"
+              :style="{ '--stagger-delay': `${Math.min(index, 24) * 22}ms` }"
             >
-              <img
-                v-lazy="item.thumbnailUrl"
-                :alt="item.name"
-                decoding="async"
-                loading="lazy"
-              />
-            </button>
+              <details class="emoji-card-menu">
+                <summary aria-label="表情包操作">
+                  <span class="material-symbols-outlined">more_horiz</span>
+                </summary>
 
-            <div class="emoji-meta">
-              <div class="emoji-title-row">
-                <h3 :title="item.name">{{ item.name }}</h3>
-              <UiBadge variant="outline" class="format-badge">{{ item.extension.toUpperCase() }}</UiBadge>
+                <div class="emoji-card-menu__content">
+                  <button
+                    type="button"
+                    @click="copyRelativePath(item.relativePath)"
+                  >
+                    复制路径
+                  </button>
+
+                  <a
+                    :href="item.previewUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    新窗口打开
+                  </a>
+
+                  <button
+                    type="button"
+                    class="danger"
+                    :disabled="deletingPaths.has(item.relativePath)"
+                    @click="deleteEmojiItem(item)"
+                  >
+                    {{ deletingPaths.has(item.relativePath) ? "删除中…" : "删除" }}
+                  </button>
+                </div>
+              </details>
+
+              <button
+                type="button"
+                class="preview-shell"
+                :aria-label="`预览 ${item.name}`"
+                @click="openPreview(item)"
+              >
+                <img
+                  v-lazy="item.thumbnailUrl"
+                  :alt="item.name"
+                  decoding="async"
+                  loading="lazy"
+                />
+              </button>
+
+              <div class="emoji-meta">
+                <p class="emoji-path" :title="item.relativePath">{{ item.relativePath }}</p>
               </div>
-
-              <p class="emoji-category">{{ item.category }}</p>
-              <p class="emoji-path" :title="item.relativePath">{{ item.relativePath }}</p>
-            </div>
-
-            <div class="emoji-actions">
-              <UiButton
-                variant="outline"
-                size="sm"
-                @click="copyRelativePath(item.relativePath)"
-              >
-                复制路径
-              </UiButton>
-
-              <a
-                class="emoji-link-button"
-                :href="item.previewUrl"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                新窗口
-              </a>
-
-              <UiButton
-                variant="danger"
-                size="sm"
-                :disabled="deletingPaths.has(item.relativePath)"
-                @click="deleteEmojiItem(item)"
-              >
-                {{ deletingPaths.has(item.relativePath) ? "删除中…" : "删除" }}
-              </UiButton>
-            </div>
-          </article>
+            </article>
           </section>
         </section>
 
         <section class="pagination-controls">
+          <div class="pagination-size-control">
+            <span>共 {{ matchedEmojiCount }} 项</span>
+
+            <label class="page-size-control">
+              <span>每页</span>
+              <UiSelect
+                v-model.number="pageSize"
+                :disabled="isLoading"
+                @change="handlePageSizeChange"
+              >
+                <option
+                  v-for="size in PAGE_SIZE_OPTIONS"
+                  :key="size"
+                  :value="size"
+                >
+                  {{ size }}
+                </option>
+              </UiSelect>
+            </label>
+          </div>
+
+          <div class="pagination-nav">
           <UiButton
             variant="outline"
             :disabled="isLoading || currentPage <= 1"
@@ -479,6 +390,7 @@
           >
             下一页
           </UiButton>
+          </div>
         </section>
       </section>
     </div>
@@ -550,8 +462,8 @@ import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from "vue";
 import { useRoute, useRouter, type LocationQueryRaw } from "vue-router";
 import BaseModal from "@/components/ui/BaseModal.vue";
 import AppCheckbox from "@/components/ui/AppCheckbox.vue";
-import UiBadge from "@/components/ui/UiBadge.vue";
 import UiButton from "@/components/ui/UiButton.vue";
+import UiIconButton from "@/components/ui/UiIconButton.vue";
 import UiInput from "@/components/ui/UiInput.vue";
 import UiPageActions from "@/components/ui/UiPageActions.vue";
 import UiSelect from "@/components/ui/UiSelect.vue";
@@ -642,6 +554,7 @@ const lastRejectedItems = ref<Array<{ fileName: string; reason: string }>>([]);
 const showRejectedList = ref(false);
 
 let currentLoadController: AbortController | null = null;
+let searchSyncTimer: ReturnType<typeof setTimeout> | null = null;
 
 const totalEmojiCount = computed(() =>
   categories.value.reduce((sum, category) => sum + category.totalCount, 0)
@@ -893,15 +806,6 @@ async function loadGallery(
   }
 }
 
-function applySearch(): void {
-  const nextKeyword = searchInput.value.trim();
-  if (nextKeyword === activeKeyword.value) {
-    return;
-  }
-  activeKeyword.value = nextKeyword;
-  void loadGallery(1);
-}
-
 function clearSearch(): void {
   searchInput.value = "";
   if (activeKeyword.value === "") {
@@ -912,10 +816,21 @@ function clearSearch(): void {
 }
 
 watch(searchInput, (nextValue) => {
-  if (nextValue.trim() === "" && activeKeyword.value !== "") {
-    activeKeyword.value = "";
-    void loadGallery(1);
+  if (searchSyncTimer) {
+    clearTimeout(searchSyncTimer);
+    searchSyncTimer = null;
   }
+
+  const nextKeyword = nextValue.trim();
+  if (nextKeyword === activeKeyword.value) {
+    return;
+  }
+
+  searchSyncTimer = setTimeout(() => {
+    activeKeyword.value = nextKeyword;
+    void loadGallery(1);
+    searchSyncTimer = null;
+  }, 260);
 });
 
 watch(
@@ -1515,6 +1430,11 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  if (searchSyncTimer) {
+    clearTimeout(searchSyncTimer);
+    searchSyncTimer = null;
+  }
+
   if (currentLoadController) {
     currentLoadController.abort();
     currentLoadController = null;
@@ -1527,97 +1447,6 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-}
-
-.gallery-topbar {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 360px);
-  gap: var(--space-4);
-  align-items: stretch;
-}
-
-.gallery-heading-panel,
-.gallery-summary-card {
-  border: 1px solid color-mix(in srgb, var(--border-color) 96%, transparent);
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--primary-text) 1.5%, transparent);
-}
-
-.gallery-heading-panel {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  padding: var(--space-4);
-}
-
-.gallery-heading-copy {
-  display: grid;
-  gap: var(--space-1);
-}
-
-.gallery-kicker {
-  color: var(--secondary-text);
-  font-size: var(--font-size-caption);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.gallery-heading-copy h2 {
-  margin: 0;
-  color: var(--primary-text);
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.4;
-}
-
-.gallery-toolbar,
-.gallery-filter-summary {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-}
-
-.gallery-search-field {
-  flex: 1 1 280px;
-  max-width: 520px;
-}
-
-.gallery-summary-card {
-  display: grid;
-  align-content: space-between;
-  gap: var(--space-3);
-  padding: 14px 16px;
-}
-
-.gallery-summary-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-2);
-}
-
-.gallery-summary-item {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
-}
-
-.gallery-summary-item strong {
-  color: var(--primary-text);
-  font-size: var(--font-size-emphasis);
-  line-height: 1.1;
-}
-
-.gallery-summary-item span,
-.gallery-summary-card p {
-  color: var(--secondary-text);
-  font-size: var(--font-size-caption);
-}
-
-.gallery-summary-card p {
-  margin: 0;
-  line-height: 1.45;
 }
 
 .filter-pill {
@@ -1638,54 +1467,6 @@ onUnmounted(() => {
   background: color-mix(in srgb, var(--highlight-text) 8%, transparent);
 }
 
-.description {
-  margin: 0;
-  color: var(--secondary-text);
-  white-space: normal;
-  font-size: var(--font-size-helper);
-  line-height: 1.55;
-  max-width: 72ch;
-}
-
-.upload-console {
-  display: grid;
-  gap: var(--space-3);
-  padding: var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--border-color) 90%, transparent);
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--primary-text) 1.6%, transparent);
-}
-
-.upload-console__header {
-  display: grid;
-  grid-template-columns: minmax(170px, 0.34fr) minmax(0, 1fr);
-  gap: var(--space-3);
-  align-items: start;
-  padding-bottom: var(--space-3);
-  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
-}
-
-.upload-console__title,
-.upload-console__meta {
-  display: grid;
-  gap: var(--space-xs);
-}
-
-.upload-console__header h3 {
-  margin: 0;
-  font-size: var(--font-size-emphasis);
-  line-height: 1.4;
-}
-
-.upload-console__body {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-}
-
-.upload-console__label,
 .operations-console__label {
   color: var(--secondary-text);
   font-size: var(--font-size-caption);
@@ -1696,7 +1477,7 @@ onUnmounted(() => {
 
 .gallery-workspace {
   display: grid;
-  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+  grid-template-columns: minmax(230px, 270px) minmax(0, 1fr);
   gap: var(--space-4);
   align-items: start;
 }
@@ -1713,7 +1494,7 @@ onUnmounted(() => {
 .operations-console {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: var(--space-4);
   min-height: 0;
   height: 100%;
 }
@@ -1737,7 +1518,7 @@ onUnmounted(() => {
   gap: var(--space-2);
 }
 
-.operations-console__section + .operations-console__section {
+.operations-console__section:last-child {
   min-height: 0;
   flex: 1;
   overflow: hidden;
@@ -1751,57 +1532,57 @@ onUnmounted(() => {
 .page-size-control {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--space-sm);
   color: var(--secondary-text);
-}
-
-.panel-hint {
-  margin: 0;
-  color: var(--secondary-text);
   font-size: var(--font-size-helper);
-  line-height: 1.55;
 }
 
-.quick-actions,
-.upload-entry-actions,
+.page-size-control :deep(.ui-select) {
+  width: 88px;
+}
+
 .upload-actions {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-sm);
 }
 
-.search-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-}
-
-.search-row > button {
-  white-space: nowrap;
-}
-
-.search-field {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-sm);
+.upload-actions :deep(.ui-button) {
   flex: 1 1 auto;
   min-width: 0;
 }
 
-.search-field .material-symbols-outlined {
+.gallery-search-field {
+  position: relative;
+  width: 100%;
+}
+
+.gallery-search-field :deep(.ui-input) {
+  width: 100%;
+  padding-left: 34px;
+  padding-right: 32px;
+}
+
+.gallery-search-field .search-icon {
+  position: absolute;
+  top: 50%;
+  left: 10px;
+  transform: translateY(-50%);
   color: var(--secondary-text);
-  font-size: 1.2rem;
+  font-size: 18px !important;
+  pointer-events: none;
 }
 
-.search-field :deep(.ui-input) {
-  min-width: 0;
+.gallery-search-field .search-clear {
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
 }
 
-.upload-target-tip {
-  margin: 0;
-  color: var(--primary-text);
-  font-size: var(--font-size-helper);
-  font-weight: 500;
+.gallery-search-field .search-clear .material-symbols-outlined {
+  font-size: 16px !important;
 }
 
 .upload-sync-option {
@@ -1818,11 +1599,18 @@ onUnmounted(() => {
   display: none;
 }
 
+.upload-queue-panel {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--border-color) 88%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--primary-text) 1.4%, transparent);
+}
+
 .upload-queue {
   display: grid;
   gap: var(--space-2);
-  padding-top: var(--space-2);
-  border-top: 1px solid color-mix(in srgb, var(--border-color) 68%, transparent);
 }
 
 .upload-summary {
@@ -1890,6 +1678,10 @@ onUnmounted(() => {
   font-size: var(--font-size-caption);
 }
 
+.upload-file-remove {
+  justify-self: end;
+}
+
 .upload-file-remove:hover {
   color: var(--danger-color);
 }
@@ -1903,7 +1695,7 @@ onUnmounted(() => {
 .overview-card {
   display: grid;
   gap: var(--space-2);
-  padding: var(--space-3);
+  padding: 10px var(--space-3);
   border: 1px solid color-mix(in srgb, var(--border-color) 90%, transparent);
   border-radius: var(--radius-lg);
   background: transparent;
@@ -1919,13 +1711,15 @@ onUnmounted(() => {
 
 .content-header h3 {
   margin: 0;
-  font-size: var(--font-size-title);
+  font-size: var(--font-size-emphasis);
+  line-height: 1.35;
 }
 
 .content-header p {
-  margin: 0;
+  margin: 2px 0 0;
   color: var(--secondary-text);
   font-size: var(--font-size-helper);
+  line-height: 1.4;
 }
 
 .stats-strip {
@@ -1988,9 +1782,10 @@ onUnmounted(() => {
 }
 
 .emoji-card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm);
+  gap: 0;
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--border-color) 86%, transparent);
   background: color-mix(in srgb, var(--primary-text) 1.2%, transparent);
@@ -2011,6 +1806,91 @@ onUnmounted(() => {
 
 .emoji-card--skeleton {
   overflow: hidden;
+}
+
+.emoji-card-menu {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 3;
+}
+
+.emoji-card-menu summary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--primary-bg) 72%, transparent);
+  color: var(--primary-text);
+  backdrop-filter: blur(10px);
+  cursor: pointer;
+  list-style: none;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.emoji-card-menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.emoji-card-menu summary:hover,
+.emoji-card-menu[open] summary {
+  border-color: color-mix(in srgb, var(--highlight-text) 30%, var(--border-color));
+  background: color-mix(in srgb, var(--accent-bg) 82%, transparent);
+}
+
+.emoji-card-menu summary .material-symbols-outlined {
+  font-size: 18px !important;
+}
+
+.emoji-card-menu__content {
+  position: absolute;
+  top: 36px;
+  right: 0;
+  display: grid;
+  gap: 2px;
+  min-width: 128px;
+  padding: 4px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 88%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary-bg) 94%, transparent);
+  box-shadow: var(--overlay-panel-shadow);
+}
+
+.emoji-card-menu__content button,
+.emoji-card-menu__content a {
+  display: flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 9px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--primary-text);
+  font: inherit;
+  font-size: var(--font-size-helper);
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.emoji-card-menu__content button:hover,
+.emoji-card-menu__content a:hover {
+  background: var(--accent-bg);
+}
+
+.emoji-card-menu__content button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.emoji-card-menu__content .danger {
+  color: var(--danger-color);
 }
 
 .preview-shell {
@@ -2080,84 +1960,48 @@ onUnmounted(() => {
 .emoji-meta {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 0 var(--space-sm);
-}
-
-.emoji-title-row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-sm);
-}
-
-.emoji-title-row h3 {
-  margin: 0;
-  font-size: var(--font-size-body);
-  line-height: 1.45;
-  word-break: break-word;
-}
-
-.format-badge {
-  flex-shrink: 0;
-  font-size: var(--font-size-caption);
-}
-
-.emoji-category {
-  margin: 0;
-  color: var(--secondary-text);
-  font-size: var(--font-size-helper);
+  padding: 8px 10px 10px;
 }
 
 .emoji-path {
   margin: 0;
   color: var(--secondary-text);
   font-size: var(--font-size-caption);
-  word-break: break-all;
-}
-
-.emoji-actions {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-xs);
-  padding: 0 var(--space-sm) var(--space-sm);
-}
-
-.emoji-link-button {
-  height: 28px;
-  text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 10px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--primary-text);
-  font-size: var(--font-size-helper);
-  font-weight: 600;
-  line-height: 1;
-  transition:
-    color var(--transition-fast),
-    background-color var(--transition-fast),
-    border-color var(--transition-fast);
-}
-
-.emoji-link-button:hover {
-  background: color-mix(in srgb, var(--primary-text) 3%, transparent);
-  color: var(--primary-text);
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pagination-controls {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-  gap: var(--space-md);
+  gap: var(--space-3);
   flex-wrap: wrap;
+  min-height: 40px;
+  padding: var(--space-2) 0;
 }
 
 .pagination-summary {
   color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+}
+
+.pagination-size-control,
+.pagination-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.pagination-size-control {
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+}
+
+.pagination-size-control > span {
+  white-space: nowrap;
 }
 
 .preview-modal {
@@ -2325,17 +2169,12 @@ onUnmounted(() => {
 }
 
 @media (max-width: 1200px) {
-  .gallery-topbar {
-    grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
-  }
-
   .gallery-workspace {
     grid-template-columns: minmax(210px, 240px) minmax(0, 1fr);
   }
 }
 
 @media (max-width: 1024px) {
-  .gallery-topbar,
   .gallery-workspace {
     grid-template-columns: 1fr;
   }
@@ -2348,19 +2187,7 @@ onUnmounted(() => {
 }
 
 @media (max-width: 768px) {
-  .gallery-heading-panel,
-  .gallery-summary-card {
-    padding: var(--space-3);
-  }
-
-  .gallery-summary-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .gallery-toolbar,
   .gallery-filter-summary,
-  .quick-actions,
-  .upload-entry-actions,
   .upload-actions {
     display: grid;
     grid-template-columns: 1fr;
@@ -2369,10 +2196,6 @@ onUnmounted(() => {
   .gallery-search-field {
     min-width: 0;
     max-width: none;
-  }
-
-  .upload-console__header {
-    grid-template-columns: 1fr;
   }
 
   .upload-file-item {
@@ -2396,10 +2219,6 @@ onUnmounted(() => {
 
   .emoji-grid {
     grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
-  }
-
-  .emoji-actions {
-    grid-template-columns: 1fr;
   }
 
   .preview-nav--prev {


### PR DESCRIPTION
## 变更内容

本次 PR 继续优化 AdminPanel 的页面布局与视觉细节，包含 Agent 文件编辑器和表情图库两个页面。

- 优化 Agent 文件编辑器三栏布局：右栏放宽、中栏收窄，让编辑区和右侧辅助信息区比例更合理。
- 优化右侧占位符面板：加入横向切换器，改善命令列表/占位符内容切换体验。
- 改善占位符展示：避免文本截断，支持完整显示和内部滚动。
- 优化 EmojiGallery 页面布局，整理页面结构和样式，减少冗余并提升整体可读性。

## 验证

- `cd AdminPanel-Vue && npx vue-tsc --noEmit`
- `git diff --check`

## 说明

- 基于最新 `origin/main` 整理。
- PR 范围仅包含 AdminPanel 页面源码改动。
- 不包含 `design.md`，也不包含无关 `dist` 构建产物。