### PR TITLE
Codex/adminpanel upstream latest

### DIFF
--- a/AdminPanel-Vue/src/components/layout/ThemeQuickDrawer.vue
+++ b/AdminPanel-Vue/src/components/layout/ThemeQuickDrawer.vue
@@ -1,0 +1,586 @@
+<template>
+  <Teleport to="body">
+    <Transition name="theme-quick-drawer">
+      <div
+        v-if="open"
+        class="theme-quick"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="theme-quick-title"
+        @keydown.esc="emitClose"
+      >
+        <button
+          class="theme-quick__scrim"
+          type="button"
+          aria-label="关闭快捷外观"
+          @click="emitClose"
+        />
+
+        <aside class="theme-quick__panel">
+          <header class="theme-quick__header">
+            <div>
+              <h2 id="theme-quick-title">快捷外观</h2>
+              <p>快速调整面板外观与布局偏好。</p>
+            </div>
+            <UiIconButton label="关闭快捷外观" title="关闭" @click="emitClose">
+              <span class="material-symbols-outlined" aria-hidden="true">close</span>
+            </UiIconButton>
+          </header>
+
+          <div class="theme-quick__body">
+            <section class="theme-quick__section">
+              <h3>预设主题</h3>
+              <div class="theme-quick__preset-grid">
+                <button
+                  v-for="preset in presets"
+                  :key="preset.id"
+                  type="button"
+                  class="theme-quick__preset"
+                  :class="{ 'theme-quick__preset--active': activePresetId === preset.id }"
+                  @click="applyPreset(preset)"
+                >
+                  <span class="theme-quick__preset-swatches" aria-hidden="true">
+                    <span
+                      v-for="(color, index) in getPresetSwatches(preset)"
+                      :key="index"
+                      :style="{ backgroundColor: color }"
+                    />
+                  </span>
+                  <span class="theme-quick__preset-label">{{ preset.label }}</span>
+                  <span class="theme-quick__check material-symbols-outlined" aria-hidden="true">check_circle</span>
+                </button>
+              </div>
+            </section>
+
+            <section class="theme-quick__section">
+              <h3>外观</h3>
+              <div class="theme-quick__grid theme-quick__grid--two">
+                <button
+                  v-for="item in themeModeOptions"
+                  :key="item.id"
+                  type="button"
+                  class="theme-quick__choice theme-quick__choice--icon"
+                  :class="{ 'theme-quick__choice--active': settings.themeMode === item.id }"
+                  @click="updateQuickSetting('themeMode', item.id)"
+                >
+                  <span class="theme-quick__preview" aria-hidden="true">
+                    <span class="material-symbols-outlined">{{ item.icon }}</span>
+                  </span>
+                  <span>{{ item.label }}</span>
+                  <span class="theme-quick__check material-symbols-outlined" aria-hidden="true">check_circle</span>
+                </button>
+              </div>
+            </section>
+
+            <section class="theme-quick__section">
+              <h3>圆角</h3>
+              <div class="theme-quick__grid theme-quick__grid--three">
+                <button
+                  v-for="item in radiusOptions"
+                  :key="item.id"
+                  type="button"
+                  class="theme-quick__choice theme-quick__choice--radius"
+                  :class="{ 'theme-quick__choice--active': settings.radius === item.id }"
+                  @click="updateQuickSetting('radius', item.id)"
+                >
+                  <span class="theme-quick__radius-preview" aria-hidden="true">
+                    <span :style="{ borderTopLeftRadius: item.preview }" />
+                  </span>
+                  <span>{{ item.label }}</span>
+                  <small>{{ item.description }}</small>
+                  <span class="theme-quick__check material-symbols-outlined" aria-hidden="true">check_circle</span>
+                </button>
+              </div>
+            </section>
+
+            <section class="theme-quick__section">
+              <h3>密度</h3>
+              <div class="theme-quick__grid theme-quick__grid--two">
+                <button
+                  v-for="item in scaleOptions"
+                  :key="item.id"
+                  type="button"
+                  class="theme-quick__choice"
+                  :class="{ 'theme-quick__choice--active': settings.scale === item.id }"
+                  @click="updateQuickSetting('scale', item.id)"
+                >
+                  <span>{{ item.label }}</span>
+                  <small>{{ item.description }}</small>
+                  <span class="theme-quick__check material-symbols-outlined" aria-hidden="true">check_circle</span>
+                </button>
+              </div>
+            </section>
+
+            <section class="theme-quick__section">
+              <h3>字体</h3>
+              <div class="theme-quick__grid theme-quick__grid--three">
+                <button
+                  v-for="item in fontOptions"
+                  :key="item.id"
+                  type="button"
+                  class="theme-quick__choice"
+                  :class="{ 'theme-quick__choice--active': settings.font === item.id }"
+                  @click="updateQuickSetting('font', item.id)"
+                >
+                  <span>{{ item.label }}</span>
+                  <small>{{ item.description }}</small>
+                  <span class="theme-quick__check material-symbols-outlined" aria-hidden="true">check_circle</span>
+                </button>
+              </div>
+            </section>
+
+            <section class="theme-quick__section">
+              <h3>布局</h3>
+              <div class="theme-quick__grid theme-quick__grid--two">
+                <button
+                  v-for="item in contentLayoutOptions"
+                  :key="item.id"
+                  type="button"
+                  class="theme-quick__choice"
+                  :class="{ 'theme-quick__choice--active': settings.contentLayout === item.id }"
+                  @click="updateQuickSetting('contentLayout', item.id)"
+                >
+                  <span>{{ item.label }}</span>
+                  <small>{{ item.description }}</small>
+                  <span class="theme-quick__check material-symbols-outlined" aria-hidden="true">check_circle</span>
+                </button>
+              </div>
+            </section>
+
+            <section class="theme-quick__section">
+              <h3>外壳</h3>
+              <div class="theme-quick__grid theme-quick__grid--two">
+                <button
+                  v-for="item in shellLayoutOptions"
+                  :key="item.id"
+                  type="button"
+                  class="theme-quick__choice"
+                  :class="{ 'theme-quick__choice--active': settings.shellLayout === item.id }"
+                  @click="updateQuickSetting('shellLayout', item.id)"
+                >
+                  <span>{{ item.label }}</span>
+                  <small>{{ item.description }}</small>
+                  <span class="theme-quick__check material-symbols-outlined" aria-hidden="true">check_circle</span>
+                </button>
+              </div>
+            </section>
+          </div>
+
+          <footer class="theme-quick__footer">
+            <UiButton variant="outline" size="lg" block @click="openThemeEditor">
+              <template #leading>
+                <span class="material-symbols-outlined">tune</span>
+              </template>
+              打开完整主题编辑器
+            </UiButton>
+          </footer>
+        </aside>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import UiButton from "@/components/ui/UiButton.vue";
+import UiIconButton from "@/components/ui/UiIconButton.vue";
+import { useAppStore } from "@/stores/app";
+import {
+  applyActiveTheme,
+  FULL_PRESET_THEMES,
+  loadActivePresetId,
+  loadThemeQuickSettings,
+  notifyThemeSettingsChanged,
+  saveActivePresetId,
+  saveThemeQuickSettings,
+  THEME_CONTENT_LAYOUT_OPTIONS,
+  THEME_FONT_OPTIONS,
+  THEME_MODE_OPTIONS,
+  THEME_RADIUS_OPTIONS,
+  THEME_SCALE_OPTIONS,
+  THEME_SHELL_LAYOUT_OPTIONS,
+  type FullPresetTheme,
+  type ThemeQuickSettings,
+} from "@/features/theme-editor/themeEngine";
+
+const props = defineProps<{
+  open: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const router = useRouter();
+const appStore = useAppStore();
+
+const themeModeOptions = THEME_MODE_OPTIONS;
+const radiusOptions = THEME_RADIUS_OPTIONS;
+const scaleOptions = THEME_SCALE_OPTIONS;
+const fontOptions = THEME_FONT_OPTIONS;
+const contentLayoutOptions = THEME_CONTENT_LAYOUT_OPTIONS;
+const shellLayoutOptions = THEME_SHELL_LAYOUT_OPTIONS;
+const presets = FULL_PRESET_THEMES;
+
+const settings = reactive<ThemeQuickSettings>(loadThemeQuickSettings());
+const activePresetId = ref(loadActivePresetId() || "default-blue");
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (!isOpen) return;
+    Object.assign(settings, loadThemeQuickSettings());
+    activePresetId.value = loadActivePresetId() || "default-blue";
+  }
+);
+
+function updateQuickSetting<K extends keyof ThemeQuickSettings>(
+  key: K,
+  value: ThemeQuickSettings[K]
+) {
+  settings[key] = value;
+  saveThemeQuickSettings(settings);
+
+  if (key === "themeMode") {
+    appStore.setTheme(settings.themeMode);
+  }
+
+  applyActiveTheme();
+  notifyThemeSettingsChanged();
+}
+
+function getPresetSwatches(preset: FullPresetTheme): string[] {
+  if (preset.swatches?.length) {
+    return preset.swatches.slice(0, 3);
+  }
+
+  return [
+    preset.colors["--highlight-text-dark"] || "oklch(0.75 0.14 230)",
+    preset.colors["--button-bg-dark"] || "oklch(0.68 0.16 230)",
+    preset.colors["--accent-bg-dark"] || "oklch(0.30 0.08 230)",
+  ];
+}
+
+function applyPreset(preset: FullPresetTheme) {
+  activePresetId.value = preset.id;
+  saveActivePresetId(preset.id);
+
+  if (preset.defaultRadius) {
+    settings.radius = preset.defaultRadius;
+  }
+  if (preset.defaultFont) {
+    settings.font = preset.defaultFont;
+  }
+
+  saveThemeQuickSettings(settings);
+  applyActiveTheme();
+  notifyThemeSettingsChanged();
+}
+
+function emitClose() {
+  emit("close");
+}
+
+function openThemeEditor() {
+  emitClose();
+  router.push({ name: "ThemeEditor" });
+}
+</script>
+
+<style scoped>
+.theme-quick {
+  position: fixed;
+  inset: 0;
+  z-index: 2147482000;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.theme-quick__scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: color-mix(in srgb, var(--primary-bg) 34%, transparent);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  cursor: default;
+}
+
+.theme-quick__panel {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  width: min(420px, calc(100vw - 16px));
+  height: 100%;
+  background: color-mix(in srgb, var(--secondary-bg) 98%, var(--primary-bg));
+  border-left: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+  box-shadow: var(--shadow-overlay-soft);
+  color: var(--primary-text);
+}
+
+.theme-quick__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 18px 14px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+}
+
+.theme-quick__header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 650;
+  line-height: 1.35;
+  letter-spacing: 0;
+}
+
+.theme-quick__header p {
+  margin: 4px 0 0;
+  color: var(--secondary-text);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+}
+
+.theme-quick__body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px 18px 18px;
+}
+
+.theme-quick__section {
+  display: grid;
+  gap: 8px;
+}
+
+.theme-quick__section h3 {
+  margin: 0;
+  color: var(--secondary-text);
+  font-size: 0.8125rem;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.theme-quick__grid {
+  display: grid;
+  gap: 8px;
+}
+
+.theme-quick__grid--two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.theme-quick__grid--three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.theme-quick__preset-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.theme-quick__preset {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 7px 10px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 86%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary-text) 1.4%, transparent);
+  color: var(--primary-text);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.theme-quick__preset:hover {
+  border-color: color-mix(in srgb, var(--highlight-text) 34%, var(--border-color));
+  background: color-mix(in srgb, var(--highlight-text) 4%, transparent);
+}
+
+.theme-quick__preset:focus-visible {
+  outline: 2px solid var(--highlight-text);
+  outline-offset: 2px;
+}
+
+.theme-quick__preset--active {
+  border-color: color-mix(in srgb, var(--highlight-text) 76%, var(--border-color));
+  background: color-mix(in srgb, var(--highlight-text) 7%, transparent);
+}
+
+.theme-quick__preset-swatches {
+  display: inline-flex;
+  align-items: center;
+  width: 38px;
+  height: 18px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
+  border-radius: 999px;
+}
+
+.theme-quick__preset-swatches span {
+  flex: 1 1 0;
+  align-self: stretch;
+}
+
+.theme-quick__preset-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.theme-quick__choice {
+  position: relative;
+  display: grid;
+  align-content: start;
+  gap: 4px;
+  min-height: 56px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 86%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary-text) 1.4%, transparent);
+  color: var(--primary-text);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    background-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.theme-quick__choice:hover {
+  border-color: color-mix(in srgb, var(--highlight-text) 34%, var(--border-color));
+  background: color-mix(in srgb, var(--highlight-text) 4%, transparent);
+}
+
+.theme-quick__choice:focus-visible {
+  outline: 2px solid var(--highlight-text);
+  outline-offset: 2px;
+}
+
+.theme-quick__choice > span:not(.theme-quick__preview):not(.theme-quick__check):not(.theme-quick__radius-preview) {
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.theme-quick__choice small {
+  color: var(--secondary-text);
+  font-size: 0.6875rem;
+  line-height: 1.3;
+}
+
+.theme-quick__choice--active {
+  border-color: color-mix(in srgb, var(--highlight-text) 76%, var(--border-color));
+  background: color-mix(in srgb, var(--highlight-text) 7%, transparent);
+}
+
+.theme-quick__choice--icon {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  min-height: 48px;
+}
+
+.theme-quick__preview {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent-bg) 72%, transparent);
+  color: var(--primary-text);
+}
+
+.theme-quick__preview .material-symbols-outlined {
+  font-size: 17px;
+}
+
+.theme-quick__radius-preview {
+  display: block;
+  width: 26px;
+  height: 20px;
+}
+
+.theme-quick__radius-preview span {
+  display: block;
+  width: 24px;
+  height: 18px;
+  border-top: 2px solid var(--highlight-text);
+  border-left: 2px solid var(--highlight-text);
+}
+
+.theme-quick__check {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  display: none;
+  color: var(--highlight-text);
+  font-size: 18px;
+  background: var(--secondary-bg);
+  border-radius: 999px;
+}
+
+.theme-quick__choice--active .theme-quick__check {
+  display: inline-flex;
+}
+
+.theme-quick__footer {
+  padding: 12px 18px 16px;
+  border-top: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+  background: color-mix(in srgb, var(--secondary-bg) 92%, transparent);
+}
+
+.theme-quick__footer .material-symbols-outlined {
+  font-size: 18px;
+}
+
+.theme-quick-drawer-enter-active,
+.theme-quick-drawer-leave-active {
+  transition: opacity var(--transition-fast);
+}
+
+.theme-quick-drawer-enter-active .theme-quick__panel,
+.theme-quick-drawer-leave-active .theme-quick__panel {
+  transition: transform var(--transition-fast);
+}
+
+.theme-quick-drawer-enter-from,
+.theme-quick-drawer-leave-to {
+  opacity: 0;
+}
+
+.theme-quick-drawer-enter-from .theme-quick__panel,
+.theme-quick-drawer-leave-to .theme-quick__panel {
+  transform: translateX(18px);
+}
+
+@media (max-width: 640px) {
+  .theme-quick__panel {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-quick-drawer-enter-active,
+  .theme-quick-drawer-leave-active,
+  .theme-quick-drawer-enter-active .theme-quick__panel,
+  .theme-quick-drawer-leave-active .theme-quick__panel {
+    transition: none;
+  }
+}
+</style>

--- a/AdminPanel-Vue/src/components/layout/TopBar.vue
+++ b/AdminPanel-Vue/src/components/layout/TopBar.vue
@@ -52,6 +52,46 @@
 
       <!-- 右列：通知 + 系统菜单 + 用户菜单 -->
       <div class="header-actions">
+        <UiIconButton
+          class="external-link-trigger"
+          label="打开 VCPToolBox 官网"
+          title="VCPToolBox 官网"
+          @click="openExternalLink('https://www.vcptoolbox.com/')"
+        >
+          <span class="material-symbols-outlined" aria-hidden="true">language</span>
+        </UiIconButton>
+
+        <UiIconButton
+          class="external-link-trigger"
+          label="打开 GitHub 仓库"
+          title="GitHub 仓库"
+          @click="openExternalLink('https://github.com/lioensky/VCPToolBox')"
+        >
+          <svg
+            class="github-icon"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              fill="currentColor"
+              d="M12 2C6.48 2 2 6.58 2 12.24c0 4.52 2.87 8.35 6.84 9.71.5.1.68-.22.68-.49 0-.24-.01-1.05-.01-1.9-2.78.62-3.37-1.22-3.37-1.22-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.57 2.36 1.12 2.93.86.09-.67.35-1.12.63-1.38-2.22-.26-4.55-1.14-4.55-5.05 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.28 2.75 1.05A9.32 9.32 0 0 1 12 6.95c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.92-2.34 4.79-4.57 5.04.36.32.68.94.68 1.9 0 1.38-.01 2.49-.01 2.83 0 .27.18.59.69.49A10.17 10.17 0 0 0 22 12.24C22 6.58 17.52 2 12 2Z"
+            />
+          </svg>
+        </UiIconButton>
+
+        <UiIconButton
+          class="theme-quick-trigger"
+          label="快捷外观"
+          title="快捷外观"
+          :active="isThemeQuickDrawerOpen"
+          aria-haspopup="dialog"
+          :aria-expanded="isThemeQuickDrawerOpen"
+          @click="openThemeQuickDrawer"
+        >
+          <span class="material-symbols-outlined" aria-hidden="true">palette</span>
+        </UiIconButton>
+
         <!-- 通知图标（预留） -->
         <button
           class="icon-button notification-btn"
@@ -124,11 +164,12 @@
         </div>
       </div>
     </div>
+    <ThemeQuickDrawer :open="isThemeQuickDrawerOpen" @close="closeThemeQuickDrawer" />
   </header>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import { systemApi } from "@/api";
 import { askConfirm } from "@/platform/feedback/feedbackBus";
@@ -137,6 +178,7 @@ import { useAuthStore } from "@/stores/auth";
 import { showMessage, createLogger } from "@/utils";
 import UiIconButton from "@/components/ui/UiIconButton.vue";
 import Breadcrumb from "@/components/layout/Breadcrumb.vue";
+import ThemeQuickDrawer from "@/components/layout/ThemeQuickDrawer.vue";
 import topbarLogoUrl from "@/assets/topbar-logo.png";
 
 interface Props {
@@ -165,6 +207,7 @@ const appStore = useAppStore();
 const authStore = useAuthStore();
 
 const theme = computed(() => appStore.theme);
+const isThemeQuickDrawerOpen = ref(false);
 const themeToggleIcon = computed(() => {
   if (theme.value === "dark") return "light_mode";
   return "dark_mode";
@@ -190,6 +233,20 @@ function toggleSystemMenu() {
 
 function toggleUserMenu() {
   emit("toggleUserMenu");
+}
+
+function openThemeQuickDrawer() {
+  isThemeQuickDrawerOpen.value = true;
+  emit("closeAllMenus");
+}
+
+function closeThemeQuickDrawer() {
+  isThemeQuickDrawerOpen.value = false;
+}
+
+function openExternalLink(url: string) {
+  window.open(url, "_blank", "noopener,noreferrer");
+  emit("closeAllMenus");
 }
 
 function toggleTheme() {
@@ -366,6 +423,18 @@ function goToDashboard() {
   min-width: 0;
   justify-self: end;
   height: 32px;
+}
+
+.theme-quick-trigger .material-symbols-outlined,
+.external-link-trigger .material-symbols-outlined {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.github-icon {
+  display: block;
+  width: 18px;
+  height: 18px;
 }
 
 @media (max-width: 768px) {
@@ -595,12 +664,14 @@ function goToDashboard() {
   top: 100%;
   right: 0;
   margin-top: 4px;
-  background-color: var(--tertiary-bg);
-  border: 1px solid var(--border-color);
+  background-color: color-mix(in srgb, var(--primary-bg) 96%, var(--secondary-bg));
+  border: 1px solid color-mix(in srgb, var(--border-color) 84%, transparent);
   border-radius: 8px;
   min-width: 168px;
   padding: 4px;
   box-shadow: var(--shadow-overlay-soft);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   opacity: 0;
   visibility: hidden;
   transform: translateY(-4px) scale(0.98);

--- a/AdminPanel-Vue/src/features/theme-editor/themeEngine.ts
+++ b/AdminPanel-Vue/src/features/theme-editor/themeEngine.ts
@@ -18,6 +18,7 @@ const STORAGE_KEY_CONTENT_LAYOUT = 'customThemeContentLayout'
 const STORAGE_KEY_SHELL_LAYOUT = 'customThemeShellLayout'
 const INJECTED_CSS_ID = 'vcp-custom-theme-css'
 const INJECTED_BG_ID = 'vcp-custom-theme-bg'
+export const THEME_SETTINGS_CHANGED_EVENT = 'vcp-theme-settings-changed'
 
 // ── 类型定义 ──
 
@@ -74,6 +75,15 @@ export interface ThemeSnapshot {
   customCss: string
   backgroundImage: string
   activePresetId: string | null
+  themeMode: ThemeMode
+  radius: ThemeRadius
+  scale: ThemeScale
+  font: ThemeFont
+  contentLayout: ThemeContentLayout
+  shellLayout: ThemeShellLayout
+}
+
+export interface ThemeQuickSettings {
   themeMode: ThemeMode
   radius: ThemeRadius
   scale: ThemeScale
@@ -141,6 +151,7 @@ export const FULL_PRESET_THEMES: FullPresetTheme[] = [
     icon: 'rocket_launch',
     colors: {},
     swatches: ['oklch(0.75 0.14 230)', 'oklch(0.68 0.16 230)', 'oklch(0.30 0.08 230)'],
+    defaultRadius: 'xl',
   },
   {
     id: 'midnight-purple',
@@ -149,6 +160,7 @@ export const FULL_PRESET_THEMES: FullPresetTheme[] = [
     icon: 'dark_mode',
     colors: hueColors(270),
     swatches: ['oklch(0.75 0.14 270)', 'oklch(0.68 0.16 270)', 'oklch(0.30 0.08 270)'],
+    defaultRadius: 'xl',
   },
   {
     id: 'aurora-green',
@@ -157,6 +169,7 @@ export const FULL_PRESET_THEMES: FullPresetTheme[] = [
     icon: 'forest',
     colors: hueColors(155),
     swatches: ['oklch(0.75 0.14 155)', 'oklch(0.68 0.16 155)', 'oklch(0.30 0.08 155)'],
+    defaultRadius: 'xl',
   },
   {
     id: 'sunset-orange',
@@ -165,6 +178,7 @@ export const FULL_PRESET_THEMES: FullPresetTheme[] = [
     icon: 'wb_twilight',
     colors: hueColors(30),
     swatches: ['oklch(0.75 0.14 30)', 'oklch(0.68 0.16 30)', 'oklch(0.30 0.08 30)'],
+    defaultRadius: 'xl',
   },
   {
     id: 'cherry-red',
@@ -173,6 +187,7 @@ export const FULL_PRESET_THEMES: FullPresetTheme[] = [
     icon: 'local_florist',
     colors: hueColors(0),
     swatches: ['oklch(0.75 0.14 0)', 'oklch(0.68 0.16 0)', 'oklch(0.30 0.08 0)'],
+    defaultRadius: 'xl',
   },
   {
     id: 'ocean-cyan',
@@ -181,6 +196,7 @@ export const FULL_PRESET_THEMES: FullPresetTheme[] = [
     icon: 'waves',
     colors: hueColors(190),
     swatches: ['oklch(0.75 0.14 190)', 'oklch(0.68 0.16 190)', 'oklch(0.30 0.08 190)'],
+    defaultRadius: 'xl',
   },
   {
     id: 'rose-pink',
@@ -189,6 +205,7 @@ export const FULL_PRESET_THEMES: FullPresetTheme[] = [
     icon: 'favorite',
     colors: hueColors(310),
     swatches: ['oklch(0.75 0.14 310)', 'oklch(0.68 0.16 310)', 'oklch(0.30 0.08 310)'],
+    defaultRadius: 'xl',
   },
   {
     id: 'golden-amber',
@@ -197,6 +214,7 @@ export const FULL_PRESET_THEMES: FullPresetTheme[] = [
     icon: 'diamond',
     colors: hueColors(60),
     swatches: ['oklch(0.75 0.14 60)', 'oklch(0.68 0.16 60)', 'oklch(0.30 0.08 60)'],
+    defaultRadius: 'xl',
   },
   {
     id: 'anthropic',
@@ -205,13 +223,13 @@ export const FULL_PRESET_THEMES: FullPresetTheme[] = [
     icon: 'auto_awesome',
     colors: {},
     swatches: ['oklch(0.984 0.005 95)', 'oklch(0.685 0.142 38)', 'oklch(0.92 0.03 72)'],
-    defaultRadius: 'lg',
+    defaultRadius: 'xl',
     defaultFont: 'serif',
   },
   {
     id: 'rose-garden',
-    label: 'Rose Garden',
-    description: '玫瑰花园般的红粉主题',
+    label: '蔷薇庭院',
+    description: '玫瑰粉与柔和浅红的花园主题',
     icon: 'local_florist',
     colors: {},
     swatches: ['oklch(0.5827 0.2418 12.23)', 'oklch(0.8131 0.1129 5.67)', 'oklch(0.93 0.04 12)'],
@@ -219,21 +237,57 @@ export const FULL_PRESET_THEMES: FullPresetTheme[] = [
   },
   {
     id: 'lake-view',
-    label: 'Lake View',
-    description: '湖水与薄雾青绿色调',
+    label: '湖畔薄雾',
+    description: '湖绿色与水蓝色的清透主题',
     icon: 'water',
     colors: {},
     swatches: ['oklch(0.765 0.177 163.22)', 'oklch(0.551 0.0899 200.52)', 'oklch(0.92 0.035 180)'],
-    defaultRadius: 'md',
+    defaultRadius: 'xl',
   },
   {
     id: 'ocean-breeze',
-    label: 'Ocean Breeze',
-    description: '蓝紫海风主题',
+    label: '海风蓝紫',
+    description: '高饱和蓝紫渐变主题',
     icon: 'sailing',
     colors: {},
     swatches: ['oklch(0.5461 0.2152 262.88)', 'oklch(0.5854 0.2041 277.12)', 'oklch(0.92 0.03 250)'],
-    defaultRadius: 'sm',
+    defaultRadius: 'xl',
+  },
+  {
+    id: 'underground',
+    label: '地下霓虹',
+    description: '青绿与洋红的夜间霓虹主题',
+    icon: 'subway',
+    colors: {},
+    swatches: ['oklch(0.5315 0.0694 156.19)', 'oklch(0.5748 0.0862 336.52)', 'oklch(0.20 0.03 210)'],
+    defaultRadius: 'xl',
+  },
+  {
+    id: 'sunset-glow',
+    label: '暮色余晖',
+    description: '朱红与琥珀色的夕阳主题',
+    icon: 'wb_twilight',
+    colors: {},
+    swatches: ['oklch(0.5591 0.1882 25.33)', 'oklch(0.7938 0.1248 42.42)', 'oklch(0.93 0.05 55)'],
+    defaultRadius: 'xl',
+  },
+  {
+    id: 'forest-whisper',
+    label: '森林低语',
+    description: '冷杉绿与灰蓝的安静主题',
+    icon: 'forest',
+    colors: {},
+    swatches: ['oklch(0.5276 0.1072 182.22)', 'oklch(0.5236 0.0505 250.18)', 'oklch(0.90 0.025 165)'],
+    defaultRadius: 'xl',
+  },
+  {
+    id: 'lavender-dream',
+    label: '薰衣草梦',
+    description: '紫粉与浅蓝的柔和主题',
+    icon: 'spa',
+    colors: {},
+    swatches: ['oklch(0.5709 0.1808 306.89)', 'oklch(0.811 0.0589 201.14)', 'oklch(0.94 0.035 300)'],
+    defaultRadius: 'xl',
   },
 ]
 
@@ -621,6 +675,31 @@ export function loadThemeShellLayout(): ThemeShellLayout {
 
 export function saveThemeShellLayout(layout: ThemeShellLayout): void {
   saveOption(STORAGE_KEY_SHELL_LAYOUT, layout, 'inset')
+}
+
+export function loadThemeQuickSettings(): ThemeQuickSettings {
+  return {
+    themeMode: loadThemeMode(),
+    radius: loadThemeRadius(),
+    scale: loadThemeScale(),
+    font: loadThemeFont(),
+    contentLayout: loadThemeContentLayout(),
+    shellLayout: loadThemeShellLayout(),
+  }
+}
+
+export function saveThemeQuickSettings(settings: ThemeQuickSettings): void {
+  saveThemeMode(settings.themeMode)
+  saveThemeRadius(settings.radius)
+  saveThemeScale(settings.scale)
+  saveThemeFont(settings.font)
+  saveThemeContentLayout(settings.contentLayout)
+  saveThemeShellLayout(settings.shellLayout)
+}
+
+export function notifyThemeSettingsChanged(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent(THEME_SETTINGS_CHANGED_EVENT))
 }
 
 // ── 用户自定义主题 ──

--- a/AdminPanel-Vue/src/style/theme-presets.css
+++ b/AdminPanel-Vue/src/style/theme-presets.css
@@ -112,6 +112,50 @@ html[data-theme-preset="ocean-breeze"] {
   --button-hover-bg-light: oklch(0.50 0.20 270);
 }
 
+html[data-theme-preset="underground"] {
+  --highlight-text-dark: oklch(0.64 0.12 156.19);
+  --highlight-text-light: oklch(0.45 0.12 156.19);
+  --accent-bg-dark: oklch(0.26 0.045 156.19);
+  --accent-bg-light: oklch(0.90 0.035 156.19);
+  --button-bg-dark: oklch(0.5748 0.0862 336.52);
+  --button-bg-light: oklch(0.5748 0.0862 336.52);
+  --button-hover-bg-dark: oklch(0.52 0.10 336.52);
+  --button-hover-bg-light: oklch(0.50 0.11 336.52);
+}
+
+html[data-theme-preset="sunset-glow"] {
+  --highlight-text-dark: oklch(0.72 0.16 25.33);
+  --highlight-text-light: oklch(0.50 0.17 25.33);
+  --accent-bg-dark: oklch(0.30 0.07 42.42);
+  --accent-bg-light: oklch(0.92 0.045 42.42);
+  --button-bg-dark: oklch(0.7938 0.1248 42.42);
+  --button-bg-light: oklch(0.66 0.15 35);
+  --button-hover-bg-dark: oklch(0.68 0.15 38);
+  --button-hover-bg-light: oklch(0.58 0.17 35);
+}
+
+html[data-theme-preset="forest-whisper"] {
+  --highlight-text-dark: oklch(0.68 0.10 182.22);
+  --highlight-text-light: oklch(0.44 0.10 182.22);
+  --accent-bg-dark: oklch(0.28 0.04 182.22);
+  --accent-bg-light: oklch(0.91 0.035 182.22);
+  --button-bg-dark: oklch(0.5236 0.0505 250.18);
+  --button-bg-light: oklch(0.49 0.07 250.18);
+  --button-hover-bg-dark: oklch(0.46 0.065 250.18);
+  --button-hover-bg-light: oklch(0.42 0.08 250.18);
+}
+
+html[data-theme-preset="lavender-dream"] {
+  --highlight-text-dark: oklch(0.70 0.15 306.89);
+  --highlight-text-light: oklch(0.48 0.16 306.89);
+  --accent-bg-dark: oklch(0.30 0.07 306.89);
+  --accent-bg-light: oklch(0.93 0.04 306.89);
+  --button-bg-dark: oklch(0.5709 0.1808 306.89);
+  --button-bg-light: oklch(0.57 0.17 306.89);
+  --button-hover-bg-dark: oklch(0.51 0.20 306.89);
+  --button-hover-bg-light: oklch(0.50 0.19 306.89);
+}
+
 html[data-theme-radius="none"] {
   --radius-sm: 0;
   --radius-md: 0;

--- a/AdminPanel-Vue/src/views/AgentScores.vue
+++ b/AdminPanel-Vue/src/views/AgentScores.vue
@@ -14,14 +14,14 @@
       </UiPageActions>
     </Teleport>
 
-    <UiCard
-      class="agent-scores-card"
-      variant="default"
-      size="sm"
-      title="Agent 积分排行"
-      description="查看各 Agent 的累计积分、最近动态和更新时间。"
-      divided
-    >
+    <div class="agent-scores-shell">
+      <header class="scores-heading">
+        <div>
+          <h2>Agent 积分排行</h2>
+          <p>查看各 Agent 的累计积分、最近动态和更新时间。</p>
+        </div>
+      </header>
+
       <UiToolbar density="compact" class="scores-toolbar">
         <div class="scores-summary">
           <UiBadge variant="outline">
@@ -77,24 +77,22 @@
         </tbody>
       </UiTableFrame>
 
-      <template v-if="totalPages > 1" #footer>
-        <div class="pagination-controls">
-          <UiButton variant="outline" size="sm" :disabled="!hasPrev" @click="prevPage">
-            <template #leading>
-              <span class="material-symbols-outlined">chevron_left</span>
-            </template>
-            上一页
-          </UiButton>
-          <span class="pagination-info">第 {{ currentPage }} / {{ totalPages }} 页</span>
-          <UiButton variant="outline" size="sm" :disabled="!hasNext" @click="nextPage">
-            下一页
-            <template #trailing>
-              <span class="material-symbols-outlined">chevron_right</span>
-            </template>
-          </UiButton>
-        </div>
-      </template>
-    </UiCard>
+      <div v-if="totalPages > 1" class="pagination-controls">
+        <UiButton variant="outline" size="sm" :disabled="!hasPrev" @click="prevPage">
+          <template #leading>
+            <span class="material-symbols-outlined">chevron_left</span>
+          </template>
+          上一页
+        </UiButton>
+        <span class="pagination-info">第 {{ currentPage }} / {{ totalPages }} 页</span>
+        <UiButton variant="outline" size="sm" :disabled="!hasNext" @click="nextPage">
+          下一页
+          <template #trailing>
+            <span class="material-symbols-outlined">chevron_right</span>
+          </template>
+        </UiButton>
+      </div>
+    </div>
   </section>
 </template>
 
@@ -105,7 +103,6 @@ import { showMessage } from '@/utils'
 import { usePagination } from '@/composables/usePagination'
 import UiBadge from '@/components/ui/UiBadge.vue'
 import UiButton from '@/components/ui/UiButton.vue'
-import UiCard from '@/components/ui/UiCard.vue'
 import UiEmptyState from '@/components/ui/UiEmptyState.vue'
 import UiPageActions from '@/components/ui/UiPageActions.vue'
 import UiTableFrame from '@/components/ui/UiTableFrame.vue'
@@ -188,8 +185,31 @@ onMounted(() => {
 </script>
 
 <style scoped>
-.agent-scores-card {
+.agent-scores-shell {
+  display: grid;
   gap: var(--space-3);
+}
+
+.scores-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.scores-heading h2 {
+  margin: 0;
+  color: var(--primary-text);
+  font-size: 1rem;
+  font-weight: 650;
+  line-height: 1.4;
+}
+
+.scores-heading p {
+  margin: var(--space-1) 0 0;
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+  line-height: 1.5;
 }
 
 .scores-toolbar {

--- a/AdminPanel-Vue/src/views/ClawMailManager.vue
+++ b/AdminPanel-Vue/src/views/ClawMailManager.vue
@@ -2,46 +2,44 @@
   <section class="claw-mail-page">
     <Teleport to="#page-header-actions">
       <UiPageActions>
-        <UiButton type="button" variant="outline" :disabled="isLoadingState" :loading="isLoadingState" @click="loadState(true)">
-          <span class="material-symbols-outlined">sync</span>
-          <span>{{ isLoadingState ? "刷新中…" : "刷新邮箱缓存" }}</span>
+        <UiButton type="button" variant="outline" size="lg" :disabled="isLoadingState" :loading="isLoadingState" @click="loadState(true)">
+          <template #leading>
+            <span class="material-symbols-outlined">refresh</span>
+          </template>
+          {{ isLoadingState ? "刷新中…" : "刷新邮箱缓存" }}
         </UiButton>
       </UiPageActions>
     </Teleport>
 
-    <UiCard class="hero-card" variant="subtle">
-      <div>
-        <span class="eyebrow">VCPClawMail</span>
-        <h2>邮件总览与垃圾箱操作</h2>
-        <p>
-          在服务器面板中查看 VCPClawMail 已配置的公共邮箱与子邮箱邮件，支持读取正文，并将邮件安全移入垃圾箱。
-        </p>
+    <section class="mail-status-strip" aria-label="Agent 信箱状态">
+      <div class="status-copy">
+        <strong>邮件总览与垃圾箱操作</strong>
+        <span>查看 VCPClawMail 公共邮箱与子邮箱邮件，读取正文并安全移入垃圾箱。</span>
       </div>
-    </UiCard>
-
-    <UiCard class="status-card" variant="subtle">
-      <article class="stat-chip">
-        <span>SDK</span>
-        <UiBadge :variant="state?.sdkLoaded ? 'success' : 'danger'">
-          {{ state?.sdkLoaded ? "已加载" : "不可用" }}
-        </UiBadge>
-      </article>
-      <article class="stat-chip">
-        <span>邮箱数</span>
-        <strong>{{ state?.mailboxes.length ?? 0 }}</strong>
-      </article>
-      <article class="stat-chip">
-        <span>更新时间</span>
-        <strong>{{ state?.updatedAt || "未轮询" }}</strong>
-      </article>
-      <article v-if="state?.lastError" class="stat-chip warning">
-        <span>最近错误</span>
-        <UiBadge variant="danger">{{ state.lastError }}</UiBadge>
-      </article>
-    </UiCard>
+      <div class="status-metrics">
+        <article class="stat-chip">
+          <span>SDK</span>
+          <UiBadge :variant="state?.sdkLoaded ? 'success' : 'danger'">
+            {{ state?.sdkLoaded ? "已加载" : "不可用" }}
+          </UiBadge>
+        </article>
+        <article class="stat-chip">
+          <span>邮箱</span>
+          <strong>{{ state?.mailboxes.length ?? 0 }}</strong>
+        </article>
+        <article class="stat-chip">
+          <span>更新时间</span>
+          <strong>{{ state?.updatedAt || "未轮询" }}</strong>
+        </article>
+        <article v-if="state?.lastError" class="stat-chip stat-chip--error">
+          <span>最近错误</span>
+          <UiBadge variant="danger">{{ state.lastError }}</UiBadge>
+        </article>
+      </div>
+    </section>
 
     <section class="mail-layout">
-      <UiCard class="mailbox-panel" variant="subtle">
+      <aside class="mailbox-panel" aria-label="邮箱列表">
         <div class="panel-header">
           <h3>邮箱</h3>
         </div>
@@ -62,9 +60,9 @@
           </span>
         </button>
         <UiEmptyState v-if="!state?.mailboxes.length" title="暂无已配置邮箱" />
-      </UiCard>
+      </aside>
 
-      <UiCard class="message-panel" variant="subtle">
+      <main class="message-panel" aria-label="邮件列表">
         <div class="panel-header message-toolbar">
           <div>
             <h3>邮件列表</h3>
@@ -83,42 +81,48 @@
           </div>
         </div>
 
-        <UiEmptyState v-if="isLoadingMessages" title="正在加载邮件..." />
-        <UiEmptyState v-else-if="messages.length === 0" title="暂无邮件" description="请选择邮箱，或调整筛选条件后重新加载。" />
-        <div v-else class="message-list">
-          <article
-            v-for="message in messages"
-            :key="String(message.mailId || message.id)"
-            class="message-item"
-            :class="{ active: selectedMailId === String(message.mailId || message.id) }"
-          >
-            <button type="button" class="message-main" @click="openMessage(message)">
-              <span class="status-dot" :class="{ unread: message.unread }"></span>
-              <span class="message-content">
-                <strong>{{ message.subject || "(无主题)" }}</strong>
-                <small>{{ formatAddress(message.from) }} · {{ message.date || "未知时间" }}</small>
-                <span>{{ message.preview || "无预览" }}</span>
-              </span>
-            </button>
-            <UiButton type="button" variant="danger" size="sm" class="trash-btn" @click="trashMessage(message)">
-              <span class="material-symbols-outlined">delete</span>
-              <span>移入垃圾箱</span>
-            </UiButton>
-          </article>
+        <div class="message-list-shell">
+          <UiEmptyState v-if="isLoadingMessages" title="正在加载邮件..." />
+          <UiEmptyState v-else-if="messages.length === 0" title="暂无邮件" description="请选择邮箱，或调整筛选条件后重新加载。" />
+          <div v-else class="message-list">
+            <article
+              v-for="message in messages"
+              :key="String(message.mailId || message.id)"
+              class="message-item"
+              :class="{ active: selectedMailId === String(message.mailId || message.id) }"
+            >
+              <button type="button" class="message-main" @click="openMessage(message)">
+                <span class="status-dot" :class="{ unread: message.unread }"></span>
+                <span class="message-content">
+                  <strong>{{ message.subject || "(无主题)" }}</strong>
+                  <small>{{ formatAddress(message.from) }} · {{ message.date || "未知时间" }}</small>
+                  <span>{{ message.preview || "无预览" }}</span>
+                </span>
+              </button>
+              <UiButton type="button" variant="danger" size="sm" class="trash-btn" @click="trashMessage(message)">
+                <span class="material-symbols-outlined">delete</span>
+                <span>移入垃圾箱</span>
+              </UiButton>
+            </article>
+          </div>
         </div>
-      </UiCard>
-    </section>
+      </main>
 
-    <UiCard v-if="selectedMailMarkdown" class="detail-card" variant="subtle">
-      <div class="panel-header">
-        <h3>邮件详情</h3>
-        <UiButton type="button" variant="ghost" size="sm" @click="selectedMailMarkdown = ''">
-          <span class="material-symbols-outlined">close</span>
-          <span>关闭</span>
-        </UiButton>
-      </div>
-      <pre>{{ selectedMailMarkdown }}</pre>
-    </UiCard>
+      <aside class="mail-detail-panel" aria-label="邮件详情">
+        <div class="panel-header">
+          <div>
+            <h3>邮件详情</h3>
+            <p>{{ selectedMailId ? "当前邮件正文" : "选择一封邮件查看正文" }}</p>
+          </div>
+          <UiButton v-if="selectedMailMarkdown" type="button" variant="ghost" size="sm" @click="selectedMailMarkdown = ''">
+            <span class="material-symbols-outlined">close</span>
+            <span>关闭</span>
+          </UiButton>
+        </div>
+        <pre v-if="selectedMailMarkdown">{{ selectedMailMarkdown }}</pre>
+        <UiEmptyState v-else title="未选择邮件" description="从邮件列表中点击一封邮件后，正文会显示在这里。" />
+      </aside>
+    </section>
   </section>
 </template>
 
@@ -128,7 +132,6 @@ import { clawMailApi, type ClawMailMailbox, type ClawMailState, type ClawMailSum
 import AppCheckbox from "@/components/ui/AppCheckbox.vue";
 import UiBadge from "@/components/ui/UiBadge.vue";
 import UiButton from "@/components/ui/UiButton.vue";
-import UiCard from "@/components/ui/UiCard.vue";
 import UiEmptyState from "@/components/ui/UiEmptyState.vue";
 import UiInput from "@/components/ui/UiInput.vue";
 import UiPageActions from "@/components/ui/UiPageActions.vue";
@@ -269,76 +272,153 @@ onMounted(() => {
 
 <style scoped>
 .claw-mail-page {
+  --mail-workspace-height: calc(var(--app-viewport-height, 100vh) - 220px);
+  --mail-workspace-min-height: 520px;
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
-}
-
-.hero-card,
-.status-card,
-.mail-layout {
-  display: grid;
   gap: var(--space-4);
 }
 
-.hero-card {
-  grid-template-columns: minmax(0, 1fr) auto;
+.mail-status-strip {
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: 0 0 var(--space-3);
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
 }
 
-.hero-card h2 {
-  font-size: var(--font-size-headline);
-  margin: var(--space-2) 0;
+.status-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
 }
 
-.hero-card p,
+.status-copy strong {
+  color: var(--primary-text);
+  font-size: var(--font-size-emphasis);
+  line-height: 1.25;
+}
+
+.status-copy span,
 .panel-header p {
   color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+  line-height: 1.45;
 }
 
-.status-card {
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+.status-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-2);
 }
 
 .stat-chip {
   display: flex;
-  flex-direction: column;
   gap: var(--space-2);
-  padding: var(--space-3);
-  border: 1px solid var(--border-color);
+  align-items: center;
+  min-height: 32px;
+  padding: 0 var(--space-2);
+  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
+  background: color-mix(in srgb, var(--primary-text) 1.2%, transparent);
 }
 
 .stat-chip span {
   color: var(--secondary-text);
   font-size: var(--font-size-helper);
+  white-space: nowrap;
 }
 
 .stat-chip strong {
+  color: var(--primary-text);
+  font-size: var(--font-size-helper);
+  font-weight: 650;
   overflow-wrap: anywhere;
 }
 
+.stat-chip--error {
+  border-color: color-mix(in srgb, var(--danger-color) 34%, var(--border-color));
+}
+
 .mail-layout {
-  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-  align-items: start;
+  display: grid;
+  grid-template-areas:
+    "mailboxes messages"
+    "mailboxes detail";
+  grid-template-columns: minmax(230px, 280px) minmax(0, 1fr);
+  grid-template-rows: minmax(320px, 1fr) minmax(180px, 0.72fr);
+  gap: var(--space-4);
+  min-height: var(--mail-workspace-min-height);
+  height: max(var(--mail-workspace-height), var(--mail-workspace-min-height));
+}
+
+.mailbox-panel,
+.message-panel,
+.mail-detail-panel {
+  min-width: 0;
+  min-height: 0;
+}
+
+.mailbox-panel {
+  grid-area: mailboxes;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.message-panel,
+.mail-detail-panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border-color) 84%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--primary-text) 0.8%, transparent);
+}
+
+.message-panel {
+  grid-area: messages;
+}
+
+.mail-detail-panel {
+  grid-area: detail;
 }
 
 .panel-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-3);
-  margin-bottom: var(--space-4);
+  gap: var(--space-2);
+  min-height: 48px;
+  padding: var(--space-3);
+}
+
+.mailbox-panel > .panel-header {
+  min-height: 32px;
+  padding: 0 0 var(--space-2);
+}
+
+.panel-header h3 {
+  margin: 0;
+  color: var(--primary-text);
+  font-size: var(--font-size-body);
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.panel-header p {
+  margin: 2px 0 0;
 }
 
 .mailbox-item {
   width: 100%;
   display: flex;
-  gap: var(--space-3);
+  gap: var(--space-2);
   align-items: center;
-  min-height: 44px;
-  padding: var(--space-3);
+  min-height: 42px;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid transparent;
   border-radius: var(--radius-md);
   background: transparent;
@@ -352,12 +432,17 @@ onMounted(() => {
 }
 
 .mailbox-item:hover {
-  background: color-mix(in srgb, var(--primary-text) 3%, transparent);
+  background: var(--accent-bg);
 }
 
 .mailbox-item.active {
-  border-color: color-mix(in srgb, var(--button-bg) 36%, var(--border-color));
-  background: color-mix(in srgb, var(--button-bg) 8%, transparent);
+  border-color: color-mix(in srgb, var(--button-bg) 32%, var(--border-color));
+  background: color-mix(in srgb, var(--button-bg) 7%, transparent);
+}
+
+.mailbox-item > .material-symbols-outlined {
+  color: var(--secondary-text);
+  font-size: 18px !important;
 }
 
 .mailbox-copy {
@@ -375,16 +460,18 @@ onMounted(() => {
 
 .mailbox-copy small {
   color: var(--secondary-text);
+  font-size: var(--font-size-helper);
 }
 
 .message-toolbar {
   align-items: flex-start;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 68%, transparent);
 }
 
 .toolbar-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-3);
+  gap: var(--space-2);
   align-items: center;
   justify-content: flex-end;
 }
@@ -395,26 +482,39 @@ onMounted(() => {
   gap: var(--space-2);
   align-items: center;
   color: var(--secondary-text);
+  font-size: var(--font-size-helper);
 }
 
 .limit-input {
   width: 72px;
 }
 
+.message-list-shell {
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+  padding: var(--space-2) var(--space-3) var(--space-3);
+}
+
 .message-list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 0;
+  height: 100%;
+  overflow-y: auto;
+  padding-right: var(--space-1);
+  scrollbar-gutter: stable;
 }
 
 .message-item {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--space-3);
+  gap: var(--space-2);
   align-items: center;
-  padding: var(--space-3);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
+  padding: var(--space-3) 0;
+  border: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 68%, transparent);
+  border-radius: 0;
   background: transparent;
   transition:
     background-color var(--transition-fast),
@@ -422,12 +522,11 @@ onMounted(() => {
 }
 
 .message-item:hover {
-  background: color-mix(in srgb, var(--primary-text) 3%, transparent);
+  background: color-mix(in srgb, var(--primary-text) 1.8%, transparent);
 }
 
 .message-item.active {
-  border-color: color-mix(in srgb, var(--button-bg) 44%, var(--border-color));
-  background: color-mix(in srgb, var(--button-bg) 6%, transparent);
+  background: color-mix(in srgb, var(--button-bg) 5%, transparent);
 }
 
 .message-main {
@@ -442,8 +541,8 @@ onMounted(() => {
 }
 
 .status-dot {
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   margin-top: 6px;
   border-radius: 999px;
   background: var(--border-color);
@@ -458,7 +557,7 @@ onMounted(() => {
   display: flex;
   min-width: 0;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
 }
 
 .message-content strong,
@@ -479,15 +578,24 @@ onMounted(() => {
   white-space: nowrap;
 }
 
-.detail-card pre {
-  max-height: 70vh;
+.mail-detail-panel pre {
+  flex: 1;
+  min-height: 0;
+  margin: 0 var(--space-3) var(--space-3);
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-word;
-  padding: var(--space-4);
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--primary-text) 3%, transparent);
+  padding: var(--space-3) 0 0;
+  border-top: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+  background: transparent;
   color: var(--primary-text);
+  font-family: "Consolas", "Monaco", monospace;
+  font-size: var(--font-size-helper);
+  line-height: 1.6;
+}
+
+.mail-detail-panel :deep(.empty-state) {
+  flex: 1;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -498,9 +606,23 @@ onMounted(() => {
 }
 
 @media (max-width: 1024px) {
-  .hero-card,
+  .mail-status-strip {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .status-metrics {
+    justify-content: flex-start;
+  }
+
   .mail-layout {
     grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    grid-template-areas:
+      "mailboxes"
+      "messages"
+      "detail";
+    height: auto;
   }
 
   .toolbar-actions {

--- a/AdminPanel-Vue/src/views/DailyNotesManager/FolderList.vue
+++ b/AdminPanel-Vue/src/views/DailyNotesManager/FolderList.vue
@@ -95,7 +95,7 @@ function handleFolderNavClick(item: UiSideConsoleNavItem): void {
 .notes-sidebar {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-2);
   align-self: start;
   height: 100%;
   max-height: 100%;
@@ -107,30 +107,39 @@ function handleFolderNavClick(item: UiSideConsoleNavItem): void {
 
 .folder-search-label {
   display: block;
-  margin: 0 0 var(--space-2);
+  margin: 0 0 6px;
   padding: 0 8px;
-  color: var(--secondary-text);
-  font-size: var(--font-size-helper);
-  font-weight: 600;
+  color: color-mix(in srgb, var(--secondary-text) 72%, transparent);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
 
 .folder-console__search {
-  padding: 0 0 var(--space-3);
+  padding: 0;
 }
 
 .folder-search-box {
-  display: flex;
-  gap: var(--space-2);
-  padding: 0 8px;
+  position: relative;
+  display: block;
+  padding: 0;
 }
 
 .folder-search-input {
-  flex: 1;
-  min-width: 0;
+  width: 100%;
 }
 
 .folder-search-clear {
-  flex-shrink: 0;
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+}
+
+.folder-search-box:has(.folder-search-clear) .folder-search-input {
+  padding-right: 54px;
 }
 
 .notes-sidebar__nav {
@@ -150,15 +159,12 @@ function handleFolderNavClick(item: UiSideConsoleNavItem): void {
   .notes-sidebar {
     height: auto;
     max-height: none;
-    padding: var(--space-4);
+    padding: 0;
   }
 
   .notes-sidebar__nav {
     max-height: 40vh;
   }
 
-  .folder-search-box {
-    flex-direction: column;
-  }
 }
 </style>

--- a/AdminPanel-Vue/src/views/DailyNotesManager/NoteList.vue
+++ b/AdminPanel-Vue/src/views/DailyNotesManager/NoteList.vue
@@ -529,11 +529,12 @@ function toggleSelected(file: string, checked: boolean) {
   flex-direction: column;
   gap: var(--space-3);
   min-height: 190px;
+  background: color-mix(in srgb, var(--primary-text) 0.8%, transparent);
   transition: border-color var(--transition-fast), background-color var(--transition-fast);
 }
 
 .note-card:hover {
-  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
+  background: color-mix(in srgb, var(--primary-text) 3.5%, transparent);
 }
 
 .note-card-header {
@@ -568,10 +569,10 @@ function toggleSelected(file: string, checked: boolean) {
   overflow: hidden;
   text-overflow: ellipsis;
   flex: 1;
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-color) 68%, transparent);
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .note-card-footer {

--- a/AdminPanel-Vue/src/views/DailyNotesManager/RagTagsConfig.vue
+++ b/AdminPanel-Vue/src/views/DailyNotesManager/RagTagsConfig.vue
@@ -1,14 +1,27 @@
 <template>
-  <UiCard
+  <section
     v-if="selectedFolder"
     class="rag-tags-config-area"
-    size="sm"
-    variant="subtle"
   >
     <div class="rag-tags-header">
       <div class="rag-tags-title-row">
         <h3>{{ titleLabel }} - {{ selectedFolder }}</h3>
         <div class="rag-tags-actions">
+          <UiBadge class="tag-count" variant="outline">
+            {{ ragTagsConfig.tags.length }} 个标签
+          </UiBadge>
+          <UiButton variant="outline" size="sm" @click="$emit('addTag')">
+            <template #leading>
+              <span class="material-symbols-outlined">add</span>
+            </template>
+            添加标签
+          </UiButton>
+          <UiButton variant="primary" size="sm" @click="$emit('saveRagTags')">
+            <template #leading>
+              <span class="material-symbols-outlined">save</span>
+            </template>
+            保存
+          </UiButton>
           <UiButton
             variant="danger"
             size="sm"
@@ -20,6 +33,12 @@
             </template>
             清空全部
           </UiButton>
+          <UiBadge
+            v-if="ragTagsStatus"
+            :variant="ragTagsStatusBadgeVariant"
+          >
+            {{ ragTagsStatus }}
+          </UiBadge>
         </div>
       </div>
       <p class="rag-tags-hint">
@@ -56,6 +75,7 @@
         <input
           :value="ragTagsConfig.threshold"
           type="range"
+          class="threshold-slider"
           min="0.1"
           max="1.0"
           step="0.01"
@@ -70,7 +90,7 @@
       <div class="tags-container">
         <div v-if="ragTagsConfig.tags.length === 0" class="empty-tags-hint">
           <span class="material-symbols-outlined">tag</span>
-          <p>暂无标签，点击上方"添加标签"按钮添加</p>
+          <p>暂无标签，点击上方“添加标签”按钮添加</p>
         </div>
         <div
           v-for="(tag, index) in ragTagsConfig.tags"
@@ -97,35 +117,8 @@
           </UiIconButton>
         </div>
       </div>
-
-      <div class="add-tag-controls">
-        <UiButton variant="outline" size="sm" @click="$emit('addTag')">
-          <template #leading>
-            <span class="material-symbols-outlined">add</span>
-          </template>
-          添加标签
-        </UiButton>
-        <span class="tag-count"
-          >当前标签数：{{ ragTagsConfig.tags.length }}</span
-        >
-      </div>
-
-      <div class="rag-tags-controls">
-        <UiButton variant="primary" @click="$emit('saveRagTags')">
-          <template #leading>
-            <span class="material-symbols-outlined">save</span>
-          </template>
-          保存更改到 {{ targetFileName }}
-        </UiButton>
-        <UiBadge
-          v-if="ragTagsStatus"
-          :variant="ragTagsStatusBadgeVariant"
-        >
-          {{ ragTagsStatus }}
-        </UiBadge>
-      </div>
     </div>
-  </UiCard>
+  </section>
 </template>
 
 <script setup lang="ts">
@@ -133,7 +126,6 @@ import { computed } from 'vue'
 import AppSwitch from '@/components/ui/AppSwitch.vue'
 import UiBadge from '@/components/ui/UiBadge.vue'
 import UiButton from '@/components/ui/UiButton.vue'
-import UiCard from '@/components/ui/UiCard.vue'
 import UiIconButton from '@/components/ui/UiIconButton.vue'
 import UiInput from '@/components/ui/UiInput.vue'
 import UiTextarea from '@/components/ui/UiTextarea.vue'
@@ -195,8 +187,14 @@ function onDescriptionInput(event: Event) {
 </script>
 
 <style scoped>
+.rag-tags-config-area {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-1) 0 var(--space-2);
+}
+
 .rag-tags-header {
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-2);
 }
 
 .rag-tags-title-row {
@@ -210,13 +208,17 @@ function onDescriptionInput(event: Event) {
 
 .rag-tags-title-row h3 {
   margin: 0;
-  font-size: var(--font-size-title);
+  font-size: 1rem;
+  line-height: 1.4;
+  font-weight: 650;
   color: var(--primary-text);
 }
 
 .rag-tags-actions {
   display: flex;
   gap: var(--space-2);
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .rag-tags-actions button {
@@ -235,11 +237,7 @@ function onDescriptionInput(event: Event) {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  margin-bottom: var(--space-4);
-  padding: var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--border-color) 76%, transparent);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
+  margin-bottom: var(--space-3);
 }
 
 .description-label {
@@ -269,16 +267,66 @@ function onDescriptionInput(event: Event) {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  margin-bottom: var(--space-4);
-  padding: var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--border-color) 76%, transparent);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
+  margin-bottom: var(--space-3);
+  min-height: 32px;
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
 }
 
-.threshold-controls input[type="range"] {
+.threshold-slider {
   flex: 1;
   max-width: 200px;
+  height: 24px;
+  margin: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.threshold-slider:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.threshold-slider::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--border-color) 72%, transparent);
+}
+
+.threshold-slider::-webkit-slider-thumb {
+  width: 16px;
+  height: 16px;
+  margin-top: -5px;
+  border: 2px solid var(--primary-bg);
+  border-radius: var(--radius-full);
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--highlight-text);
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--primary-text) 18%, transparent);
+}
+
+.threshold-slider::-moz-range-track {
+  height: 6px;
+  border: 0;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--border-color) 72%, transparent);
+}
+
+.threshold-slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--primary-bg);
+  border-radius: var(--radius-full);
+  background: var(--highlight-text);
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--primary-text) 18%, transparent);
+}
+
+.threshold-slider:focus-visible {
+  outline: 2px solid var(--highlight-text);
+  outline-offset: 3px;
+  border-radius: var(--radius-full);
 }
 
 .threshold-value {
@@ -291,11 +339,10 @@ function onDescriptionInput(event: Event) {
 .tags-container {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: var(--space-3);
-  margin-bottom: var(--space-4);
-  padding: var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--border-color) 76%, transparent);
-  border-radius: var(--radius-md);
+  gap: var(--space-2);
+  margin-bottom: 0;
+  padding: 0;
+  border: 0;
   background: transparent;
 }
 
@@ -305,7 +352,7 @@ function onDescriptionInput(event: Event) {
   flex-direction: column;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-7) var(--space-5);
+  padding: var(--space-4) var(--space-3);
   color: var(--secondary-text);
   text-align: center;
 }
@@ -324,9 +371,9 @@ function onDescriptionInput(event: Event) {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
-  background: transparent;
-  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
+  padding: var(--space-2);
+  background: color-mix(in srgb, var(--primary-text) 1.2%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 76%, transparent);
   border-radius: var(--radius-md);
   transition: border-color var(--transition-fast), background-color var(--transition-fast);
   min-width: 0;
@@ -365,29 +412,8 @@ function onDescriptionInput(event: Event) {
   font-size: var(--font-size-emphasis) !important;
 }
 
-.add-tag-controls {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  margin-bottom: var(--space-4);
-  padding: var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--border-color) 76%, transparent);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
-}
-
 .tag-count {
-  font-size: var(--font-size-helper);
-  color: var(--secondary-text);
-  font-weight: 600;
-}
-
-.rag-tags-controls {
-  display: flex;
-  gap: var(--space-3);
-  align-items: center;
-  padding-top: var(--space-3);
-  border-top: 1px solid color-mix(in srgb, var(--border-color) 76%, transparent);
+  flex-shrink: 0;
 }
 
 .material-symbols-outlined {
@@ -404,6 +430,7 @@ function onDescriptionInput(event: Event) {
   .rag-tags-actions {
     width: 100%;
     flex-wrap: wrap;
+    justify-content: flex-start;
   }
 
   .rag-tags-actions button {
@@ -417,7 +444,7 @@ function onDescriptionInput(event: Event) {
     align-items: flex-start;
   }
 
-  .threshold-controls input[type="range"] {
+  .threshold-slider {
     flex: 1 1 100%;
     max-width: none;
   }
@@ -430,28 +457,5 @@ function onDescriptionInput(event: Event) {
     padding: var(--space-2);
   }
 
-  .add-tag-controls {
-    flex-direction: column;
-    align-items: stretch;
-    gap: var(--space-3);
-  }
-
-  .add-tag-controls button {
-    width: 100%;
-    justify-content: center;
-    min-height: 40px;
-  }
-
-  .rag-tags-controls {
-    flex-direction: column;
-    align-items: stretch;
-    gap: var(--space-3);
-  }
-
-  .rag-tags-controls button {
-    width: 100%;
-    justify-content: center;
-    min-height: 40px;
-  }
 }
 </style>

--- a/AdminPanel-Vue/src/views/RagTuning.vue
+++ b/AdminPanel-Vue/src/views/RagTuning.vue
@@ -8,6 +8,13 @@
         />
         <UiButton
           variant="secondary"
+          :disabled="isThemeLoading"
+          @click="loadThemes"
+        >
+          {{ isThemeLoading ? "刷新中…" : "刷新预设" }}
+        </UiButton>
+        <UiButton
+          variant="secondary"
           :disabled="!isDirty"
           @click="resetParams"
         >
@@ -22,31 +29,6 @@
         </UiButton>
       </UiPageActions>
     </Teleport>
-
-    <header class="rag-lab__hero card">
-      <div class="rag-lab__hero-copy">
-        <span class="eyebrow rag-lab__eyebrow">Wave RAG Parameter Lab</span>
-        <h2>浪潮 RAG 参数调优工作台</h2>
-        <p class="description">
-          集中查看和调整浪潮 RAG 的核心参数，支持按模块浏览、快速定位高影响项，并对虫洞脉冲路由等复杂参数进入独立控制舱进行细化编辑。
-        </p>
-      </div>
-
-      <div class="rag-lab__hero-stats">
-        <div class="hero-stat">
-          <span class="hero-stat__value">{{ groupSections.length }}</span>
-          <span class="hero-stat__label">参数组</span>
-        </div>
-        <div class="hero-stat">
-          <span class="hero-stat__value">{{ totalLeafCount }}</span>
-          <span class="hero-stat__label">可调节点</span>
-        </div>
-        <div class="hero-stat" :class="{ 'hero-stat--warning': isDirty }">
-          <span class="hero-stat__value">{{ changedLeafCount }}</span>
-          <span class="hero-stat__label">未保存修改</span>
-        </div>
-      </div>
-    </header>
 
     <div v-if="isLoading" class="rag-lab__state card">
       <span class="material-symbols-outlined">hourglass_top</span>
@@ -65,23 +47,174 @@
       <UiButton variant="secondary" @click="loadParams">重新加载</UiButton>
     </div>
 
-    <form v-else :id="formId" class="rag-lab__workspace" :class="{ 'is-aside-collapsed': asideCollapsed }" @submit.prevent="saveParams">
+    <form v-else :id="formId" class="rag-lab__workspace" @submit.prevent="saveParams">
+      <aside class="rag-lab__aside">
+        <div
+          class="rag-console"
+          aria-label="RAG 调优操作台"
+        >
+            <div class="rag-console__section rag-console__section--themes">
+              <div class="rag-console__themes-header">
+                <div>
+                  <span class="rag-console__label">参数预设</span>
+                  <p>以 <code>rag_params_模型名.json</code> 保存不同向量模型方案。</p>
+                </div>
+              </div>
+
+              <label class="theme-field">
+                <span>选择预设</span>
+                <UiSelect v-model="selectedThemeName" :disabled="isThemeLoading || isThemeSaving">
+                  <option value="">未选择预设</option>
+                  <option
+                    v-for="theme in ragParamThemes"
+                    :key="theme.fileName"
+                    :value="theme.name"
+                  >
+                    {{ theme.name }}
+                  </option>
+                </UiSelect>
+              </label>
+
+              <div class="rag-console__actions rag-console__theme-actions">
+                <UiButton
+                  variant="secondary"
+                  :disabled="!selectedThemeName || isThemeLoading || isThemeSaving"
+                  @click="openSelectedTheme"
+                >
+                  打开预设调参
+                </UiButton>
+                <UiButton
+                  variant="secondary"
+                  :disabled="!selectedThemeName || isThemeLoading || isThemeSaving || !hasParams"
+                  @click="saveCurrentToSelectedTheme"
+                >
+                  保存到所选预设
+                </UiButton>
+                <UiButton
+                  :disabled="!selectedThemeName || isThemeLoading || isThemeSaving"
+                  @click="applySelectedTheme"
+                >
+                  应用所选预设
+                </UiButton>
+              </div>
+
+              <UiBadge
+                v-if="statusMessage"
+                class="rag-console__status"
+                :variant="statusBadgeVariant"
+                role="status"
+                aria-live="polite"
+              >
+                {{ statusMessage }}
+              </UiBadge>
+
+              <label class="theme-field">
+                <span>新预设名称 / 向量模型名</span>
+                <UiInput
+                  v-model.trim="newThemeName"
+                  type="text"
+                  placeholder="例如 gemini-embedding-2-preview"
+                  :disabled="isThemeSaving"
+                />
+              </label>
+
+              <UiButton
+                :disabled="!canSaveNewTheme"
+                block
+                @click="saveCurrentAsNewTheme"
+              >
+                {{ isThemeSaving ? "保存预设中…" : "保存当前为新预设" }}
+              </UiButton>
+            </div>
+
+            <div class="rag-console__section rag-console__section--simulation">
+              <span class="rag-console__label">语义沙盘</span>
+              <div class="semantic-sim-card">
+                <div class="semantic-sim-card__copy">
+                  <strong>浪潮语义地形模拟器</strong>
+                  <p>预览 KNN 击中、顺逆流、虫洞跃迁与测地线能量场。</p>
+                </div>
+                <UiButton @click="openSemanticSimulation">
+                  打开沙盘
+                </UiButton>
+              </div>
+            </div>
+
+            <div class="rag-console__section">
+              <span class="rag-console__label">快速跳转</span>
+              <div class="rag-console__jump-list">
+                <UiButton
+                  v-for="section in groupSections"
+                  :key="`${section.name}-jump`"
+                  variant="ghost"
+                  class="rag-console__jump-btn"
+                  @click="scrollToGroup(section.anchor)"
+                >
+                  <span>{{ section.meta.title }}</span>
+                  <small>{{ section.changedLeaves }}/{{ section.totalLeaves }}</small>
+                </UiButton>
+              </div>
+            </div>
+
+            <div class="rag-console__section">
+              <span class="rag-console__label">风险提示</span>
+              <ul class="rag-console__tips">
+                <li>高风险参数建议单独修改并观察效果。</li>
+                <li>虫洞路由参数耦合较强，不建议一次联动改太多项。</li>
+                <li>
+                  召回漂移时优先回看 <code>tensionThreshold</code>、
+                  <code>baseMomentum</code> 和 <code>dynamicBoostRange</code>。
+                </li>
+              </ul>
+            </div>
+        </div>
+      </aside>
+
       <div class="rag-lab__main">
+        <header class="rag-lab__summary">
+          <div class="rag-lab__summary-copy">
+            <h2>浪潮 RAG 参数调优工作台</h2>
+            <p>
+              按模块浏览和调整核心参数；复杂的虫洞脉冲、有序共现与语义地形模拟可进入独立控制舱细化。
+            </p>
+          </div>
+
+          <div class="rag-lab__summary-stats">
+            <div class="hero-stat">
+              <span class="hero-stat__value">{{ groupSections.length }}</span>
+              <span class="hero-stat__label">参数组</span>
+            </div>
+            <div class="hero-stat">
+              <span class="hero-stat__value">{{ totalLeafCount }}</span>
+              <span class="hero-stat__label">可调节点</span>
+            </div>
+            <div class="hero-stat" :class="{ 'hero-stat--warning': isDirty }">
+              <span class="hero-stat__value">{{ changedLeafCount }}</span>
+              <span class="hero-stat__label">未保存修改</span>
+            </div>
+          </div>
+        </header>
+
         <article
           v-for="section in groupSections"
           :id="section.anchor"
           :key="section.name"
-          class="group-panel card"
+          :class="[
+            'group-panel',
+            `group-panel--${section.name}`,
+          ]"
           :style="{ '--group-accent': section.meta.accent }"
         >
           <header class="group-panel__header">
             <div class="group-panel__header-main">
-              <UiBadge class="group-panel__badge" variant="outline">{{ section.meta.badge }}</UiBadge>
               <div class="group-panel__title-row">
                 <span class="material-symbols-outlined">{{ section.meta.icon }}</span>
-                <div>
+                <div class="group-panel__title-copy">
                   <h3>{{ section.meta.title }}</h3>
-                  <p class="group-panel__name">{{ section.name }}</p>
+                  <div class="group-panel__meta-row">
+                    <UiBadge class="group-panel__badge" variant="outline">{{ section.meta.badge }}</UiBadge>
+                    <span class="group-panel__name">{{ section.name }}</span>
+                  </div>
                 </div>
               </div>
               <p class="group-panel__description">{{ section.meta.description }}</p>
@@ -120,6 +253,12 @@
                     <div class="param-row__heading">
                       <div class="param-row__title-block">
                         <h4>{{ entry.meta.label }}</h4>
+                        <details v-if="entry.meta.logic" class="param-row__details param-row__details--inline">
+                          <summary>展开调优逻辑</summary>
+                          <div class="param-row__details-body">
+                            <p>{{ entry.meta.logic }}</p>
+                          </div>
+                        </details>
                         <p class="param-row__key">{{ entry.key }}</p>
                       </div>
 
@@ -143,12 +282,6 @@
                       {{ entry.meta.range }}
                     </p>
 
-                    <details v-if="entry.meta.logic" class="param-row__details">
-                      <summary>展开调优逻辑</summary>
-                      <div class="param-row__details-body">
-                        <p>{{ entry.meta.logic }}</p>
-                      </div>
-                    </details>
                   </div>
 
                   <div class="wormhole-launchpad__control">
@@ -178,6 +311,12 @@
                     <div class="param-row__heading">
                       <div class="param-row__title-block">
                         <h4>{{ entry.meta.label }}</h4>
+                        <details v-if="entry.meta.logic" class="param-row__details param-row__details--inline">
+                          <summary>展开 V8.2 调优逻辑</summary>
+                          <div class="param-row__details-body">
+                            <p>{{ entry.meta.logic }}</p>
+                          </div>
+                        </details>
                         <p class="param-row__key">{{ entry.key }}</p>
                       </div>
 
@@ -201,12 +340,6 @@
                       {{ entry.meta.range }}
                     </p>
 
-                    <details v-if="entry.meta.logic" class="param-row__details">
-                      <summary>展开 V8.2 调优逻辑</summary>
-                      <div class="param-row__details-body">
-                        <p>{{ entry.meta.logic }}</p>
-                      </div>
-                    </details>
                   </div>
 
                   <div class="wormhole-launchpad__control ordered-launchpad__control">
@@ -246,6 +379,12 @@
                   <div class="param-row__heading">
                     <div class="param-row__title-block">
                       <h4>{{ entry.meta.label }}</h4>
+                      <details v-if="entry.meta.logic" class="param-row__details param-row__details--inline">
+                        <summary>展开测地线融合逻辑</summary>
+                        <div class="param-row__details-body">
+                          <p>{{ entry.meta.logic }}</p>
+                        </div>
+                      </details>
                       <p class="param-row__key">{{ entry.key }}</p>
                     </div>
 
@@ -269,12 +408,6 @@
                     {{ entry.meta.range }}
                   </p>
 
-                  <details v-if="entry.meta.logic" class="param-row__details">
-                    <summary>展开测地线融合逻辑</summary>
-                    <div class="param-row__details-body">
-                      <p>{{ entry.meta.logic }}</p>
-                    </div>
-                  </details>
                 </div>
 
                 <div class="geodesic-launchpad__control">
@@ -347,6 +480,12 @@
                   <div class="param-row__heading">
                     <div class="param-row__title-block">
                       <h4>{{ entry.meta.label }}</h4>
+                      <details v-if="entry.meta.logic" class="param-row__details param-row__details--inline">
+                        <summary>展开调优逻辑</summary>
+                        <div class="param-row__details-body">
+                          <p>{{ entry.meta.logic }}</p>
+                        </div>
+                      </details>
                       <p class="param-row__key">{{ entry.key }}</p>
                     </div>
 
@@ -376,12 +515,6 @@
                     {{ entry.meta.range }}
                   </p>
 
-                  <details v-if="entry.meta.logic" class="param-row__details">
-                    <summary>展开调优逻辑</summary>
-                    <div class="param-row__details-body">
-                      <p>{{ entry.meta.logic }}</p>
-                    </div>
-                  </details>
                 </div>
 
                 <div class="param-row__control">
@@ -491,191 +624,6 @@
         </article>
       </div>
 
-      <aside class="rag-lab__aside">
-        <div
-          class="rag-console card"
-          :class="{ 'is-collapsed': asideCollapsed }"
-          :aria-label="asideCollapsed ? 'RAG 调优操作台（已折叠）' : 'RAG 调优操作台'"
-        >
-          <template v-if="asideCollapsed">
-            <div class="console-rail">
-              <UiIconButton
-                class="console-rail-toggle"
-                label="展开操作台"
-                title="展开操作台"
-                @click="toggleAside"
-              >
-                <span class="material-symbols-outlined">right_panel_open</span>
-              </UiIconButton>
-              <div class="console-rail-divider"></div>
-              <UiIconButton
-                class="console-rail-icon console-rail-icon--simulation"
-                label="打开浪潮语义沙盘"
-                title="打开浪潮语义沙盘"
-                @click="openSemanticSimulation"
-              >
-                <span class="material-symbols-outlined">travel_explore</span>
-              </UiIconButton>
-              <UiIconButton
-                v-for="section in groupSections.slice(0, 8)"
-                :key="`${section.anchor}-rail`"
-                class="console-rail-icon"
-                :title="section.meta.title"
-                :label="`跳转到 ${section.meta.title}`"
-                @click="scrollToGroup(section.anchor)"
-              >
-                <span class="material-symbols-outlined">tune</span>
-              </UiIconButton>
-            </div>
-          </template>
-          <template v-else>
-          <div class="rag-console__section">
-            <div class="rag-console__header">
-              <div>
-                <span class="rag-console__label">操作台</span>
-                <h3>参数预设与沙盘</h3>
-                <p>保存与回退已统一放在页面标题右侧，这里保留预设管理、模块跳转和语义沙盘。</p>
-              </div>
-              <UiIconButton
-                class="console-rail-toggle"
-                label="折叠操作台"
-                title="折叠操作台"
-                @click="toggleAside"
-              >
-                <span class="material-symbols-outlined">right_panel_close</span>
-              </UiIconButton>
-            </div>
-          </div>
-
-          <div class="rag-console__section rag-console__section--themes">
-            <div class="rag-console__themes-header">
-              <div>
-                <span class="rag-console__label">参数预设</span>
-                <p>以 <code>rag_params_模型名.json</code> 形式保存不同向量模型的调参方案。</p>
-              </div>
-              <UiButton
-                variant="secondary"
-                size="sm"
-                class="rag-console__mini-action"
-                :disabled="isThemeLoading"
-                @click="loadThemes"
-              >
-                {{ isThemeLoading ? "刷新中…" : "刷新" }}
-              </UiButton>
-            </div>
-
-            <label class="theme-field">
-              <span>选择预设</span>
-              <UiSelect v-model="selectedThemeName" :disabled="isThemeLoading || isThemeSaving">
-                <option value="">未选择预设</option>
-                <option
-                  v-for="theme in ragParamThemes"
-                  :key="theme.fileName"
-                  :value="theme.name"
-                >
-                  {{ theme.name }}
-                </option>
-              </UiSelect>
-            </label>
-
-            <div class="rag-console__actions rag-console__theme-actions">
-              <UiButton
-                variant="secondary"
-                :disabled="!selectedThemeName || isThemeLoading || isThemeSaving"
-                @click="openSelectedTheme"
-              >
-                打开预设调参
-              </UiButton>
-              <UiButton
-                variant="secondary"
-                :disabled="!selectedThemeName || isThemeLoading || isThemeSaving || !hasParams"
-                @click="saveCurrentToSelectedTheme"
-              >
-                保存到所选预设
-              </UiButton>
-              <UiButton
-                :disabled="!selectedThemeName || isThemeLoading || isThemeSaving"
-                @click="applySelectedTheme"
-              >
-                应用所选预设
-              </UiButton>
-            </div>
-
-            <label class="theme-field">
-              <span>新预设名称 / 向量模型名</span>
-              <UiInput
-                v-model.trim="newThemeName"
-                type="text"
-                placeholder="例如 gemini-embedding-2-preview"
-                :disabled="isThemeSaving"
-              />
-            </label>
-
-            <UiButton
-              :disabled="!canSaveNewTheme"
-              block
-              @click="saveCurrentAsNewTheme"
-            >
-              {{ isThemeSaving ? "保存预设中…" : "保存当前为新预设" }}
-            </UiButton>
-          </div>
-
-          <UiBadge
-            v-if="statusMessage"
-            class="rag-console__status"
-            :variant="statusBadgeVariant"
-            role="status"
-            aria-live="polite"
-          >
-            {{ statusMessage }}
-          </UiBadge>
-
-          <div class="rag-console__section rag-console__section--simulation">
-            <span class="rag-console__label">语义沙盘</span>
-            <div class="semantic-sim-card">
-              <div class="semantic-sim-card__orb">
-                <span class="material-symbols-outlined">travel_explore</span>
-              </div>
-              <div class="semantic-sim-card__copy">
-                <strong>浪潮语义地形模拟器</strong>
-                <p>在子模态窗中预览 KNN 击中、顺逆流、虫洞跃迁与测地线能量场。</p>
-              </div>
-              <UiButton @click="openSemanticSimulation">
-                打开沙盘
-              </UiButton>
-            </div>
-          </div>
-
-          <div class="rag-console__section">
-            <span class="rag-console__label">快速跳转</span>
-            <div class="rag-console__jump-list">
-              <UiButton
-                v-for="section in groupSections"
-                :key="`${section.name}-jump`"
-                variant="ghost"
-                class="rag-console__jump-btn"
-                @click="scrollToGroup(section.anchor)"
-              >
-                <span>{{ section.meta.title }}</span>
-                <small>{{ section.changedLeaves }}/{{ section.totalLeaves }}</small>
-              </UiButton>
-            </div>
-          </div>
-
-          <div class="rag-console__section">
-            <span class="rag-console__label">风险提示</span>
-            <ul class="rag-console__tips">
-              <li>标记为“高风险”的参数建议单独修改并观察效果。</li>
-              <li>虫洞路由参数之间耦合较强，不建议一次联动改太多项。</li>
-              <li>
-                如果召回突然漂移，优先回看 <code>tensionThreshold</code>、
-                <code>baseMomentum</code> 和 <code>dynamicBoostRange</code>。
-              </li>
-            </ul>
-          </div>
-          </template>
-        </div>
-      </aside>
     </form>
 
     <WormholeRoutingModal
@@ -761,12 +709,10 @@ import {
   type RagParamTheme,
   type RagParams,
 } from "@/api";
-import { useConsoleCollapse } from "@/composables/useConsoleCollapse";
 import { useAppStore } from "@/stores/app";
 import UiBadge from "@/components/ui/UiBadge.vue";
 import UiButton from "@/components/ui/UiButton.vue";
 import UiDirtyIndicator from "@/components/ui/UiDirtyIndicator.vue";
-import UiIconButton from "@/components/ui/UiIconButton.vue";
 import UiInput from "@/components/ui/UiInput.vue";
 import UiPageActions from "@/components/ui/UiPageActions.vue";
 import UiSelect from "@/components/ui/UiSelect.vue";
@@ -859,10 +805,6 @@ const selectedThemeName = ref("");
 const newThemeName = ref("");
 const isThemeLoading = ref(false);
 const isThemeSaving = ref(false);
-
-const { collapsed: asideCollapsed, toggle: toggleAside } = useConsoleCollapse(
-  "rag-tuning-aside"
-);
 
 function cloneParams(source: RagParams): RagParams {
   return JSON.parse(JSON.stringify(source));
@@ -1561,63 +1503,45 @@ onBeforeUnmount(() => {
 .rag-lab {
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: var(--space-4);
 }
 
-.rag-lab__hero {
-  position: relative;
-  overflow: hidden;
-  display: grid;
-  grid-template-columns: minmax(0, 1.35fr) auto;
-  gap: var(--space-5);
-  padding: var(--space-6);
-  border-radius: var(--radius-xl);
-}
-
-.rag-lab__hero::before {
-  content: "";
-  position: absolute;
-  inset: auto -10% -30% 55%;
-  height: 260px;
-  background: radial-gradient(
-    circle,
-    color-mix(in srgb, var(--highlight-text) 24%, transparent),
-    transparent 68%
-  );
-  pointer-events: none;
-}
-
-.rag-lab__eyebrow {
-  background: var(--info-bg);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-}
-
-.rag-lab__hero-copy {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.rag-lab__hero-copy h2 {
+.rag-lab__summary-copy h2 {
   margin: 0;
-  font-size: var(--font-size-section-title-fluid);
-  line-height: 1.2;
+  font-size: 1.125rem;
+  line-height: 1.35;
 }
 
-.rag-lab__hero-copy .description {
+.rag-lab__summary-copy p {
   max-width: 68ch;
   margin: 0;
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+  line-height: 1.55;
 }
 
-.rag-lab__hero-stats {
+.rag-lab__summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-4);
+  align-items: center;
+  padding: var(--space-4);
+  border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--primary-text) 1.2%, transparent);
+}
+
+.rag-lab__summary-copy {
+  display: grid;
+  gap: 6px;
+}
+
+.rag-lab__summary-stats {
   position: relative;
   z-index: 1;
   display: grid;
-  grid-template-columns: repeat(3, minmax(96px, 120px));
-  gap: var(--space-3);
+  grid-template-columns: repeat(3, minmax(88px, 108px));
+  gap: var(--space-2);
   align-content: start;
 }
 
@@ -1625,10 +1549,10 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-  min-height: 72px;
-  padding: var(--space-3) var(--space-4);
+  min-height: 58px;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: transparent;
 }
 
@@ -1673,13 +1597,9 @@ onBeforeUnmount(() => {
 
 .rag-lab__workspace {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
-  gap: var(--space-5);
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: var(--space-4);
   align-items: start;
-}
-
-.rag-lab__workspace.is-aside-collapsed {
-  grid-template-columns: minmax(0, 1fr) 56px;
 }
 
 .rag-lab__main {
@@ -1688,51 +1608,79 @@ onBeforeUnmount(() => {
 }
 
 .group-panel {
-  overflow: hidden;
-  border-radius: var(--radius-xl);
+  position: relative;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
   scroll-margin-top: calc(var(--app-top-bar-height, 60px) + 16px);
+}
+
+.group-panel + .group-panel {
+  margin-top: var(--space-2);
+}
+
+.group-panel--ContextFoldingV2 {
+  background: transparent;
 }
 
 .group-panel__header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--space-4);
-  padding: var(--space-5) var(--space-5) 20px var(--space-6);
+  align-items: center;
+  padding: var(--space-4) var(--space-5);
   position: relative;
-  background: linear-gradient(90deg, var(--surface-overlay-soft), transparent);
+  border: 1px solid color-mix(in srgb, var(--group-accent) 24%, var(--border-color));
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--group-accent) 4%, transparent),
+    transparent 52%
+  );
 }
 
-.group-panel__header::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 4px;
-  height: 70%;
-  background: var(--group-accent);
-  border-radius: 2px;
+.group-panel--ContextFoldingV2 .group-panel__header {
+  border-color: color-mix(in srgb, var(--group-accent) 28%, var(--border-color));
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--group-accent) 5%, transparent),
+    transparent 56%
+  );
 }
 
 .group-panel__header-main {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: var(--space-2);
 }
 
 .group-panel__badge {
   width: fit-content;
+  border-color: color-mix(in srgb, var(--group-accent) 32%, var(--border-color));
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--group-accent) 7%, transparent);
 }
 
 .group-panel__title-row {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: var(--space-3);
 }
 
 .group-panel__title-row .material-symbols-outlined {
-  font-size: var(--font-size-section-icon);
-  color: var(--highlight-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 36px;
+  width: 36px;
+  height: 36px;
+  border: 1px solid color-mix(in srgb, var(--group-accent) 28%, var(--border-color));
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--group-accent) 9%, transparent);
+  color: color-mix(in srgb, var(--highlight-text) 84%, var(--primary-text));
+  font-size: 22px;
 }
 
 .group-panel__title-row h3 {
@@ -1740,40 +1688,55 @@ onBeforeUnmount(() => {
   font-size: var(--font-size-title);
 }
 
+.group-panel__title-copy {
+  display: grid;
+  gap: 6px;
+}
+
+.group-panel__meta-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
 .group-panel__name {
-  margin: var(--space-1) 0 0;
+  margin: 0;
   color: var(--secondary-text);
   font-family: "Consolas", "Monaco", monospace;
   font-size: var(--font-size-helper);
+  line-height: 1;
 }
 
 .group-panel__description {
   max-width: 70ch;
   margin: 0;
   color: var(--secondary-text);
-  line-height: 1.7;
+  font-size: var(--font-size-body);
+  line-height: 1.55;
 }
 
 .group-panel__metrics {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(96px, 110px));
-  gap: 10px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
 }
 
 .group-panel__metric {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-2);
   justify-content: center;
-  min-height: 64px;
-  padding: var(--space-3) var(--space-4);
-  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
-  border-radius: var(--radius-md);
+  min-height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
   background: transparent;
 }
 
 .group-panel__metric span {
-  font-size: var(--font-size-title);
+  font-family: "Consolas", "Monaco", monospace;
+  font-size: var(--font-size-emphasis);
   font-weight: 700;
 }
 
@@ -1787,20 +1750,34 @@ onBeforeUnmount(() => {
 
 .param-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.72fr);
-  gap: var(--space-5);
-  padding: var(--space-5) var(--space-5) var(--space-5) var(--space-6);
-  border-top: 1px solid var(--border-color);
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.62fr);
+  gap: var(--space-4);
+  align-items: center;
+  padding: var(--space-4) var(--space-5);
+  border-top: 1px solid color-mix(in srgb, var(--border-color) 58%, transparent);
+}
+
+.group-panel__list .param-row:first-child {
+  border-top: 0;
 }
 
 .param-row--changed {
   background: color-mix(in srgb, var(--highlight-text) 4%, transparent);
 }
 
+.param-row--nested {
+  grid-template-columns: 1fr;
+  gap: var(--space-2);
+}
+
+.param-row--nested .param-row__control {
+  padding-top: 0;
+}
+
 .param-row__copy {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: 10px;
 }
 
 .param-row__heading {
@@ -1812,11 +1789,20 @@ onBeforeUnmount(() => {
 
 .param-row__title-block h4 {
   margin: 0;
-  font-size: var(--font-size-body);
+  font-size: var(--font-size-emphasis);
+  line-height: 1.35;
+}
+
+.param-row__title-block {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px var(--space-3);
 }
 
 .param-row__key {
-  margin: var(--space-1) 0 0;
+  flex-basis: 100%;
+  margin: 0;
   color: var(--secondary-text);
   font-family: "Consolas", "Monaco", monospace;
   font-size: var(--font-size-helper);
@@ -1832,7 +1818,8 @@ onBeforeUnmount(() => {
 .param-row__summary {
   margin: 0;
   color: color-mix(in srgb, var(--primary-text) 84%, transparent);
-  line-height: 1.7;
+  font-size: var(--font-size-body);
+  line-height: 1.55;
 }
 
 .param-row__range {
@@ -1854,32 +1841,55 @@ onBeforeUnmount(() => {
 }
 
 .param-row__details summary {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
   cursor: pointer;
   color: var(--highlight-text);
+  font-size: var(--font-size-helper);
+  line-height: 1;
+}
+
+.param-row__details--inline {
+  display: contents;
+}
+
+.param-row__details--inline summary {
+  gap: 4px;
+  color: var(--secondary-text);
+}
+
+.param-row__details--inline summary:hover {
+  color: var(--highlight-text);
+}
+
+.param-row__details--inline[open] .param-row__details-body {
+  flex-basis: 100%;
+  order: 3;
 }
 
 .param-row__details-body {
   max-width: 68ch;
   margin-top: var(--space-2);
   color: var(--secondary-text);
-  line-height: 1.7;
+  font-size: var(--font-size-body);
+  line-height: 1.6;
 }
 
 .param-row__control {
   display: flex;
-  align-items: stretch;
+  align-items: center;
 }
 
 .control-shell {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: var(--space-3);
+  display: grid;
+  gap: 6px;
   width: 100%;
-  padding: var(--space-4);
-  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .control-shell__label,
@@ -1893,11 +1903,28 @@ onBeforeUnmount(() => {
 .tuple-field :deep(.ui-input),
 .nested-item__number {
   font-family: "Consolas", "Monaco", monospace;
+  min-height: 32px;
+}
+
+.control-shell > :deep(.ui-input) {
+  width: min(100%, 180px);
+  justify-self: end;
+  min-height: 30px;
+  border-color: transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  text-align: right;
+}
+
+.control-shell > :deep(.ui-input:hover),
+.control-shell > :deep(.ui-input:focus) {
+  border-color: color-mix(in srgb, var(--border-color) 78%, var(--highlight-text));
+  background: color-mix(in srgb, var(--input-bg) 46%, transparent);
 }
 
 .tuple-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: var(--space-3);
 }
 
@@ -1908,7 +1935,12 @@ onBeforeUnmount(() => {
 }
 
 .control-shell--nested {
-  gap: var(--space-4);
+  gap: 0;
+  min-height: 0;
+  padding: 0;
+  overflow: hidden;
+  border-top: 1px solid color-mix(in srgb, var(--border-color) 64%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 64%, transparent);
   container: nested-shell / inline-size;
 }
 
@@ -1916,27 +1948,39 @@ onBeforeUnmount(() => {
   display: flex;
   justify-content: space-between;
   gap: var(--space-3);
+  align-items: center;
+  min-height: 36px;
+  padding: 0 var(--space-3);
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 58%, transparent);
+  background: transparent;
+  font-weight: 600;
 }
 
 .nested-list {
   display: grid;
-  gap: var(--space-3);
 }
 
 .nested-item {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 160px;
-  gap: var(--space-3);
-  padding: var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
-  border-radius: var(--radius-md);
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.56fr);
+  gap: var(--space-5);
+  align-items: center;
+  padding: 10px var(--space-3);
+  border: 0;
+  border-top: 1px solid color-mix(in srgb, var(--border-color) 54%, transparent);
+  border-radius: 0;
   background: transparent;
+}
+
+.nested-item:first-child {
+  border-top: 0;
 }
 
 .nested-item__copy {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 5px;
+  min-width: 0;
 }
 
 .nested-item__title {
@@ -1949,6 +1993,7 @@ onBeforeUnmount(() => {
 .nested-item__title h5 {
   margin: 0;
   font-size: var(--font-size-body);
+  line-height: 1.35;
 }
 
 .nested-item__key {
@@ -1958,10 +2003,13 @@ onBeforeUnmount(() => {
 }
 
 .nested-item__summary {
+  overflow: hidden;
   margin: 0;
   color: var(--secondary-text);
-  font-size: var(--font-size-body);
-  line-height: 1.6;
+  font-size: var(--font-size-helper);
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .nested-item__meta {
@@ -1974,29 +2022,104 @@ onBeforeUnmount(() => {
   display: inline-flex;
   align-items: center;
   min-height: 24px;
-  padding: 0 var(--space-2);
-  border: 1px solid color-mix(in srgb, var(--border-color) 68%, transparent);
-  border-radius: var(--radius-full);
+  padding: 0;
+  border: 0;
+  border-radius: 0;
   background: transparent;
   color: var(--secondary-text);
   font-size: var(--font-size-caption);
 }
 
 .nested-item__control {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 92px;
+  gap: var(--space-3);
+  align-items: center;
 }
 
 .nested-item__slider {
   width: 100%;
+  height: 16px;
   margin: 0;
-  accent-color: var(--highlight-text);
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.nested-item__slider::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--secondary-text) 18%, transparent);
+}
+
+.nested-item__slider::-webkit-slider-thumb {
+  width: 12px;
+  height: 12px;
+  margin-top: -4px;
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid color-mix(in srgb, var(--highlight-text) 50%, var(--border-color));
+  border-radius: 50%;
+  background: var(--primary-bg);
+  transition: box-shadow var(--transition-fast), border-color var(--transition-fast);
+}
+
+.nested-item__slider::-moz-range-track {
+  height: 4px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--secondary-text) 18%, transparent);
+}
+
+.nested-item__slider::-moz-range-progress {
+  height: 4px;
+  border-radius: var(--radius-full);
+  background: var(--highlight-text);
+}
+
+.nested-item__slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border: 1px solid color-mix(in srgb, var(--highlight-text) 50%, var(--border-color));
+  border-radius: 50%;
+  background: var(--primary-bg);
+  transition: box-shadow var(--transition-fast), border-color var(--transition-fast);
+}
+
+.nested-item__slider:focus-visible {
+  outline: none;
+}
+
+.nested-item__slider:focus-visible::-webkit-slider-thumb,
+.nested-item__slider:hover::-webkit-slider-thumb {
+  border-color: var(--highlight-text);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--highlight-text) 16%, transparent);
+}
+
+.nested-item__slider:focus-visible::-moz-range-thumb,
+.nested-item__slider:hover::-moz-range-thumb {
+  border-color: var(--highlight-text);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--highlight-text) 16%, transparent);
 }
 
 .nested-item__number {
+  min-width: 0;
   text-align: right;
+}
+
+.nested-item__number :deep(.ui-input) {
+  min-height: 28px;
+  padding-inline: var(--space-2);
+  border-color: transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  text-align: right;
+}
+
+.nested-item__number :deep(.ui-input:hover),
+.nested-item__number :deep(.ui-input:focus) {
+  border-color: color-mix(in srgb, var(--border-color) 80%, var(--highlight-text));
+  background: color-mix(in srgb, var(--input-bg) 54%, transparent);
 }
 
 @container nested-shell (max-width: 480px) {
@@ -2082,7 +2205,7 @@ onBeforeUnmount(() => {
 .ordered-launchpad__control {
   border-color: color-mix(in srgb, var(--highlight-text) 18%, var(--border-color));
   background:
-    radial-gradient(circle at 16% 0%, color-mix(in srgb, var(--highlight-text) 8%, transparent), transparent 42%),
+    radial-gradient(circle at 16% 0%, color-mix(in srgb, var(--highlight-text) 4%, transparent), transparent 42%),
     color-mix(in srgb, var(--primary-text) 2%, transparent);
 }
 
@@ -2129,7 +2252,7 @@ onBeforeUnmount(() => {
   border: 1px solid color-mix(in srgb, var(--highlight-text) 18%, var(--border-color));
   border-radius: var(--radius-lg);
   background:
-    radial-gradient(circle at 18% 0%, color-mix(in srgb, var(--highlight-text) 8%, transparent), transparent 42%),
+    radial-gradient(circle at 18% 0%, color-mix(in srgb, var(--highlight-text) 4%, transparent), transparent 42%),
     color-mix(in srgb, var(--primary-text) 2%, transparent);
 }
 
@@ -2227,41 +2350,27 @@ onBeforeUnmount(() => {
 
 .rag-lab__aside {
   position: sticky;
-  top: var(--space-4);
+  top: var(--space-2);
+  max-height: calc(100vh - var(--app-top-bar-height, 48px) - 28px);
+  overflow: auto;
 }
 
 .rag-console {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
-  padding: var(--space-5);
-  border-radius: var(--radius-xl);
+  gap: var(--space-3);
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
   transition: padding 0.2s ease;
-}
-
-.rag-console.is-collapsed {
-  padding: var(--space-3) 0;
-  gap: 0;
-  align-items: center;
-}
-
-.rag-console__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-2);
-}
-
-.rag-console__header > div {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
 }
 
 .rag-console__section {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .rag-console__section h3,
@@ -2271,21 +2380,22 @@ onBeforeUnmount(() => {
 
 .rag-console__section p {
   color: var(--secondary-text);
-  font-size: var(--font-size-body);
+  font-size: var(--font-size-helper);
+  line-height: 1.45;
 }
 
 .rag-console__label {
-  color: var(--highlight-text);
+  color: var(--secondary-text);
   font-size: var(--font-size-caption);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 .rag-console__actions,
 .rag-console__jump-list {
   display: grid;
-  gap: 10px;
+  gap: var(--space-2);
 }
 
 .rag-console__actions button {
@@ -2300,13 +2410,16 @@ onBeforeUnmount(() => {
 }
 
 .rag-console__status {
+  display: block;
   max-width: 100%;
+  overflow-wrap: anywhere;
   white-space: normal;
+  line-height: 1.4;
 }
 
 .rag-console__themes-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
 }
@@ -2315,28 +2428,32 @@ onBeforeUnmount(() => {
   font-family: "Consolas", "Monaco", monospace;
 }
 
-.rag-console__mini-action {
-  flex: 0 0 auto;
-}
-
 .theme-field {
   display: grid;
-  gap: var(--space-2);
+  gap: 6px;
   color: var(--secondary-text);
   font-size: var(--font-size-helper);
 }
 
 .rag-console__theme-actions {
-  grid-template-columns: 1fr;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2);
+}
+
+.rag-console__theme-actions :deep(.ui-button) {
+  min-width: 0;
+  padding-inline: var(--space-2);
+}
+
+.rag-console__theme-actions :deep(.ui-button):last-child {
+  grid-column: 1 / -1;
 }
 
 .rag-console__section--themes {
-  padding: var(--space-4);
-  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
-  border-radius: var(--radius-lg);
-  background:
-    radial-gradient(circle at 12% 0%, color-mix(in srgb, var(--highlight-text) 6%, transparent), transparent 46%),
-    color-mix(in srgb, var(--primary-text) 2%, transparent);
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--border-color) 74%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary-text) 1%, transparent);
 }
 
 .rag-console__jump-btn {
@@ -2374,37 +2491,16 @@ onBeforeUnmount(() => {
   position: relative;
   overflow: hidden;
   display: grid;
-  gap: var(--space-3);
-  padding: var(--space-4);
-  border: 1px solid color-mix(in srgb, var(--highlight-text) 18%, var(--border-color));
-  border-radius: var(--radius-lg);
-  background:
-    radial-gradient(circle at 14% 0%, color-mix(in srgb, var(--highlight-text) 10%, transparent), transparent 42%),
-    color-mix(in srgb, var(--primary-text) 2%, transparent);
-}
-
-.semantic-sim-card::after {
-  content: "";
-  position: absolute;
-  right: -38px;
-  bottom: -42px;
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  background: color-mix(in srgb, var(--highlight-text) 10%, transparent);
-  filter: blur(2px);
-  pointer-events: none;
-}
-
-.semantic-sim-card__orb {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--highlight-text) 14%, transparent);
-  color: var(--highlight-text);
+  background: transparent;
+}
+
+.group-panel--ContextFoldingV2 .group-panel__metric {
+  border-color: transparent;
+  background: transparent;
 }
 
 .semantic-sim-card__copy {
@@ -2531,16 +2627,15 @@ onBeforeUnmount(() => {
 }
 
 @media (max-width: 1180px) {
-  .rag-lab__hero {
+  .rag-lab__summary {
     grid-template-columns: 1fr;
   }
 
-  .rag-lab__hero-stats {
+  .rag-lab__summary-stats {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .rag-lab__workspace,
-  .rag-lab__workspace.is-aside-collapsed {
+  .rag-lab__workspace {
     grid-template-columns: 1fr;
   }
 
@@ -2574,12 +2669,11 @@ onBeforeUnmount(() => {
 }
 
 @media (max-width: 640px) {
-  .rag-lab__hero,
-  .rag-console {
+  .rag-lab__summary {
     padding: var(--space-4);
   }
 
-  .rag-lab__hero-stats {
+  .rag-lab__summary-stats {
     grid-template-columns: 1fr;
   }
 

--- a/AdminPanel-Vue/src/views/SemanticGroupsEditor.vue
+++ b/AdminPanel-Vue/src/views/SemanticGroupsEditor.vue
@@ -1,131 +1,84 @@
 <template>
-  <section class="config-section active-section">
-    <p class="description">
-      管理 RAGDiaryPlugin 使用的语义组。语义组会通过关键词激活，将相关向量注入查询，以提升检索准确性。
-    </p>
+  <section class="config-section active-section semantic-groups-page">
+    <Teleport to="#page-header-actions">
+      <UiPageActions>
+        <p class="semantic-page-summary">
+          管理 RAGDiaryPlugin 语义组，通过关键词激活相关向量以提升检索准确性。
+        </p>
+        <UiBadge v-if="statusMessage" :variant="statusBadgeVariant">{{ statusMessage }}</UiBadge>
+        <UiBadge v-else :variant="isDirty ? 'warning' : 'success'">
+          {{ isDirty ? "未保存" : "已同步" }}
+        </UiBadge>
+        <UiButton type="button" variant="outline" size="lg" @click="addSemanticGroup">
+          <span class="material-symbols-outlined">add</span>
+          新增语义组
+        </UiButton>
+        <UiButton type="button" size="lg" :disabled="!isDirty" @click="saveSemanticGroups">
+          <span class="material-symbols-outlined">save</span>
+          保存更改
+        </UiButton>
+      </UiPageActions>
+    </Teleport>
 
-    <div v-if="statusMessage" class="semantic-groups-controls">
-      <UiBadge :variant="statusBadgeVariant">{{ statusMessage }}</UiBadge>
-    </div>
+    <div id="semantic-groups-container" class="semantic-groups-layout">
+      <aside class="semantic-groups-sidebar" aria-label="语义组操作台">
+        <span class="group-console__label">操作台</span>
+        <div class="semantic-groups-sidebar-header">
+          <h3>语义组</h3>
+          <UiBadge variant="outline">{{ filteredGroupEntries.length }}/{{ semanticGroups.length }}</UiBadge>
+        </div>
 
-    <div id="semantic-groups-container" class="semantic-groups-layout" :class="{ 'is-sidebar-collapsed': sidebarCollapsed }">
-      <UiCard
-        class="semantic-groups-sidebar semantic-groups-surface"
-        :class="{ 'is-collapsed': sidebarCollapsed }"
-        :aria-label="sidebarCollapsed ? '语义组操作台（已折叠）' : '语义组操作台'"
-        size="sm"
-        variant="subtle"
-      >
-        <template v-if="sidebarCollapsed">
-          <div class="console-rail">
-            <UiIconButton
-              class="console-rail-toggle"
-              label="展开操作台"
-              title="展开操作台"
-              @click="toggleSidebar"
-            >
-              <span class="material-symbols-outlined">left_panel_open</span>
-            </UiIconButton>
-            <div class="console-rail-divider"></div>
-            <UiIconButton
-              class="console-rail-icon"
-              label="添加新组"
-              title="添加新组"
-              @click="addSemanticGroup"
-            >
-              <span class="material-symbols-outlined">add</span>
-            </UiIconButton>
-            <UiIconButton
-              v-for="entry in filteredGroupEntries.slice(0, 8)"
-              :key="entry.group.localId"
-              class="console-rail-icon"
-              :active="entry.index === selectedGroupIndex"
-              :label="entry.group.name || `未命名组 #${entry.index + 1}`"
-              :title="entry.group.name || `未命名组 #${entry.index + 1}`"
+        <div class="group-search-box">
+          <span class="material-symbols-outlined">search</span>
+          <UiInput
+            id="semantic-group-search-input"
+            v-model="groupQuery"
+            type="search"
+            size="sm"
+            placeholder="筛选名称或关键词..."
+          />
+          <UiIconButton
+            v-if="groupQuery"
+            label="清空筛选"
+            title="清空筛选"
+            @click="clearGroupQuery"
+          >
+            <span class="material-symbols-outlined">close</span>
+          </UiIconButton>
+        </div>
+
+        <ul class="semantic-groups-list">
+          <li
+            v-for="entry in filteredGroupEntries"
+            :key="entry.group.localId"
+            class="group-list-item"
+          >
+            <button
+              type="button"
+              :class="['group-row', { 'is-active': entry.index === selectedGroupIndex }]"
               @click="selectGroup(entry.index)"
             >
               <span class="material-symbols-outlined">category</span>
-            </UiIconButton>
-          </div>
-        </template>
-        <template v-else>
-          <div class="group-console__section">
-            <span class="group-console__label">操作台</span>
-            <div class="semantic-groups-sidebar-header">
-              <h3>语义组列表</h3>
-              <div class="sidebar-header-meta">
-                <UiBadge variant="outline">{{ filteredGroupEntries.length }}/{{ semanticGroups.length }} 组</UiBadge>
-                <UiIconButton
-                  class="console-rail-toggle"
-                  label="折叠操作台"
-                  title="折叠操作台"
-                  @click="toggleSidebar"
-                >
-                  <span class="material-symbols-outlined">left_panel_close</span>
-                </UiIconButton>
-              </div>
-            </div>
-          </div>
-
-          <div class="group-console__section">
-            <UiField label="搜索筛选" for-id="semantic-group-search-input" size="sm">
-              <div class="group-search-box">
-                <UiInput
-                  id="semantic-group-search-input"
-                  v-model="groupQuery"
-                  type="search"
-                  size="sm"
-                  placeholder="按语义组名称或关键词筛选..."
-                />
-                <UiButton
-                  v-if="groupQuery"
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  aria-label="清空筛选"
-                  @click="clearGroupQuery"
-                >
-                  清空
-                </UiButton>
-              </div>
-            </UiField>
-          </div>
-
-          <div class="group-console__section group-console__section--actions">
-            <UiButton type="button" size="sm" block @click="addSemanticGroup">
-              <span class="material-symbols-outlined">add</span>
-              添加新组
-            </UiButton>
-          </div>
-
-          <ul class="semantic-groups-list">
-            <li
-              v-for="entry in filteredGroupEntries"
-              :key="entry.group.localId"
-              class="group-list-item"
-            >
-              <button
-                type="button"
-                :class="['group-row', { 'is-active': entry.index === selectedGroupIndex }]"
-                @click="selectGroup(entry.index)"
-              >
+              <span class="group-row-copy">
                 <span class="group-row-name">{{ entry.group.name || `未命名组 #${entry.index + 1}` }}</span>
-                <span class="group-row-meta">{{ getKeywordCount(entry.group.keywords) }} 个关键词</span>
-              </button>
-            </li>
-            <li v-if="semanticGroups.length === 0">
-              <UiEmptyState title="暂无语义组" />
-            </li>
-            <li v-else-if="filteredGroupEntries.length === 0">
-              <UiEmptyState title="未找到匹配项" :description="`未找到匹配“${groupQuery}”的语义组`" />
-            </li>
-          </ul>
-        </template>
-      </UiCard>
+                <span class="group-row-meta">
+                  {{ getKeywordCount(entry.group.keywords) }} 个关键词 · 权重 {{ entry.group.weight }}
+                </span>
+              </span>
+            </button>
+          </li>
+          <li v-if="semanticGroups.length === 0">
+            <UiEmptyState title="暂无语义组" />
+          </li>
+          <li v-else-if="filteredGroupEntries.length === 0">
+            <UiEmptyState title="未找到匹配项" :description="`未找到匹配“${groupQuery}”的语义组`" />
+          </li>
+        </ul>
+      </aside>
 
       <UiSettingsCard
         v-if="selectedGroup"
-        class="semantic-group-detail semantic-groups-surface"
+        class="semantic-group-detail"
         title="编辑语义组"
         description="维护语义组名称、权重与关键词。"
         variant="subtle"
@@ -202,7 +155,7 @@
         </template>
       </UiSettingsCard>
 
-      <UiCard v-else class="semantic-group-detail-empty semantic-groups-surface" variant="subtle">
+      <UiCard v-else class="semantic-group-detail-empty" variant="subtle">
         <UiEmptyState title="请选择语义组" description="请选择左侧语义组进行编辑，或先添加新组。" />
       </UiCard>
     </div>
@@ -221,10 +174,10 @@ import UiEmptyState from "@/components/ui/UiEmptyState.vue";
 import UiField from "@/components/ui/UiField.vue";
 import UiIconButton from "@/components/ui/UiIconButton.vue";
 import UiInput from "@/components/ui/UiInput.vue";
+import UiPageActions from "@/components/ui/UiPageActions.vue";
 import UiSettingsCard from "@/components/ui/UiSettingsCard.vue";
 import UiSettingsForm from "@/components/ui/UiSettingsForm.vue";
 import UiTextarea from "@/components/ui/UiTextarea.vue";
-import { useConsoleCollapse } from "@/composables/useConsoleCollapse";
 import { askConfirm } from "@/platform/feedback/feedbackBus";
 import { showMessage } from "@/utils";
 
@@ -242,10 +195,6 @@ const statusMessage = ref("");
 const statusType = ref<"info" | "success" | "error">("info");
 const groupQuery = ref("");
 const isDirty = ref(false);
-
-const { collapsed: sidebarCollapsed, toggle: toggleSidebar } = useConsoleCollapse(
-  "semantic-groups"
-);
 
 const statusBadgeVariant = computed(() => {
   if (statusType.value === "success") return "success";
@@ -492,94 +441,42 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-.semantic-groups-controls {
-  margin-bottom: var(--space-4);
+.semantic-groups-page {
+  --semantic-workspace-height: calc(var(--app-viewport-height, 100vh) - 150px);
+  --semantic-workspace-min-height: 520px;
 }
 
-.semantic-groups-surface {
-  --semantic-groups-surface-border: color-mix(in srgb, var(--border-color) 96%, transparent);
-  --semantic-groups-card-surface: color-mix(in srgb, var(--primary-text) 1.5%, transparent);
-}
-
-.semantic-groups-surface,
-:deep(.ui-card.semantic-groups-surface) {
-  border-color: var(--semantic-groups-surface-border);
-  background: var(--semantic-groups-card-surface);
-}
-
-.semantic-groups-surface :deep(.ui-card__header),
-:deep(.ui-card.semantic-groups-surface.ui-card--divided .ui-card__header) {
-  border-bottom-color: var(--semantic-groups-surface-border);
-}
-
-.semantic-groups-surface :deep(.ui-input),
-.semantic-groups-surface :deep(.ui-textarea) {
-  border-color: var(--semantic-groups-surface-border);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--primary-bg) 42%, transparent);
-}
-
-.semantic-group-item {
-  margin-bottom: 0;
+.semantic-page-summary {
+  max-width: 430px;
+  margin: 0 var(--space-2) 0 0;
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+  line-height: 1.35;
 }
 
 .semantic-groups-layout {
   display: grid;
-  grid-template-columns: minmax(260px, 320px) 1fr;
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
   gap: var(--space-4);
-}
-
-.semantic-groups-layout.is-sidebar-collapsed {
-  grid-template-columns: 56px 1fr;
+  min-height: var(--semantic-workspace-min-height);
+  height: max(var(--semantic-workspace-height), var(--semantic-workspace-min-height));
 }
 
 .semantic-groups-sidebar {
-  --group-console-viewport-gap: var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
-  position: sticky;
-  top: var(--group-console-viewport-gap);
-  align-self: start;
-  height: calc(100vh - (var(--group-console-viewport-gap) * 2));
-  max-height: calc(100vh - (var(--group-console-viewport-gap) * 2));
-  overflow: hidden;
-  padding: var(--space-5);
-  border-radius: var(--radius-xl);
-  transition: padding var(--transition-fast);
-}
-
-.semantic-groups-sidebar.is-collapsed {
-  padding: var(--space-3) 0;
-  gap: 0;
-  align-items: center;
-}
-
-.semantic-groups-sidebar :deep(.ui-card__content) {
-  display: flex;
+  min-width: 0;
   min-height: 0;
-  flex: 1;
-  flex-direction: column;
-  gap: var(--space-3);
-}
-
-.sidebar-header-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.group-console__section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
+  overflow: hidden;
+  padding: 0;
 }
 
 .group-console__label {
-  color: var(--highlight-text);
-  font-size: var(--font-size-caption);
-  font-weight: 700;
+  color: color-mix(in srgb, var(--secondary-text) 72%, transparent);
+  font-size: 11px;
+  font-weight: 600;
   letter-spacing: 0.08em;
+  line-height: 1.25;
   text-transform: uppercase;
 }
 
@@ -588,33 +485,56 @@ onUnmounted(() => {
   align-items: center;
   justify-content: space-between;
   gap: var(--space-2);
+  min-height: 36px;
+  margin-bottom: var(--space-2);
 }
 
 .semantic-groups-sidebar-header h3 {
   margin: 0;
-  font-size: var(--font-size-lg);
   color: var(--primary-text);
+  font-size: var(--font-size-body);
+  font-weight: 650;
+  line-height: 1.25;
 }
 
 .group-search-box {
+  position: relative;
   display: flex;
-  gap: var(--space-2);
+  align-items: center;
+  margin-bottom: var(--space-3);
+}
+
+.group-search-box > .material-symbols-outlined {
+  position: absolute;
+  left: 10px;
+  color: var(--secondary-text);
+  font-size: 18px !important;
+  pointer-events: none;
 }
 
 .group-search-box :deep(.ui-input) {
-  flex: 1;
-  min-width: 0;
+  padding-left: 36px;
+  padding-right: 34px;
+}
+
+.group-search-box :deep(.ui-icon-button) {
+  position: absolute;
+  right: 4px;
+  width: 28px;
+  height: 28px;
 }
 
 .semantic-groups-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
   display: flex;
+  flex: 1;
+  min-height: 0;
   flex-direction: column;
   gap: var(--space-2);
+  margin: 0;
+  padding: 0 var(--space-1) var(--space-2) 0;
   overflow-y: auto;
-  flex: 1;
+  list-style: none;
+  scrollbar-gutter: stable;
 }
 
 .group-list-item {
@@ -623,17 +543,21 @@ onUnmounted(() => {
 }
 
 .group-row {
-  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
   width: 100%;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  justify-items: start;
-  gap: var(--space-1);
-  min-height: 44px;
+  min-height: 48px;
   padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--border-color);
+  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
   border-radius: var(--radius-md);
-  background: transparent;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--button-bg) 4%, transparent),
+      color-mix(in srgb, var(--primary-text) 0.7%, transparent)
+    );
   color: var(--primary-text);
   text-align: left;
   cursor: pointer;
@@ -644,12 +568,32 @@ onUnmounted(() => {
 }
 
 .group-row:hover {
-  background: var(--accent-bg);
+  border-color: color-mix(in srgb, var(--button-bg) 22%, var(--border-color));
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--button-bg) 7%, transparent),
+      color-mix(in srgb, var(--primary-text) 1.6%, transparent)
+    );
 }
 
 .group-row.is-active {
-  border-color: color-mix(in srgb, var(--highlight-text) 52%, var(--border-color));
-  background: color-mix(in srgb, var(--highlight-text) 10%, transparent);
+  border-color: color-mix(in srgb, var(--button-bg) 42%, var(--border-color));
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--button-bg) 11%, transparent),
+      color-mix(in srgb, var(--primary-text) 2%, transparent)
+    );
+}
+
+.group-row.is-active::before {
+  content: "";
+  position: absolute;
+  inset: 8px auto 8px 2px;
+  width: 2px;
+  border-radius: var(--radius-full);
+  background: var(--button-bg);
 }
 
 .group-row:focus-visible {
@@ -657,28 +601,60 @@ onUnmounted(() => {
   outline-offset: 2px;
 }
 
-.group-row-name {
-  font-weight: 600;
-  color: var(--primary-text);
-  line-height: 1.3;
+.group-row > .material-symbols-outlined {
+  flex: 0 0 auto;
+  color: var(--secondary-text);
+  font-size: 18px !important;
+}
+
+.group-row-copy {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.group-row-name,
+.group-row-meta {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 100%;
 }
 
-.group-row.is-active .group-row-name {
+.group-row-name {
   color: var(--primary-text);
+  font-size: var(--font-size-body);
+  font-weight: 650;
+  line-height: 1.25;
 }
 
 .group-row-meta {
   color: var(--secondary-text);
   font-size: var(--font-size-helper);
+  line-height: 1.3;
 }
 
 .semantic-group-detail,
 .semantic-group-detail-empty {
-  min-height: 320px;
+  min-width: 0;
+  min-height: 0;
+  border-color: color-mix(in srgb, var(--border-color) 84%, transparent);
+  background: color-mix(in srgb, var(--primary-text) 0.8%, transparent);
+}
+
+.semantic-group-detail :deep(.ui-card__header),
+.semantic-group-detail-empty :deep(.ui-card__header) {
+  border-bottom-color: color-mix(in srgb, var(--border-color) 68%, transparent);
+}
+
+.semantic-group-detail :deep(.ui-card__content) {
+  min-height: 0;
+}
+
+.semantic-group-detail :deep(.ui-input),
+.semantic-group-detail :deep(.ui-textarea) {
+  border-color: color-mix(in srgb, var(--border-color) 84%, transparent);
+  background: color-mix(in srgb, var(--primary-bg) 38%, transparent);
 }
 
 .semantic-group-detail-empty {
@@ -719,36 +695,23 @@ onUnmounted(() => {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .semantic-groups-sidebar,
   .group-row {
     transition: none;
   }
 }
 
 @media (max-width: 1024px) {
-  .semantic-groups-layout,
-  .semantic-groups-layout.is-sidebar-collapsed {
+  .semantic-groups-layout {
     grid-template-columns: 1fr;
-  }
-
-  .semantic-groups-sidebar {
-    position: static;
-    top: auto;
     height: auto;
-    max-height: none;
-    padding: var(--space-4);
-  }
-}
-
-@media (max-width: 768px) {
-  .group-search-box {
-    flex-direction: column;
   }
 
   .semantic-groups-list {
     max-height: 40vh;
   }
+}
 
+@media (max-width: 768px) {
   .detail-actions {
     justify-content: space-between;
   }

--- a/AdminPanel-Vue/src/views/ThemeEditor.vue
+++ b/AdminPanel-Vue/src/views/ThemeEditor.vue
@@ -31,19 +31,17 @@
     </Teleport>
 
     <!-- Hero -->
-    <header class="page-hero card">
+    <header class="theme-lab__intro">
       <div>
-        <span class="eyebrow theme-lab__eyebrow">Theme Editor</span>
         <h2>主题编辑器</h2>
         <p class="description">
           自定义面板外观：选择预设主题配色、逐项调整颜色变量、设置自定义背景图片，或编写自定义 CSS 样式覆盖。
         </p>
       </div>
-
     </header>
 
     <!-- Tab Pills -->
-    <section class="card theme-lab__controls">
+    <section class="theme-lab__controls">
       <div class="theme-lab__filter-row" role="group" aria-label="主题编辑分区切换">
         <button
           v-for="section in sections"
@@ -60,10 +58,10 @@
       </div>
     </section>
 
-    <section v-if="activeSection === 'theme'" class="card theme-lab__quick-panel">
+    <section v-if="activeSection === 'theme'" class="theme-lab__quick-panel">
       <div class="theme-lab__section-header">
         <h3>快速外观</h3>
-        <p>外观模式、圆角、密度、字体、内容宽度和外壳布局独立切换，保存后下次启动自动恢复。</p>
+        <p>外观、圆角、密度、字体、宽度和外壳布局独立切换。</p>
       </div>
 
       <div class="theme-lab__option-grid">
@@ -85,7 +83,7 @@
           </div>
         </div>
 
-        <div class="theme-lab__option-group">
+        <div class="theme-lab__option-group theme-lab__option-group--wide">
           <span class="theme-lab__option-title">圆角</span>
           <div class="theme-lab__choice-row theme-lab__choice-row--compact">
             <button
@@ -690,6 +688,7 @@ import {
   THEME_RADIUS_OPTIONS,
   THEME_SCALE_OPTIONS,
   THEME_SHELL_LAYOUT_OPTIONS,
+  THEME_SETTINGS_CHANGED_EVENT,
   applyThemeVars,
   applyCustomCss,
   applyBackgroundImage,
@@ -759,6 +758,31 @@ const fileInputRef = ref<HTMLInputElement | null>(null)
 // -- User themes --
 
 const userThemes = ref<UserTheme[]>(loadUserThemes())
+
+function syncDraftFromSnapshot(snapshot: ThemeSnapshot, options: { syncOriginal?: boolean } = {}) {
+  const normalizedSnapshot = {
+    ...snapshot,
+    backgroundImage: normalizeBackgroundSource(snapshot.backgroundImage),
+  }
+
+  draft.colorOverrides = { ...normalizedSnapshot.colorOverrides }
+  draft.customCss = normalizedSnapshot.customCss
+  draft.backgroundImage = normalizedSnapshot.backgroundImage
+  draft.activePresetId = normalizedSnapshot.activePresetId
+  draft.themeMode = normalizedSnapshot.themeMode
+  draft.radius = normalizedSnapshot.radius
+  draft.scale = normalizedSnapshot.scale
+  draft.font = normalizedSnapshot.font
+  draft.contentLayout = normalizedSnapshot.contentLayout
+  draft.shellLayout = normalizedSnapshot.shellLayout
+  currentPresetId.value = normalizedSnapshot.activePresetId
+
+  if (options.syncOriginal) {
+    originalSnapshot.value = JSON.parse(JSON.stringify(normalizedSnapshot))
+  }
+
+  resetBgSourceCheck()
+}
 
 function formatDate(ts: number): string {
   return new Date(ts).toLocaleDateString('zh-CN', {
@@ -1310,6 +1334,12 @@ function applyPreset(preset: FullPresetTheme) {
   draft.colorOverrides = {}
   draft.customCss = preset.customCss || ''
   draft.backgroundImage = normalizeBackgroundSource(preset.backgroundImage || '')
+  if (preset.defaultRadius) {
+    draft.radius = preset.defaultRadius
+  }
+  if (preset.defaultFont) {
+    draft.font = preset.defaultFont
+  }
   resetBgSourceCheck()
   applyFullTheme(draft)
 }
@@ -1664,8 +1694,15 @@ watch(
   { immediate: true }
 )
 
+function handleExternalThemeSettingsChanged() {
+  const snapshot = loadThemeSnapshot()
+  syncDraftFromSnapshot(snapshot, { syncOriginal: true })
+  refreshGlobalCssVars()
+}
+
 onMounted(() => {
   refreshGlobalCssVars()
+  window.addEventListener(THEME_SETTINGS_CHANGED_EVENT, handleExternalThemeSettingsChanged)
 })
 
 onBeforeRouteLeave(async () => {
@@ -1686,6 +1723,7 @@ onBeforeRouteLeave(async () => {
 })
 
 onUnmounted(() => {
+  window.removeEventListener(THEME_SETTINGS_CHANGED_EVENT, handleExternalThemeSettingsChanged)
   clearTimeout(cssDebounceTimer)
   clearTimeout(bgDebounceTimer)
   pickerRefs.clear()
@@ -1698,68 +1736,143 @@ onUnmounted(() => {
 .theme-lab {
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: var(--space-3);
 }
 
-/* Hero eyebrow override (margin only) */
-.theme-lab__eyebrow {
-  margin-bottom: var(--space-3);
+.theme-lab__intro {
+  display: grid;
+  gap: 6px;
+  padding-top: 2px;
+}
+
+.theme-lab__intro h2 {
+  margin: 0;
+  color: var(--primary-text);
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.theme-lab__intro .description {
+  margin: 0;
+  max-width: 68ch;
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+  line-height: 1.5;
 }
 
 /* Tab controls */
 .theme-lab__controls {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: 0;
+  padding-top: var(--space-1);
 }
 
 .theme-lab__filter-row {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-3);
+  gap: 8px;
+}
+
+.theme-lab__filter-row .filter-pill {
+  min-height: 32px;
+  padding: 0 12px;
+  border-color: color-mix(in srgb, var(--border-color) 78%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary-text) 1.2%, transparent);
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+  font-weight: 600;
+}
+
+.theme-lab__filter-row .filter-pill:hover {
+  border-color: color-mix(in srgb, var(--highlight-text) 38%, var(--border-color));
+  background: color-mix(in srgb, var(--highlight-text) 4%, transparent);
+  color: var(--primary-text);
+}
+
+.theme-lab__filter-row .filter-pill.active {
+  border-color: color-mix(in srgb, var(--highlight-text) 72%, var(--border-color));
+  background: color-mix(in srgb, var(--highlight-text) 8%, transparent);
+  color: var(--primary-text);
+}
+
+.theme-lab__filter-row .filter-pill .material-symbols-outlined {
+  font-size: 17px;
 }
 
 .theme-lab__quick-panel {
   display: grid;
-  gap: var(--space-4);
+  gap: var(--space-2);
+  padding-block: var(--space-2) var(--space-3);
+  border-block: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+}
+
+.theme-lab__quick-panel .theme-lab__section-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  justify-content: space-between;
+}
+
+.theme-lab__quick-panel .theme-lab__section-header h3 {
+  margin: 0;
+  white-space: nowrap;
+}
+
+.theme-lab__quick-panel .theme-lab__section-header p {
+  margin: 0;
+  max-width: none;
+  text-align: right;
 }
 
 .theme-lab__option-grid {
   display: grid;
-  gap: var(--space-4);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3) var(--space-5);
 }
 
 .theme-lab__option-group {
   display: grid;
-  gap: var(--space-2);
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.theme-lab__option-group--wide {
+  grid-column: 1 / -1;
 }
 
 .theme-lab__option-title {
   color: var(--primary-text);
-  font-size: var(--font-size-helper);
+  font-size: var(--font-size-caption);
   font-weight: 700;
+  line-height: 32px;
 }
 
 .theme-lab__choice-row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
   gap: var(--space-2);
 }
 
 .theme-lab__choice-row--compact {
-  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+}
+
+.theme-lab__option-group--wide .theme-lab__choice-row--compact {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
 }
 
 .theme-choice {
   display: grid;
-  gap: 4px;
-  min-height: 74px;
-  padding: 10px 12px;
-  border: 1px solid var(--border-color);
+  gap: 2px;
+  min-height: 44px;
+  padding: 7px 9px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
   border-radius: var(--radius-md);
-  background:
-    linear-gradient(135deg, var(--surface-overlay-soft), transparent),
-    var(--secondary-bg);
+  background: color-mix(in srgb, var(--primary-text) 1.2%, transparent);
   color: var(--secondary-text);
   text-align: left;
   cursor: pointer;
@@ -1771,34 +1884,32 @@ onUnmounted(() => {
 
 .theme-choice:hover {
   border-color: color-mix(in srgb, var(--highlight-text) 44%, var(--border-color));
-  background: var(--accent-bg);
+  background: color-mix(in srgb, var(--accent-bg) 72%, transparent);
   color: var(--primary-text);
 }
 
 .theme-choice--active {
   border-color: var(--highlight-text);
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--highlight-text) 18%, transparent), transparent),
-    var(--secondary-bg);
+  background: color-mix(in srgb, var(--highlight-text) 8%, transparent);
   color: var(--primary-text);
 }
 
 .theme-choice--compact {
-  min-height: 64px;
+  min-height: 42px;
 }
 
 .theme-choice--radius {
-  grid-template-columns: 42px minmax(0, 1fr);
+  grid-template-columns: 28px minmax(0, 1fr);
   align-items: center;
-  min-height: 58px;
-  padding: 8px 10px;
+  min-height: 42px;
+  padding: 7px 9px;
 }
 
 .radius-preview {
   position: relative;
   display: block;
-  width: 36px;
-  height: 36px;
+  width: 24px;
+  height: 24px;
   border: 1px solid color-mix(in srgb, var(--border-color) 88%, transparent);
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--surface-overlay-soft) 58%, transparent);
@@ -1806,10 +1917,10 @@ onUnmounted(() => {
 
 .radius-preview__corner {
   position: absolute;
-  top: 8px;
-  left: 8px;
-  width: 20px;
-  height: 20px;
+  top: 6px;
+  left: 6px;
+  width: 13px;
+  height: 13px;
   border-top: 2px solid color-mix(in srgb, var(--primary-text) 72%, transparent);
   border-left: 2px solid color-mix(in srgb, var(--primary-text) 72%, transparent);
 }
@@ -1831,7 +1942,7 @@ onUnmounted(() => {
 
 .theme-choice .material-symbols-outlined {
   color: var(--highlight-text);
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .theme-choice strong {
@@ -1842,7 +1953,7 @@ onUnmounted(() => {
 .theme-choice small {
   color: var(--secondary-text);
   font-size: var(--font-size-caption);
-  line-height: 1.35;
+  line-height: 1.25;
 }
 
 /* Section shared */
@@ -1895,6 +2006,8 @@ onUnmounted(() => {
   cursor: pointer;
   padding: 0;
   overflow: hidden;
+  border-color: color-mix(in srgb, var(--border-color) 74%, transparent);
+  background: color-mix(in srgb, var(--primary-text) 1.1%, transparent);
   transition:
     border-color var(--transition-fast),
     background-color var(--transition-fast);
@@ -1902,12 +2015,12 @@ onUnmounted(() => {
 
 .preset-card:hover {
   border-color: color-mix(in srgb, var(--highlight-text) 50%, var(--border-color));
-  background: var(--accent-bg);
+  background: color-mix(in srgb, var(--primary-text) 3.2%, transparent);
 }
 
 .preset-card--active {
   border-color: var(--highlight-text);
-  background: color-mix(in srgb, var(--highlight-text) 8%, var(--secondary-bg));
+  background: color-mix(in srgb, var(--highlight-text) 7%, transparent);
 }
 
 .preset-card__preview {
@@ -1920,7 +2033,7 @@ onUnmounted(() => {
 }
 
 .preset-card__preview--user {
-  background: var(--tertiary-bg);
+  background: color-mix(in srgb, var(--primary-text) 2.4%, transparent);
 }
 
 .preset-card__user-icon {
@@ -2008,7 +2121,7 @@ onUnmounted(() => {
   gap: var(--space-3);
   margin-bottom: 0;
   padding-bottom: var(--space-3);
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 74%, transparent);
 }
 
 .color-group__header-actions {
@@ -2036,7 +2149,7 @@ onUnmounted(() => {
 .color-group__count {
   font-size: var(--font-size-caption);
   color: var(--secondary-text);
-  background: var(--surface-overlay-soft);
+  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
   padding: 4px 10px;
   border-radius: var(--radius-full);
 }
@@ -2048,8 +2161,8 @@ onUnmounted(() => {
   min-height: 34px;
   padding: 0 12px;
   border-radius: 999px;
-  border: 1px solid var(--border-color);
-  background: var(--secondary-bg);
+  border: 1px solid color-mix(in srgb, var(--border-color) 74%, transparent);
+  background: color-mix(in srgb, var(--primary-text) 1.2%, transparent);
   color: var(--secondary-text);
   cursor: pointer;
   transition:
@@ -2060,8 +2173,8 @@ onUnmounted(() => {
 
 .group-collapse-toggle:hover {
   color: var(--primary-text);
-  background: color-mix(in srgb, var(--button-bg) 10%, transparent);
-  border-color: color-mix(in srgb, var(--button-bg) 28%, transparent);
+  background: color-mix(in srgb, var(--accent-bg) 72%, transparent);
+  border-color: color-mix(in srgb, var(--highlight-text) 34%, var(--border-color));
 }
 
 .group-collapse-toggle:focus-visible {
@@ -2119,17 +2232,17 @@ onUnmounted(() => {
   grid-template-columns: minmax(0, 1fr) minmax(280px, 0.7fr);
   gap: var(--space-4);
   align-items: center;
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-md);
   transition: background-color var(--transition-fast);
 }
 
 .color-row:hover {
-  background: var(--surface-overlay-soft);
+  background: color-mix(in srgb, var(--primary-text) 2.4%, transparent);
 }
 
 .color-row--changed {
-  background: var(--info-bg);
+  background: color-mix(in srgb, var(--highlight-text) 6%, transparent);
 }
 
 .color-row__copy {
@@ -2148,7 +2261,7 @@ onUnmounted(() => {
   font-size: var(--font-size-caption);
   color: var(--secondary-text);
   font-family: var(--font-mono);
-  background: var(--tertiary-bg);
+  background: color-mix(in srgb, var(--primary-text) 2.4%, transparent);
   padding: 1px 6px;
   border-radius: 3px;
   display: inline-block;
@@ -2167,10 +2280,10 @@ onUnmounted(() => {
   min-width: 44px;
   height: 40px;
   flex-shrink: 0;
-  border: 1px solid var(--border-color);
+  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
   border-radius: var(--radius-md);
   overflow: hidden;
-  background: var(--input-bg);
+  background: color-mix(in srgb, var(--primary-text) 1.4%, transparent);
   transition:
     border-color var(--transition-fast),
     box-shadow var(--transition-fast);
@@ -2339,7 +2452,7 @@ onUnmounted(() => {
 .theme-lab__bg-preview {
   border-radius: var(--radius-lg);
   overflow: hidden;
-  border: 1px solid var(--border-color);
+  border: 1px solid color-mix(in srgb, var(--border-color) 74%, transparent);
 }
 
 .theme-lab__bg-preview-img {
@@ -2363,10 +2476,11 @@ onUnmounted(() => {
 
 /* CSS editor */
 .theme-lab__css-editor-wrap {
-  border: 1px solid var(--border-color);
+  border: 1px solid color-mix(in srgb, var(--border-color) 74%, transparent);
   border-radius: var(--radius-lg);
   overflow: hidden;
   margin-bottom: var(--space-4);
+  background: color-mix(in srgb, var(--primary-text) 1.1%, transparent);
 }
 
 .theme-lab__css-bar {
@@ -2374,8 +2488,8 @@ onUnmounted(() => {
   justify-content: space-between;
   align-items: center;
   padding: var(--space-2) var(--space-3);
-  background: var(--surface-overlay-soft);
-  border-bottom: 1px solid var(--border-color);
+  background: transparent;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
 }
 
 .theme-lab__css-lang {
@@ -2403,6 +2517,7 @@ onUnmounted(() => {
   min-height: 300px;
   border: none;
   border-radius: 0;
+  background: transparent;
   font-family: var(--font-mono);
   font-size: var(--font-size-helper);
   line-height: 1.6;
@@ -2410,9 +2525,10 @@ onUnmounted(() => {
 }
 
 .theme-lab__css-tips {
-  border: 1px solid var(--border-color);
+  border: 1px solid color-mix(in srgb, var(--border-color) 74%, transparent);
   border-radius: var(--radius-lg);
   overflow: hidden;
+  background: color-mix(in srgb, var(--primary-text) 1.1%, transparent);
 }
 
 .theme-lab__css-tips summary {
@@ -2423,12 +2539,12 @@ onUnmounted(() => {
   cursor: pointer;
   font-size: var(--font-size-helper);
   color: var(--secondary-text);
-  background: var(--surface-overlay-soft);
+  background: transparent;
   transition: background-color var(--transition-fast);
 }
 
 .theme-lab__css-tips summary:hover {
-  background: var(--surface-overlay);
+  background: color-mix(in srgb, var(--primary-text) 2.4%, transparent);
 }
 
 .theme-lab__css-tips summary .material-symbols-outlined {
@@ -2480,14 +2596,14 @@ onUnmounted(() => {
 
 .theme-lab__css-tips-body code {
   font-family: var(--font-mono);
-  background: var(--tertiary-bg);
+  background: color-mix(in srgb, var(--primary-text) 2.6%, transparent);
   padding: 1px 6px;
   border-radius: 3px;
   font-size: var(--font-size-caption);
 }
 
 .theme-lab__css-tips-body pre {
-  background: var(--tertiary-bg);
+  background: color-mix(in srgb, var(--primary-text) 2.6%, transparent);
   padding: var(--space-3);
   border-radius: var(--radius-sm);
   overflow-x: auto;
@@ -2553,6 +2669,19 @@ onUnmounted(() => {
 
 /* Responsive */
 @media (max-width: 768px) {
+  .theme-lab__option-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .theme-lab__option-group,
+  .theme-lab__option-group--wide {
+    grid-template-columns: 1fr;
+  }
+
+  .theme-lab__option-group--wide .theme-lab__choice-row--compact {
+    grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+  }
+
   .theme-lab__preset-grid {
     grid-template-columns: 1fr;
   }

--- a/AdminPanel-Vue/src/views/ThinkingChainsEditor.vue
+++ b/AdminPanel-Vue/src/views/ThinkingChainsEditor.vue
@@ -1,31 +1,41 @@
 <template>
-  <section class="config-section active-section">
-    <p class="description">
-      管理 RAGDiaryPlugin 使用的元思考链。按住左侧手柄拖动时会实时预览插入位置，
-      释放后再提交最终顺序。
-    </p>
-
-    <div id="thinking-chains-editor-controls" class="form-actions">
-      <UiButton variant="primary" @click="saveThinkingChains">
-        保存所有更改
-      </UiButton>
-      <UiButton variant="outline" @click="addThinkingChain">
-        添加新主题
-      </UiButton>
-      <UiBadge v-if="statusMessage" :variant="statusBadgeVariant">
-        {{ statusMessage }}
-      </UiBadge>
-    </div>
+  <section class="config-section active-section thinking-chains-page">
+    <Teleport to="#page-header-actions">
+      <UiPageActions>
+        <p class="thinking-page-summary">
+          管理 RAGDiaryPlugin 使用的元思考链，拖动模块可实时预览排序。
+        </p>
+        <UiBadge v-if="statusMessage" :variant="statusBadgeVariant">
+          {{ statusMessage }}
+        </UiBadge>
+        <UiButton variant="outline" size="lg" @click="addThinkingChain">
+          <template #leading>
+            <span class="material-symbols-outlined">add</span>
+          </template>
+          添加主题
+        </UiButton>
+        <UiButton variant="primary" size="lg" @click="saveThinkingChains">
+          <template #leading>
+            <span class="material-symbols-outlined">save</span>
+          </template>
+          保存更改
+        </UiButton>
+      </UiPageActions>
+    </Teleport>
 
     <div id="thinking-chains-container" class="thinking-chains-layout">
-      <div class="thinking-chains-editor">
-        <h3>思考主题列表</h3>
+      <main class="thinking-chains-editor" aria-label="思考主题列表">
+        <header class="thinking-pane-header">
+          <div>
+            <h3>思考主题列表</h3>
+            <p>配置主题名称、思维模块顺序和每个模块的 K 值。</p>
+          </div>
+          <UiBadge variant="outline">{{ thinkingChains.length }} 个主题</UiBadge>
+        </header>
 
-        <UiCard
+        <article
           v-for="(chain, index) in thinkingChains"
           :key="chain.uiId"
-          size="sm"
-          variant="subtle"
           :class="[
             'thinking-chain-item',
             { 'thinking-chain-item--active': index === pickerChainIndex },
@@ -34,13 +44,16 @@
           <details open>
             <summary class="chain-header">
               <span class="theme-name">主题：{{ chain.theme || '未命名主题' }}</span>
-              <UiButton
-                variant="danger"
-                size="sm"
-                @click.stop.prevent="removeChain(index)"
-              >
-                删除
-              </UiButton>
+              <div class="chain-header-actions">
+                <UiBadge variant="outline">{{ getRenderedClusters(index).length }} 个模块</UiBadge>
+                <UiButton
+                  variant="danger"
+                  size="sm"
+                  @click.stop.prevent="removeChain(index)"
+                >
+                  删除
+                </UiButton>
+              </div>
             </summary>
 
             <div class="chain-content">
@@ -54,6 +67,7 @@
                   :id="`thinking-theme-${index}`"
                   v-model.trim="chain.theme"
                   type="text"
+                  size="sm"
                   placeholder="请输入主题名称"
                   @click.stop
                 />
@@ -110,6 +124,7 @@
                         type="number"
                         min="1"
                         max="20"
+                        size="sm"
                         class="cluster-k-input"
                         :value="getRenderedKValue(index, cluster)"
                         @input="handleKValueInput(index, cluster, $event)"
@@ -140,16 +155,17 @@
               </TransitionGroup>
             </div>
           </details>
-        </UiCard>
-      </div>
+        </article>
+      </main>
 
-      <UiCard
-        class="available-clusters-panel"
-        title="可用的思维簇模块"
-        description="将模块从这里拖拽到左侧的主题列表中。"
-        size="sm"
-        variant="subtle"
-      >
+      <aside class="available-clusters-panel" aria-label="可用的思维簇模块">
+        <header class="thinking-pane-header">
+          <div>
+            <h3>可用模块</h3>
+            <p>拖到左侧主题，或通过主题内的添加按钮批量选择。</p>
+          </div>
+          <UiBadge variant="outline">{{ availableClusters.length }} 个</UiBadge>
+        </header>
         <ul class="draggable-list available-clusters-list">
           <li
             v-for="cluster in availableClusters"
@@ -171,7 +187,7 @@
             未找到可用的思维簇模块
           </li>
         </ul>
-      </UiCard>
+      </aside>
     </div>
 
     <BaseModal
@@ -293,9 +309,9 @@ import BaseModal from "@/components/ui/BaseModal.vue";
 import DragHandle from "@/components/ui/DragHandle.vue";
 import UiBadge from "@/components/ui/UiBadge.vue";
 import UiButton from "@/components/ui/UiButton.vue";
-import UiCard from "@/components/ui/UiCard.vue";
 import UiField from "@/components/ui/UiField.vue";
 import UiInput from "@/components/ui/UiInput.vue";
+import UiPageActions from "@/components/ui/UiPageActions.vue";
 
 const {
   thinkingChains,
@@ -428,24 +444,59 @@ function handleKValueInput(chainIndex: number, clusterName: string, event: Event
 </script>
 
 <style scoped>
+.thinking-chains-page {
+  min-height: 0;
+}
+
+.thinking-page-summary {
+  margin: 0;
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+}
+
 .thinking-chains-layout {
   display: grid;
-  grid-template-columns: 1fr 300px;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
   gap: var(--space-4);
+  align-items: stretch;
+  min-height: 0;
 }
 
 .thinking-chains-editor {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  min-width: 0;
+  min-height: 0;
 }
 
-.thinking-chains-editor > h3 {
+.thinking-pane-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.thinking-pane-header h3 {
   margin: 0;
   color: var(--primary-text);
+  font-size: 1rem;
+  font-weight: 650;
+  line-height: 1.4;
+}
+
+.thinking-pane-header p {
+  margin: var(--space-1) 0 0;
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+  line-height: 1.5;
 }
 
 .thinking-chain-item {
+  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--primary-text) 1.4%, transparent);
+  overflow: hidden;
   transition: border-color 0.2s ease, background 0.2s ease;
 }
 
@@ -463,20 +514,33 @@ function handleKValueInput(chainIndex: number, clusterName: string, event: Event
   justify-content: space-between;
   align-items: center;
   gap: var(--space-3);
+  min-height: 44px;
+  padding: 0 var(--space-3);
   cursor: pointer;
   user-select: none;
+}
+
+.chain-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
 }
 
 .theme-name {
   font-weight: 600;
   font-size: var(--font-size-emphasis);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .chain-content {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  margin-top: var(--space-3);
+  padding: 0 var(--space-3) var(--space-3);
 }
 
 .theme-editor {
@@ -498,12 +562,13 @@ function handleKValueInput(chainIndex: number, clusterName: string, event: Event
 
 .draggable-list {
   list-style: none;
-  padding: var(--space-2);
+  padding: 0;
   margin: 0;
   min-height: 56px;
-  border: 1px dashed color-mix(in srgb, var(--border-color) 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 76%, transparent);
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
+  background: transparent;
+  overflow: hidden;
 }
 
 .draggable-list--active-target {
@@ -516,13 +581,14 @@ function handleKValueInput(chainIndex: number, clusterName: string, event: Event
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
-  margin-bottom: var(--space-2);
+  margin-bottom: 0;
   min-height: 40px;
   background: transparent;
-  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
-  border-radius: var(--radius-md);
+  border: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+  border-radius: 0;
   will-change: transform;
   transition:
     border-color 0.2s ease,
@@ -532,7 +598,7 @@ function handleKValueInput(chainIndex: number, clusterName: string, event: Event
 }
 
 .chain-item:last-child {
-  margin-bottom: 0;
+  border-bottom: 0;
 }
 
 .chain-item:hover {
@@ -576,6 +642,9 @@ function handleKValueInput(chainIndex: number, clusterName: string, event: Event
 .cluster-name {
   min-width: 0;
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .cluster-k-control {
@@ -584,9 +653,9 @@ function handleKValueInput(chainIndex: number, clusterName: string, event: Event
   gap: var(--space-2);
   padding: 0 var(--space-2);
   min-height: 28px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--input-bg) 62%, transparent);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   flex-shrink: 0;
 }
 
@@ -598,7 +667,7 @@ function handleKValueInput(chainIndex: number, clusterName: string, event: Event
 }
 
 .cluster-k-input {
-  width: 56px;
+  width: 58px;
   text-align: center;
 }
 
@@ -618,11 +687,19 @@ function handleKValueInput(chainIndex: number, clusterName: string, event: Event
 }
 
 .available-clusters-panel {
-  height: fit-content;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-width: 0;
+  min-height: 0;
 }
 
 .available-clusters-list .chain-item {
   cursor: grab;
+}
+
+.available-clusters-list {
+  overflow: auto;
 }
 
 .no-clusters {

--- a/AdminPanel-Vue/src/views/ToolListEditor.vue
+++ b/AdminPanel-Vue/src/views/ToolListEditor.vue
@@ -751,6 +751,7 @@ onBeforeRouteLeave(async () => {
   flex-shrink: 0;
   display: grid;
   gap: var(--space-1);
+  margin-bottom: var(--space-3);
 }
 
 .tool-list-editor-intro h2 {

--- a/AdminPanel-Vue/src/views/ToolListEditor/ToolConfigPreviewPanel.vue
+++ b/AdminPanel-Vue/src/views/ToolListEditor/ToolConfigPreviewPanel.vue
@@ -131,6 +131,7 @@
         <UiTextarea
           id="preview-output"
           readonly
+          class="preview-output"
           :model-value="previewContent"
           resize="none"
           placeholder="选择工具后将在此显示配置内容…"
@@ -225,6 +226,10 @@ const emit = defineEmits<{
   overflow: hidden;
 }
 
+.preview-section :deep(.ui-card__content) {
+  flex: 1;
+}
+
 .dirty-badge {
   flex-shrink: 0;
 }
@@ -299,15 +304,25 @@ const emit = defineEmits<{
   display: flex;
 }
 
-.preview-output-wrapper :deep(.ui-textarea) {
+.preview-output {
   flex: 1;
   width: 100%;
   height: 100%;
   min-height: 0;
   padding-right: 84px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   font-family: "Consolas", "Monaco", monospace;
   font-size: var(--font-size-helper);
   line-height: 1.55;
+}
+
+.preview-output:hover:not(:disabled),
+.preview-output:focus-visible {
+  border-color: transparent;
+  background: transparent;
+  outline: none;
 }
 
 .preview-copy-btn {

--- a/AdminPanel-Vue/src/views/ToolListEditor/ToolSelectionPanel.vue
+++ b/AdminPanel-Vue/src/views/ToolListEditor/ToolSelectionPanel.vue
@@ -1,18 +1,6 @@
 <template>
   <div class="left-panel">
     <UiCard class="tools-container" variant="default">
-      <div class="tools-header">
-        <div>
-          <h2 class="section-header tle-section-header">可用工具</h2>
-          <p class="tools-subtitle">
-            显示 {{ filteredTools.length }} / {{ allToolsCount }} 个工具
-          </p>
-        </div>
-        <UiBadge v-if="selectedTools.size > 0" variant="info">
-          已选 {{ selectedTools.size }}
-        </UiBadge>
-      </div>
-
       <div class="filter-section">
         <div class="search-row">
           <UiInput
@@ -36,6 +24,12 @@
           >
             清除
           </UiButton>
+          <UiBadge variant="outline" class="tool-count-badge">
+            {{ filteredTools.length }} / {{ allToolsCount }}
+          </UiBadge>
+          <UiBadge v-if="selectedTools.size > 0" variant="info" class="tool-count-badge">
+            已选 {{ selectedTools.size }}
+          </UiBadge>
         </div>
 
         <UiBadge
@@ -329,25 +323,10 @@ onBeforeUnmount(() => {
   gap: 0;
 }
 
-.tools-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-3);
-  padding: var(--space-3) var(--space-3) var(--space-2);
-  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
-}
-
-.tools-subtitle {
-  margin: 3px 0 0;
-  font-size: var(--font-size-helper);
-  color: var(--secondary-text);
-}
-
 .filter-section {
   display: grid;
   gap: var(--space-2);
-  padding: var(--space-3);
+  padding: var(--space-3) var(--space-3) var(--space-2);
   border-bottom: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
   background: color-mix(in srgb, var(--primary-text) 0.8%, transparent);
 }
@@ -367,6 +346,10 @@ onBeforeUnmount(() => {
 }
 
 .search-clear-btn {
+  flex-shrink: 0;
+}
+
+.tool-count-badge {
   flex-shrink: 0;
 }
 

--- a/AdminPanel-Vue/src/views/ToolboxManager.vue
+++ b/AdminPanel-Vue/src/views/ToolboxManager.vue
@@ -1,82 +1,58 @@
 <template>
   <section class="config-section active-section toolbox-manager-page">
-    <p class="description">
-      维护 toolbox_map.json（alias→file+description），并编辑 TVStxt 下映射文件内容。
-    </p>
+    <Teleport to="#page-header-actions">
+      <UiPageActions>
+        <p class="toolbox-page-summary">
+          维护 toolbox_map.json，并编辑 TVStxt 下映射文件内容。
+        </p>
+        <UiBadge
+          :variant="mapDirty ? 'warning' : 'success'"
+          :title="mapDirty ? '映射未保存' : '映射已同步'"
+          :aria-label="mapDirty ? '映射未保存' : '映射已同步'"
+        >
+          {{ mapDirty ? '映射未保存' : '映射已同步' }}
+        </UiBadge>
+        <UiButton
+          @click="refreshAll"
+          variant="outline"
+          size="lg"
+          title="刷新 Toolbox 数据"
+        >
+          <template #leading>
+            <span class="material-symbols-outlined">refresh</span>
+          </template>
+          刷新
+        </UiButton>
+        <UiButton
+          @click="openCreateDialog"
+          variant="outline"
+          size="lg"
+          title="新建 Toolbox 映射"
+        >
+          <template #leading>
+            <span class="material-symbols-outlined">add</span>
+          </template>
+          新建
+        </UiButton>
+        <UiButton
+          @click="saveToolboxMap"
+          :disabled="mapSaving || !mapDirty"
+          variant="primary"
+          size="lg"
+          title="保存映射表"
+        >
+          <template #leading>
+            <span class="material-symbols-outlined" :class="{ spinning: mapSaving }">
+              {{ mapSaving ? 'sync' : 'save' }}
+            </span>
+          </template>
+          {{ mapSaving ? '保存中…' : mapDirty ? '保存映射' : '已保存' }}
+        </UiButton>
+      </UiPageActions>
+    </Teleport>
 
-    <DualPaneEditor
-      left-title="Toolbox 映射表"
-      right-title="Toolbox 文件内容"
-      :initial-left-width="450"
-      :min-left-width="350"
-      :max-left-width="600"
-      collapsible
-      persist-key="toolboxManager"
-    >
-      <template #left-actions>
-        <div class="pane-toolbar pane-toolbar--left">
-          <div class="pane-toolbar-main">
-            <UiButton @click="openCreateDialog" variant="primary" size="sm" title="新建 Toolbox 映射">
-              <template #leading>
-                <span class="material-symbols-outlined">add</span>
-              </template>
-              新建
-            </UiButton>
-            <UiButton
-              @click="saveToolboxMap"
-              :disabled="mapSaving || !mapDirty"
-              variant="primary"
-              size="sm"
-              title="保存映射表"
-            >
-              <template #leading>
-                <span class="material-symbols-outlined">save</span>
-              </template>
-              {{ mapSaving ? '保存中…' : mapDirty ? '保存' : '已保存' }}
-            </UiButton>
-            <details class="pane-toolbar-menu">
-              <summary class="pane-toolbar-menu-trigger" aria-label="更多操作" title="更多操作">
-                <span class="material-symbols-outlined">more_vert</span>
-              </summary>
-              <div class="pane-toolbar-menu-content" role="menu" aria-label="Toolbox 映射更多操作">
-                <button type="button" @click="refreshAll" class="pane-toolbar-menu-item">
-                  <span class="material-symbols-outlined">refresh</span>
-                  刷新数据
-                </button>
-              </div>
-            </details>
-          </div>
-          <UiBadge
-            :variant="mapDirty ? 'warning' : 'success'"
-            :title="mapDirty ? '映射未保存' : '映射已同步'"
-            :aria-label="mapDirty ? '映射未保存' : '映射已同步'"
-          >
-            {{ mapDirty ? '映射未保存' : '映射已同步' }}
-          </UiBadge>
-        </div>
-      </template>
-
-      <template #left-collapsed>
-        <div class="collapsed-list">
-          <button
-            v-for="entry in toolboxMap"
-            :key="entry.localId"
-            type="button"
-            class="collapsed-item"
-            :class="{ active: editingFile === entry.file }"
-            :title="entry.alias"
-            @click="selectToolboxFile(entry.file)"
-          >
-            <span class="material-symbols-outlined">inventory_2</span>
-            <span class="collapsed-label">{{ entry.alias }}</span>
-          </button>
-          <div v-if="toolboxMap.length === 0" class="collapsed-empty">
-            <span class="material-symbols-outlined">inventory_2</span>
-          </div>
-        </div>
-      </template>
-
-      <template #left-content>
+    <div class="toolbox-manager-shell">
+      <aside class="toolbox-map-pane" aria-label="Toolbox 映射表">
         <div class="toolbox-search">
           <span class="material-symbols-outlined search-icon">search</span>
           <UiInput
@@ -91,9 +67,48 @@
         </div>
 
         <div class="toolbox-map-list">
-          <div v-for="entry in filteredToolboxMap" :key="entry.localId" class="toolbox-map-entry card">
-            <div class="toolbox-entry-row">
-              <label>别名 (Alias):</label>
+          <article
+            v-for="entry in filteredToolboxMap"
+            :key="entry.localId"
+            class="toolbox-map-entry"
+            :class="{ 'is-active': editingFile === entry.file }"
+          >
+            <div class="toolbox-entry-header">
+              <div class="toolbox-entry-identity">
+                <span class="material-symbols-outlined">inventory_2</span>
+                <div class="toolbox-entry-title-group">
+                  <span class="toolbox-entry-title">{{ entry.alias || '未命名 Toolbox' }}</span>
+                  <span class="toolbox-entry-file">{{ entry.file || '未绑定文件' }}</span>
+                </div>
+              </div>
+              <UiBadge
+                :variant="isValidAlias(entry.alias.trim()) && isValidToolboxFileName(entry.file.trim()) ? 'success' : 'warning'"
+              >
+                {{ isValidAlias(entry.alias.trim()) && isValidToolboxFileName(entry.file.trim()) ? '可用' : '待完善' }}
+              </UiBadge>
+              <div class="toolbox-entry-actions">
+                <UiIconButton
+                  @click="selectToolboxEntry(entry)"
+                  label="编辑 Toolbox 文件"
+                  title="编辑"
+                  :disabled="!entry.file.trim() || !isValidToolboxFileName(entry.file.trim())"
+                >
+                  <span class="material-symbols-outlined">edit</span>
+                </UiIconButton>
+                <UiIconButton
+                  @click="removeToolboxEntry(entry.localId)"
+                  variant="danger"
+                  label="删除 Toolbox 映射"
+                  title="删除"
+                >
+                  <span class="material-symbols-outlined">delete</span>
+                </UiIconButton>
+              </div>
+            </div>
+
+            <div class="toolbox-entry-fields">
+              <div class="toolbox-entry-row">
+                <label>别名</label>
               <div class="input-validated">
                 <UiInput
                   type="text"
@@ -107,49 +122,60 @@
               </div>
             </div>
             <div class="toolbox-entry-row">
-              <label>文件名:</label>
+              <label>文件</label>
               <div class="input-validated">
-                <UiInput
-                  type="text"
-                  v-model="entry.file"
-                  placeholder="例如：MyTool.txt"
-                  list="tvs-files-datalist"
+                <UiSelect
+                  :model-value="entry.file.trim()"
+                  class="toolbox-file-picker"
                   :invalid="Boolean(entry.file.trim()) && !isValidToolboxFileName(entry.file.trim())"
-                />
+                  :disabled="tvsFiles.length === 0"
+                  aria-label="选择已有 Toolbox 文件"
+                  @change="handleToolboxFilePickerChange(entry, $event)"
+                >
+                  <option value="">选择已有文件…</option>
+                  <optgroup
+                    v-if="getToolboxFilePickerGroups(entry).matched.length > 0"
+                    label="名称匹配（置顶）"
+                  >
+                    <option
+                      v-for="file in getToolboxFilePickerGroups(entry).matched"
+                      :key="`matched-${entry.localId}-${file}`"
+                      :value="file"
+                    >
+                      {{ file }}
+                    </option>
+                  </optgroup>
+                  <optgroup
+                    v-if="getToolboxFilePickerGroups(entry).others.length > 0"
+                    label="──────── 其他文件 ────────"
+                  >
+                    <option
+                      v-for="file in getToolboxFilePickerGroups(entry).others"
+                      :key="`other-${entry.localId}-${file}`"
+                      :value="file"
+                    >
+                      {{ file }}
+                    </option>
+                  </optgroup>
+                </UiSelect>
                 <span v-if="entry.file.trim() && !isValidToolboxFileName(entry.file.trim())" class="validation-hint">
                   文件名须以 .txt 或 .md 结尾，不可含非法字符
                 </span>
               </div>
             </div>
-            <div class="toolbox-entry-row">
-              <label>描述:</label>
-              <UiInput
-                type="text"
+            <div class="toolbox-entry-row toolbox-entry-row--description">
+              <label>描述</label>
+              <UiTextarea
                 v-model="entry.description"
                 placeholder="工具描述…"
                 maxlength="200"
+                rows="3"
+                size="sm"
+                resize="none"
               />
             </div>
-            <div class="toolbox-entry-actions">
-              <UiButton
-                @click="selectToolboxFile(entry.file)"
-                variant="outline"
-                size="sm"
-                :disabled="!entry.file.trim() || !isValidToolboxFileName(entry.file.trim())"
-              >
-                <template #leading>
-                  <span class="material-symbols-outlined">edit</span>
-                </template>
-                编辑
-              </UiButton>
-              <UiButton @click="removeToolboxEntry(entry.localId)" variant="danger" size="sm">
-                <template #leading>
-                  <span class="material-symbols-outlined">delete</span>
-                </template>
-                删除
-              </UiButton>
             </div>
-          </div>
+          </article>
 
           <div v-if="filteredToolboxMap.length === 0 && toolboxMap.length > 0" class="empty-state">
             <span class="material-symbols-outlined">search_off</span>
@@ -162,11 +188,18 @@
             <UiButton @click="openCreateDialog" variant="primary">新建第一个 Toolbox</UiButton>
           </div>
         </div>
-      </template>
+      </aside>
 
-      <template #right-actions>
-        <div v-if="editingFile" class="pane-toolbar pane-toolbar--right">
-          <div class="pane-toolbar-main">
+      <main class="toolbox-file-pane" aria-label="Toolbox 文件内容">
+        <header class="toolbox-file-pane-header">
+          <div class="toolbox-file-title">
+            <span class="toolbox-pane-label">Toolbox 文件内容</span>
+            <span class="toolbox-file-name">
+              <span class="material-symbols-outlined">description</span>
+              {{ editingFile || '未选择文件' }}
+            </span>
+          </div>
+          <div v-if="editingFile" class="toolbox-file-actions">
             <div class="editor-mode-toggle">
               <UiButton :class="['mode-btn', { active: editorMode === 'visual' }]" variant="ghost" size="sm" @click="switchEditorMode('visual')" title="可视化 Fold 块编辑">
                 <span class="material-symbols-outlined">view_agenda</span> 可视化
@@ -184,33 +217,36 @@
               <template #leading>
                 <span class="material-symbols-outlined">save</span>
               </template>
-              {{ fileSaving ? '保存中…' : fileDirty ? '保存文件' : '已保存' }}
+              {{ fileSaving ? '保存中…' : '保存文件' }}
             </UiButton>
-            <details class="pane-toolbar-menu">
-              <summary class="pane-toolbar-menu-trigger" aria-label="文件更多操作" title="文件更多操作">
-                <span class="material-symbols-outlined">more_vert</span>
-              </summary>
-              <div class="pane-toolbar-menu-content pane-toolbar-menu-content--right" role="menu" aria-label="文件更多操作">
-                <button type="button" @click="deleteCurrentFile" class="pane-toolbar-menu-item pane-toolbar-menu-item--danger">
-                  <span class="material-symbols-outlined">delete_forever</span>
-                  删除文件
-                </button>
-              </div>
-            </details>
+            <UiButton
+              @click="deleteCurrentFile"
+              variant="danger"
+              size="sm"
+              title="删除当前 Toolbox 文件"
+            >
+              <template #leading>
+                <span class="material-symbols-outlined">delete_forever</span>
+              </template>
+              删除文件
+            </UiButton>
+            <UiButton
+              v-if="editorMode === 'visual'"
+              @click="addFoldBlockAtEnd"
+              variant="outline"
+              size="sm"
+              title="新增 Block"
+            >
+              <template #leading>
+                <span class="material-symbols-outlined">add</span>
+              </template>
+              新增 Block
+            </UiButton>
           </div>
-        </div>
-      </template>
+        </header>
 
-      <template #right-content>
-        <div class="toolbox-file-editor">
-          <div class="toolbox-editor-controls">
-            <span class="editing-file-display">
-              <span class="material-symbols-outlined">description</span>
-              {{ editingFile || '未选择文件' }}
-              <span v-if="fileDirty" class="dirty-indicator">（未保存）</span>
-            </span>
-          </div>
-
+        <div class="toolbox-file-workspace">
+          <div class="toolbox-file-editor">
           <!-- Visual mode (default) -->
           <template v-if="editorMode === 'visual' && editingFile">
             <div class="threshold-simulator">
@@ -223,6 +259,7 @@
                 v-model.number="simulatedThreshold"
                 min="0" max="1" step="0.05"
                 class="threshold-slider"
+                :style="rangeProgressStyle(simulatedThreshold)"
               >
               <span class="threshold-hint">
                 {{ visibleBlockCount }}/{{ foldBlocks.length }} 块可见
@@ -231,14 +268,24 @@
 
             <div class="fold-blocks-visual">
               <template v-for="(block, i) in foldBlocks" :key="i">
-                <div class="fold-block-card card" :class="{ 'block-hidden': block.threshold > simulatedThreshold }">
-                  <div class="fold-block-header">
-                    <span class="block-index">Block {{ i + 1 }}</span>
-                    <UiBadge class="block-threshold-badge" :variant="thresholdVariant(block.threshold)">
-                      {{ block.threshold.toFixed(2) }}
-                    </UiBadge>
-                    <UiBadge v-if="block.threshold > simulatedThreshold" variant="danger" class="block-folded-badge">折叠中</UiBadge>
-                    <span class="flex-spacer"></span>
+                <article class="fold-block-card" :class="{ 'block-hidden': block.threshold > simulatedThreshold }">
+                  <div class="fold-block-topline">
+                    <div class="fold-block-header">
+                      <span class="block-index">Block {{ i + 1 }}</span>
+                      <UiBadge class="block-threshold-badge" :variant="thresholdVariant(block.threshold)">
+                        {{ block.threshold.toFixed(2) }}
+                      </UiBadge>
+                      <UiBadge v-if="block.threshold > simulatedThreshold" variant="danger" class="block-folded-badge">折叠中</UiBadge>
+                    </div>
+                    <div class="fold-block-field">
+                      <label>阈值:</label>
+                      <input type="range" v-model.number="block.threshold" min="0" max="1" step="0.05" class="block-threshold-slider" :style="rangeProgressStyle(block.threshold)">
+                      <UiInput type="number" v-model.number="block.threshold" min="0" max="1" step="0.05" class="block-threshold-input" size="sm" />
+                    </div>
+                    <div class="fold-block-field">
+                      <label>语义:</label>
+                      <UiInput type="text" v-model="block.description" placeholder="用于按块独立语义匹配（为空则按工具箱整体描述匹配）" class="block-desc-input" />
+                    </div>
                     <UiIconButton
                       @click="removeFoldBlock(i)"
                       label="删除此块"
@@ -249,17 +296,6 @@
                       <span class="material-symbols-outlined">close</span>
                     </UiIconButton>
                   </div>
-                  <div class="fold-block-meta">
-                    <div class="fold-block-field">
-                      <label>阈值:</label>
-                      <input type="range" v-model.number="block.threshold" min="0" max="1" step="0.05" class="block-threshold-slider">
-                      <UiInput type="number" v-model.number="block.threshold" min="0" max="1" step="0.05" class="block-threshold-input" size="sm" />
-                    </div>
-                    <div class="fold-block-field">
-                      <label>语义描述:</label>
-                      <UiInput type="text" v-model="block.description" placeholder="用于按块独立语义匹配（为空则按工具箱整体描述匹配）" class="block-desc-input" />
-                    </div>
-                  </div>
                   <UiTextarea
                     v-model="block.content"
                     class="fold-block-content"
@@ -267,20 +303,13 @@
                     spellcheck="false"
                     placeholder="输入此块的内容…"
                   />
-                </div>
+                </article>
                 <div class="block-divider">
                   <UiIconButton @click="addFoldBlockAfter(i)" class="add-block-button" label="在此处插入新块" title="在此处插入新块">
                     <span class="material-symbols-outlined">add_circle</span>
                   </UiIconButton>
                 </div>
               </template>
-
-              <UiButton @click="addFoldBlockAtEnd" variant="outline" size="sm" class="add-block-final">
-                <template #leading>
-                  <span class="material-symbols-outlined">add</span>
-                </template>
-                新增 Block
-              </UiButton>
             </div>
           </template>
 
@@ -302,8 +331,9 @@
           </div>
 
         </div>
-      </template>
-    </DualPaneEditor>
+        </div>
+      </main>
+    </div>
 
     <!-- File autocomplete datalist -->
     <datalist id="tvs-files-datalist">
@@ -387,12 +417,13 @@ import { onBeforeRouteLeave } from 'vue-router'
 import { toolboxApi } from '@/api'
 import { askConfirm } from '@/platform/feedback/feedbackBus'
 import { showMessage } from '@/utils'
-import DualPaneEditor from '@/components/DualPaneEditor.vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import UiBadge from '@/components/ui/UiBadge.vue'
 import UiButton from '@/components/ui/UiButton.vue'
 import UiIconButton from '@/components/ui/UiIconButton.vue'
 import UiInput from '@/components/ui/UiInput.vue'
+import UiPageActions from '@/components/ui/UiPageActions.vue'
+import UiSelect from '@/components/ui/UiSelect.vue'
 import UiTextarea from '@/components/ui/UiTextarea.vue'
 
 /* ── Types ── */
@@ -520,6 +551,34 @@ function isValidToolboxFileName(name: string): boolean {
   return lower.endsWith('.txt') || lower.endsWith('.md')
 }
 
+function getToolboxFilePickerGroups(entry: ToolboxEntry): {
+  matched: string[]
+  others: string[]
+} {
+  const normalizedAlias = entry.alias.trim().toLowerCase()
+  const matched: string[] = []
+  const others: string[] = []
+
+  tvsFiles.value.forEach((file) => {
+    const comparableFile = file.toLowerCase()
+    if (normalizedAlias && comparableFile.includes(normalizedAlias)) {
+      matched.push(file)
+      return
+    }
+
+    others.push(file)
+  })
+
+  return { matched, others }
+}
+
+function handleToolboxFilePickerChange(entry: ToolboxEntry, event: Event): void {
+  const selectedFile = (event.target as HTMLSelectElement).value
+  if (!selectedFile) return
+
+  entry.file = selectedFile
+}
+
 /* ── Fold Block Parsing & Serialization ── */
 function parseFoldBlocks(content: string): FoldBlock[] {
   const blocks: FoldBlock[] = []
@@ -565,6 +624,11 @@ function thresholdVariant(t: number): 'success' | 'warning' | 'danger' {
   if (t <= 0.3) return 'success'
   if (t <= 0.6) return 'warning'
   return 'danger'
+}
+
+function rangeProgressStyle(value: number) {
+  const progress = Math.max(0, Math.min(100, value * 100))
+  return { '--range-progress': `${progress}%` }
 }
 
 /* ── Data Loading ── */
@@ -644,7 +708,8 @@ async function openFileInEditor(fileName: string, isNewlyCreated = false) {
   originalFoldSerialized.value = serializeFoldBlocks(foldBlocks.value)
 }
 
-async function selectToolboxFile(fileName: string) {
+async function selectToolboxEntry(entry: ToolboxEntry) {
+  const fileName = entry.file.trim()
   if (!fileName) return
   if (fileDirty.value && !(await askConfirm('当前文件有未保存的修改，确定放弃并切换吗？'))) return
   await openFileInEditor(fileName)
@@ -730,7 +795,17 @@ async function removeToolboxEntry(localId: string) {
     confirmText: '删除',
   }))) return
   const idx = toolboxMap.value.findIndex(e => e.localId === localId)
-  if (idx !== -1) toolboxMap.value.splice(idx, 1)
+  if (idx !== -1) {
+    const [removed] = toolboxMap.value.splice(idx, 1)
+    if (editingFile.value === removed?.file) {
+      editingFile.value = ''
+      fileContent.value = ''
+      originalFileContent.value = ''
+      originalFoldSerialized.value = ''
+      foldBlocks.value = []
+      if (removed?.file) fileContentCache.delete(removed.file)
+    }
+  }
   showMessage('已删除映射条目，请点击"保存"以生效', 'info')
 }
 
@@ -886,95 +961,114 @@ onBeforeRouteLeave(async () => {
 </script>
 
 <style scoped>
-.collapsed-list {
+.toolbox-manager-page {
+  --toolbox-workspace-height: calc(var(--app-viewport-height, 100vh) - 150px);
+  --toolbox-workspace-min-height: 520px;
+}
+
+.toolbox-page-summary {
+  max-width: 390px;
+  margin: 0 var(--space-2) 0 0;
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+  line-height: 1.35;
+}
+
+.toolbox-manager-shell {
+  display: grid;
+  grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
+  gap: var(--space-4);
+  min-height: var(--toolbox-workspace-min-height);
+  height: max(var(--toolbox-workspace-height), var(--toolbox-workspace-min-height));
+}
+
+.toolbox-map-pane,
+.toolbox-file-pane {
+  min-width: 0;
+  min-height: 0;
+}
+
+.toolbox-map-pane {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-  align-items: center;
+  padding: 0;
+  overflow: hidden;
 }
 
-.collapsed-item {
+.toolbox-file-pane {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border-color) 88%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--primary-text) 0.8%, transparent);
+}
+
+.toolbox-file-pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  min-height: 58px;
+  padding: var(--space-3) var(--space-4);
+}
+
+.toolbox-file-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.toolbox-pane-label {
+  flex: 0 0 auto;
+  color: color-mix(in srgb, var(--secondary-text) 72%, transparent);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.toolbox-file-name {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--secondary-text);
-  cursor: pointer;
-  padding: 0;
-  transition:
-    background-color var(--transition-fast),
-    border-color var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.collapsed-item:hover {
-  background: var(--accent-bg);
-  color: var(--primary-text);
-}
-
-.collapsed-item.active {
-  color: var(--primary-text);
-  border-color: color-mix(in srgb, var(--highlight-text) 52%, var(--border-color));
-  background: color-mix(in srgb, var(--highlight-text) 10%, transparent);
-}
-
-.collapsed-label {
-  display: none;
-}
-
-.collapsed-empty {
-  color: var(--secondary-text);
-}
-
-.toolbox-manager-page {
-  --dual-pane-min-height: 420px;
-}
-
-/* Allow both panes to expand naturally with content */
-.toolbox-manager-page :deep(.dual-pane-editor) {
-  height: auto;
-  min-height: var(--dual-pane-min-height);
-}
-
-.toolbox-manager-page :deep(.pane) {
-  overflow: visible;
-}
-
-/* 右侧 pane header 保持单行：标题 + 可视化/原始切换 + 保存 + more_vert */
-.toolbox-manager-page :deep(.pane-right .pane-header) {
-  flex-wrap: nowrap;
-  align-items: center;
-  gap: var(--space-3);
-}
-
-.toolbox-manager-page :deep(.pane-right .pane-header h3) {
-  flex: 0 1 auto;
+  gap: 6px;
   min-width: 0;
-  white-space: nowrap;
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
+  line-height: 1.25;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.toolbox-manager-page :deep(.pane-right .pane-toolbar),
-.toolbox-manager-page :deep(.pane-right .pane-toolbar-main) {
-  flex-wrap: nowrap;
-  width: auto;
+.toolbox-file-name .material-symbols-outlined {
   flex: 0 0 auto;
+  font-size: 16px !important;
 }
 
-.toolbox-manager-page :deep(.pane-content) {
-  overflow-y: visible;
-  flex: none;
+.toolbox-file-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.toolbox-file-workspace {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+  padding: 0 var(--space-3) var(--space-3);
 }
 
 /* ── Search ── */
 .toolbox-search {
   position: relative;
   margin-bottom: var(--space-3);
+  width: 100%;
 }
 
 .search-icon {
@@ -1007,25 +1101,144 @@ onBeforeRouteLeave(async () => {
 .toolbox-map-list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: var(--space-2);
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 var(--space-1) var(--space-2) 0;
+  scrollbar-gutter: stable;
 }
 
 .toolbox-map-entry {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
   padding: var(--space-3);
-  border-color: color-mix(in srgb, var(--border-color) 84%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--button-bg) 5%, transparent),
+      color-mix(in srgb, var(--primary-text) 0.8%, transparent)
+    );
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast);
+  overflow: visible;
+}
+
+.toolbox-map-entry:hover {
+  border-color: color-mix(in srgb, var(--button-bg) 24%, var(--border-color));
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--button-bg) 8%, transparent),
+      color-mix(in srgb, var(--primary-text) 1.8%, transparent)
+    );
+}
+
+.toolbox-map-entry.is-active {
+  border-color: color-mix(in srgb, var(--button-bg) 42%, var(--border-color));
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--button-bg) 12%, transparent),
+      color-mix(in srgb, var(--primary-text) 2.2%, transparent)
+    );
+}
+
+.toolbox-map-entry.is-active::before {
+  content: "";
+  position: absolute;
+  inset: 8px auto 8px 2px;
+  width: 2px;
+  border-radius: var(--radius-full);
+  background: var(--button-bg);
+}
+
+.toolbox-entry-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.toolbox-entry-identity {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.toolbox-entry-identity > .material-symbols-outlined {
+  flex: 0 0 auto;
+  color: var(--secondary-text);
+  font-size: 18px !important;
+}
+
+.toolbox-entry-title-group {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.toolbox-entry-title,
+.toolbox-entry-file {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.toolbox-entry-title {
+  color: var(--primary-text);
+  font-size: var(--font-size-body);
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.toolbox-entry-file {
+  color: var(--secondary-text);
+  font-size: var(--font-size-caption);
+  line-height: 1.3;
+}
+
+.toolbox-entry-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px var(--space-2);
 }
 
 .toolbox-entry-row {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-  margin-bottom: var(--space-3);
+  gap: 5px;
+  min-width: 0;
+  margin-bottom: 0;
+}
+
+.toolbox-entry-row--description {
+  grid-column: 1 / -1;
+}
+
+.toolbox-entry-row--description :deep(.ui-textarea) {
+  min-height: 66px;
+  max-height: none;
+  padding-block: 6px;
+  overflow: hidden;
+}
+
+.toolbox-file-picker {
+  width: 100%;
 }
 
 .toolbox-entry-row label {
-  font-size: var(--font-size-helper);
   color: var(--secondary-text);
-  font-weight: 500;
+  font-size: var(--font-size-caption);
+  font-weight: 600;
+  line-height: 1.25;
 }
 
 .input-validated {
@@ -1042,8 +1255,19 @@ onBeforeRouteLeave(async () => {
 
 .toolbox-entry-actions {
   display: flex;
-  gap: var(--space-2);
-  margin-top: var(--space-2);
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-1);
+  margin-left: auto;
+}
+
+.toolbox-entry-actions :deep(.ui-icon-button) {
+  width: 28px;
+  height: 28px;
+}
+
+.toolbox-entry-actions :deep(.ui-icon-button .material-symbols-outlined) {
+  font-size: 16px !important;
 }
 
 /* ── Mode Toggle ── */
@@ -1074,35 +1298,10 @@ onBeforeRouteLeave(async () => {
 .toolbox-file-editor {
   display: flex;
   flex-direction: column;
-}
-
-.toolbox-editor-controls {
-  display: flex;
-  gap: var(--space-2);
-  align-items: center;
-  margin-bottom: var(--space-3);
-  padding: var(--space-2) var(--space-3);
-  background: color-mix(in srgb, var(--primary-text) 3%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
-  border-radius: var(--radius-md);
-}
-
-.editing-file-display {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-size: var(--font-size-body);
-  color: var(--secondary-text);
-  font-weight: 500;
-}
-
-.editing-file-display .material-symbols-outlined {
-  font-size: 18px !important;
-}
-
-.dirty-indicator {
-  color: var(--highlight-text);
-  font-size: var(--font-size-helper);
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .editor-placeholder {
@@ -1128,18 +1327,34 @@ onBeforeRouteLeave(async () => {
 
 /* ── Raw Editor ── */
 .file-content-editor {
+  flex: 1;
   width: 100%;
-  min-height: 400px;
+  min-height: 300px;
   font-family: 'Consolas', 'Monaco', monospace;
   font-size: var(--font-size-body);
   line-height: 1.6;
 }
 
+.file-content-editor :deep(.ui-textarea),
 .file-content-editor.ui-textarea {
-  min-height: 400px;
+  height: 100%;
+  max-height: none;
+  min-height: 300px;
+  border-color: transparent;
+  background: transparent;
+  border-radius: 0;
+  resize: none;
   font-family: 'Consolas', 'Monaco', monospace;
   font-size: var(--font-size-body);
   line-height: 1.6;
+}
+
+.file-content-editor :deep(.ui-textarea:hover:not(:disabled)),
+.file-content-editor.ui-textarea:hover:not(:disabled),
+.file-content-editor :deep(.ui-textarea:focus-visible),
+.file-content-editor.ui-textarea:focus-visible {
+  border-color: transparent;
+  background: transparent;
 }
 
 /* ── Visual Editor ── */
@@ -1148,9 +1363,10 @@ onBeforeRouteLeave(async () => {
   flex-wrap: wrap;
   align-items: center;
   gap: var(--space-2) var(--space-3);
+  flex: 0 0 auto;
   padding: var(--space-2) var(--space-3);
-  background: color-mix(in srgb, var(--primary-text) 3%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
+  background: color-mix(in srgb, var(--button-bg) 4%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
   border-radius: var(--radius-md);
   margin-bottom: var(--space-3);
 }
@@ -1171,7 +1387,6 @@ onBeforeRouteLeave(async () => {
 .threshold-slider {
   flex: 1;
   min-width: 100px;
-  accent-color: var(--highlight-text);
 }
 
 .threshold-hint {
@@ -1183,69 +1398,183 @@ onBeforeRouteLeave(async () => {
 .fold-blocks-visual {
   display: flex;
   flex-direction: column;
+  gap: var(--space-1);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: var(--space-1);
+  scrollbar-gutter: stable;
 }
 
 .fold-block-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
   padding: var(--space-3);
-  border-color: color-mix(in srgb, var(--border-color) 84%, transparent);
-  transition: opacity var(--transition-fast);
+  border: 1px solid color-mix(in srgb, var(--border-color) 84%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary-text) 1.4%, transparent);
+  transition:
+    opacity var(--transition-fast),
+    border-color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.fold-block-card:hover {
+  border-color: color-mix(in srgb, var(--highlight-text) 22%, var(--border-color));
+  background: color-mix(in srgb, var(--primary-text) 2.2%, transparent);
 }
 
 .fold-block-card.block-hidden {
-  opacity: 0.4;
+  opacity: 0.52;
+}
+
+.fold-block-topline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  flex-wrap: nowrap;
 }
 
 .fold-block-header {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  margin-bottom: var(--space-3);
+  min-width: max-content;
 }
 
 .block-index {
-  font-weight: 600;
-  font-size: var(--font-size-body);
   color: var(--primary-text);
-}
-
-.flex-spacer {
-  flex: 1;
-}
-
-.fold-block-meta {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  margin-bottom: var(--space-3);
+  font-size: var(--font-size-body);
+  font-weight: 650;
+  line-height: 1.25;
 }
 
 .fold-block-field {
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  min-width: 0;
+}
+
+.fold-block-field:first-of-type {
+  flex: 0 1 250px;
+}
+
+.fold-block-field:nth-of-type(2) {
+  flex: 1 1 280px;
 }
 
 .fold-block-field label {
   font-size: var(--font-size-helper);
   color: var(--secondary-text);
-  min-width: 56px;
+  min-width: 36px;
   flex-shrink: 0;
 }
 
 .block-threshold-slider {
   flex: 1;
-  max-width: 180px;
-  accent-color: var(--highlight-text);
+  max-width: 112px;
+}
+
+.threshold-slider,
+.block-threshold-slider {
+  --range-progress: 100%;
+  --range-track: color-mix(in srgb, var(--primary-text) 9%, transparent);
+  --range-fill: var(--button-bg);
+  --range-thumb-border: color-mix(in srgb, var(--button-bg) 52%, var(--border-color));
+  appearance: none;
+  height: 18px;
+  margin: 0;
+  border: 0;
+  border-radius: var(--radius-full);
+  background:
+    linear-gradient(
+      to right,
+      var(--range-fill) 0 var(--range-progress),
+      var(--range-track) var(--range-progress) 100%
+    )
+    center / 100% 4px no-repeat;
+  cursor: pointer;
+}
+
+.threshold-slider:focus-visible,
+.block-threshold-slider:focus-visible {
+  outline: 2px solid var(--highlight-text);
+  outline-offset: 2px;
+}
+
+.threshold-slider::-webkit-slider-thumb,
+.block-threshold-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 13px;
+  height: 13px;
+  border: 1px solid var(--range-thumb-border);
+  border-radius: var(--radius-full);
+  background: var(--primary-bg);
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--primary-text) 18%, transparent);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.threshold-slider:hover::-webkit-slider-thumb,
+.block-threshold-slider:hover::-webkit-slider-thumb {
+  border-color: var(--button-bg);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--button-bg) 12%, transparent);
+}
+
+.threshold-slider:active::-webkit-slider-thumb,
+.block-threshold-slider:active::-webkit-slider-thumb {
+  transform: scale(1.08);
+}
+
+.threshold-slider::-moz-range-track,
+.block-threshold-slider::-moz-range-track {
+  height: 4px;
+  border: 0;
+  border-radius: var(--radius-full);
+  background: var(--range-track);
+}
+
+.threshold-slider::-moz-range-progress,
+.block-threshold-slider::-moz-range-progress {
+  height: 4px;
+  border-radius: var(--radius-full);
+  background: var(--range-fill);
+}
+
+.threshold-slider::-moz-range-thumb,
+.block-threshold-slider::-moz-range-thumb {
+  width: 13px;
+  height: 13px;
+  border: 1px solid var(--range-thumb-border);
+  border-radius: var(--radius-full);
+  background: var(--primary-bg);
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--primary-text) 18%, transparent);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.threshold-slider:hover::-moz-range-thumb,
+.block-threshold-slider:hover::-moz-range-thumb {
+  border-color: var(--button-bg);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--button-bg) 12%, transparent);
 }
 
 .block-threshold-input {
-  width: 64px;
+  width: 56px;
   font-size: var(--font-size-helper);
   text-align: center;
 }
 
 .block-desc-input {
   flex: 1;
+  min-width: 0;
   font-size: var(--font-size-body);
 }
 
@@ -1259,15 +1588,29 @@ onBeforeRouteLeave(async () => {
 
 .fold-block-content.ui-textarea {
   min-height: 100px;
+  padding: var(--space-2) 0 0;
+  border: 0;
+  border-top: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+  border-radius: 0;
+  background: transparent;
+  resize: vertical;
   font-family: 'Consolas', 'Monaco', monospace;
   font-size: var(--font-size-body);
   line-height: 1.6;
 }
 
+.fold-block-content.ui-textarea:hover:not(:disabled),
+.fold-block-content.ui-textarea:focus-visible {
+  border-color: color-mix(in srgb, var(--highlight-text) 32%, var(--border-color));
+  background: transparent;
+}
+
 .block-divider {
   display: flex;
   justify-content: center;
-  padding: var(--space-1) 0;
+  height: var(--space-2);
+  margin: 0;
+  padding: 0;
 }
 
 .add-block-button {
@@ -1287,11 +1630,6 @@ onBeforeRouteLeave(async () => {
 .block-divider:hover .add-block-button,
 .add-block-button:focus-visible {
   opacity: 1;
-}
-
-.add-block-final {
-  align-self: flex-start;
-  margin-top: var(--space-3);
 }
 
 /* ── Editor Actions ── */
@@ -1351,13 +1689,21 @@ onBeforeRouteLeave(async () => {
 
 /* ── Responsive ── */
 @media (max-width: 1024px) {
+  .toolbox-manager-shell {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+
+  .toolbox-entry-fields {
+    grid-template-columns: 1fr;
+  }
+
   .file-content-editor {
     min-height: 300px;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .collapsed-item,
   .fold-block-card,
   .add-block-button {
     transition: none;

--- a/AdminPanel-Vue/src/views/TvsFilesEditor.vue
+++ b/AdminPanel-Vue/src/views/TvsFilesEditor.vue
@@ -1,296 +1,175 @@
 <template>
   <section class="config-section active-section tvs-files-editor-page">
-    <p class="description">
-      TVS 变量文件用于存储系统自定义变量，每行一个 <code>KEY=VALUE</code> 对。
-    </p>
+    <Teleport to="#page-header-actions">
+      <UiPageActions>
+        <p class="tvs-page-summary">
+          管理 TVS 变量文件，每行一个 <code>KEY=VALUE</code> 对。
+        </p>
+        <UiBadge :variant="isDirty ? 'warning' : 'success'">
+          {{ isDirty ? '未保存' : '已同步' }}
+        </UiBadge>
+        <UiButton variant="outline" size="lg" :loading="loadingFiles" @click="reloadFiles">
+          <template #leading>
+            <span class="material-symbols-outlined">refresh</span>
+          </template>
+          刷新
+        </UiButton>
+        <UiButton variant="outline" size="lg" :disabled="isCreating" @click="beginCreateFile">
+          <template #leading>
+            <span class="material-symbols-outlined">add</span>
+          </template>
+          新建
+        </UiButton>
+        <UiButton
+          variant="primary"
+          size="lg"
+          :disabled="!selectedFile || !isDirty"
+          :title="selectedFile ? '保存 (Ctrl+S)' : ''"
+          @click="saveFile"
+        >
+          <template #leading>
+            <span class="material-symbols-outlined">save</span>
+          </template>
+          保存
+        </UiButton>
+      </UiPageActions>
+    </Teleport>
 
-    <div class="tvs-files-editor" :class="{ 'is-sidebar-collapsed': sidebarCollapsed }">
-      <!-- 左侧：文件列表（操作台风格） -->
-      <aside
-        class="tvs-console card"
-        :class="{ 'is-collapsed': sidebarCollapsed }"
-        :aria-label="sidebarCollapsed ? '变量文件操作台（已折叠）' : '变量文件操作台'"
-      >
-        <template v-if="sidebarCollapsed">
-          <div class="console-rail">
-            <UiIconButton
+    <div class="tvs-files-editor">
+      <aside class="tvs-console" aria-label="变量文件列表">
+        <div class="tvs-search">
+          <span class="material-symbols-outlined search-icon">search</span>
+          <UiInput
+            id="tvs-file-search-input"
+            v-model="searchQuery"
+            type="search"
+            class="tvs-search-input"
+            placeholder="搜索变量文件…"
+          />
+          <UiIconButton v-if="searchQuery" class="search-clear" label="清除搜索" title="清除" @click="searchQuery = ''">
+            <span class="material-symbols-outlined">close</span>
+          </UiIconButton>
+        </div>
+
+        <div v-if="isCreating" class="tvs-new-file">
+          <UiInput
+            id="tvs-new-file-input"
+            ref="newFileInputRef"
+            v-model="newFileName"
+            type="text"
+            placeholder="文件名（自动补 .txt）"
+            @keydown.enter.prevent="confirmCreateFile"
+            @keydown.esc.prevent="cancelCreateFile"
+          />
+          <div class="tvs-new-file__actions">
+            <UiButton variant="primary" size="sm" @click="confirmCreateFile">创建</UiButton>
+            <UiButton variant="outline" size="sm" @click="cancelCreateFile">取消</UiButton>
+          </div>
+          <p v-if="createError" class="tvs-new-file__error">{{ createError }}</p>
+        </div>
+
+        <UiEmptyState
+          v-if="loadingFiles"
+          title="正在加载文件列表…"
+          description="请稍候，面板正在读取 TVS 变量文件。"
+        >
+          <template #icon>
+            <span class="material-symbols-outlined spinning">progress_activity</span>
+          </template>
+        </UiEmptyState>
+
+        <UiEmptyState
+          v-else-if="files.length === 0"
+          title="暂无变量文件"
+          description="点击上方新建创建第一个 TVS 变量文件。"
+        >
+          <template #icon>
+            <span class="material-symbols-outlined">edit_note</span>
+          </template>
+        </UiEmptyState>
+
+        <UiEmptyState
+          v-else-if="filteredFiles.length === 0"
+          title="未找到匹配文件"
+          :description="`未找到匹配「${searchQuery}」的文件。`"
+        />
+
+        <ul v-else class="tvs-file-list">
+          <li v-for="file in filteredFiles" :key="file" class="tvs-file-list-item">
+            <button
               type="button"
-              class="console-rail-toggle"
-              label="展开操作台"
-              title="展开操作台"
-              @click="toggleSidebar"
-            >
-              <span class="material-symbols-outlined">left_panel_open</span>
-            </UiIconButton>
-            <div class="console-rail-divider"></div>
-            <UiIconButton
-              type="button"
-              class="console-rail-icon"
-              label="新建文件"
-              title="新建文件"
-              :disabled="isCreating"
-              @click="beginCreateFile"
-            >
-              <span class="material-symbols-outlined">add</span>
-            </UiIconButton>
-            <UiIconButton
-              v-for="file in filteredFiles.slice(0, 8)"
-              :key="file"
-              class="console-rail-icon"
-              :active="file === selectedFile"
-              :label="`打开变量文件 ${file}`"
-              :title="file"
+              :class="['tvs-file-row', { 'is-active': file === selectedFile }]"
               @click="requestSelectFile(file)"
             >
-              <span class="material-symbols-outlined">description</span>
-            </UiIconButton>
-          </div>
-        </template>
-        <template v-else>
-          <div class="tvs-console__section">
-            <span class="tvs-console__label">操作台</span>
-            <div class="tvs-console__header">
-              <h3>变量文件</h3>
-              <div class="sidebar-header-meta">
-                <span class="tvs-file-count">
-                  {{ filteredFiles.length }}/{{ files.length }} 个
-                </span>
-                <UiIconButton
-                  type="button"
-                  class="console-rail-toggle"
-                  label="折叠操作台"
-                  title="折叠操作台"
-                  @click="toggleSidebar"
-                >
-                  <span class="material-symbols-outlined">left_panel_close</span>
-                </UiIconButton>
-              </div>
-            </div>
-          </div>
-
-          <div class="tvs-console__section">
-            <UiField label="搜索筛选" for-id="tvs-file-search-input" size="sm">
-              <div class="tvs-search-box">
-                <UiInput
-                  id="tvs-file-search-input"
-                  v-model="searchQuery"
-                  type="search"
-                  class="tvs-search-input"
-                  placeholder="按文件名筛选..."
-                />
-                <UiButton
-                  v-if="searchQuery"
-                  variant="ghost"
-                  size="sm"
-                  aria-label="清空筛选"
-                  @click="searchQuery = ''"
-                >
-                  清空
-                </UiButton>
-              </div>
-            </UiField>
-          </div>
-
-          <div class="tvs-console__actions">
-            <UiIconButton
-              type="button"
-              class="tvs-refresh-button"
-              size="sm"
-              label="刷新文件列表"
-              title="刷新"
-              :disabled="loadingFiles"
-              @click="reloadFiles"
-            >
-              <span class="material-symbols-outlined">refresh</span>
-            </UiIconButton>
-            <UiButton
-              variant="outline"
-              size="sm"
-              :disabled="isCreating"
-              @click="beginCreateFile"
-            >
-              新建
-            </UiButton>
-          </div>
-
-          <div v-if="isCreating" class="tvs-console__section tvs-new-file">
-            <UiField label="新建文件" for-id="tvs-new-file-input" size="sm">
-              <div class="tvs-search-box">
-                <UiInput
-                  id="tvs-new-file-input"
-                  ref="newFileInputRef"
-                  v-model="newFileName"
-                  type="text"
-                  class="tvs-search-input"
-                  placeholder="文件名（自动补 .txt）"
-                  @keydown.enter.prevent="confirmCreateFile"
-                  @keydown.esc.prevent="cancelCreateFile"
-                />
-              </div>
-            </UiField>
-            <div class="tvs-new-file__actions">
-              <UiButton
-                variant="primary"
-                size="sm"
-                block
-                @click="confirmCreateFile"
-              >
-                创建
-              </UiButton>
-              <UiButton
-                variant="outline"
-                size="sm"
-                block
-                @click="cancelCreateFile"
-              >
-                取消
-              </UiButton>
-            </div>
-            <p v-if="createError" class="tvs-new-file__error">{{ createError }}</p>
-          </div>
-
-          <UiEmptyState
-            v-if="loadingFiles"
-            title="正在加载文件列表…"
-            description="请稍候，面板正在读取 TVS 变量文件。"
-          >
-            <template #icon>
-              <span class="material-symbols-outlined spinning">progress_activity</span>
-            </template>
-          </UiEmptyState>
-
-          <UiEmptyState
-            v-else-if="files.length === 0"
-            title="暂无变量文件"
-            description="点击上方新建创建第一个 TVS 变量文件。"
-          >
-            <template #icon>
-              <span class="material-symbols-outlined">edit_note</span>
-            </template>
-          </UiEmptyState>
-
-          <UiEmptyState
-            v-else-if="filteredFiles.length === 0"
-            title="未找到匹配文件"
-            :description="`未找到匹配「${searchQuery}」的文件。`"
-          />
-
-          <ul v-else class="tvs-file-list">
-            <li
-              v-for="file in filteredFiles"
-              :key="file"
-              class="tvs-file-list-item"
-            >
-              <button
-                type="button"
-                :class="['tvs-file-row', { 'is-active': file === selectedFile }]"
-                @click="requestSelectFile(file)"
-              >
-                <span class="material-symbols-outlined tvs-file-icon">description</span>
-                <span class="tvs-file-name">{{ file }}</span>
-                <span
-                  v-if="file === selectedFile && isDirty"
-                  class="tvs-file-dirty"
-                  title="有未保存更改"
-                  aria-label="有未保存更改"
-                >●</span>
-              </button>
-            </li>
-          </ul>
-        </template>
+              <span class="material-symbols-outlined tvs-file-icon">description</span>
+              <span class="tvs-file-name">{{ file }}</span>
+              <span v-if="file === selectedFile && isDirty" class="tvs-file-dirty">未保存</span>
+            </button>
+          </li>
+        </ul>
       </aside>
 
-      <!-- 右侧：编辑器 -->
-      <main class="tvs-editor-panel">
-        <div class="tvs-editor card">
-          <div class="tvs-editor__toolbar">
-            <div class="tvs-editor__title">
-              <span class="material-symbols-outlined tvs-editor__title-icon">edit_note</span>
-              <div class="tvs-editor__title-main">
-                <h3>编辑内容</h3>
-                <div class="tvs-editor__meta">
-                  <span class="tvs-editor__filename">
-                    {{ selectedFile || "未选择文件" }}
-                  </span>
-                  <UiBadge v-if="isDirty" variant="warning">未保存</UiBadge>
-                </div>
-              </div>
-            </div>
-
-            <div class="tvs-editor__actions">
-              <UiButton
-                variant="outline"
-                size="sm"
-                :disabled="!isDirty"
-                @click="resetContent"
-              >
-                撤销更改
-              </UiButton>
-              <UiButton
-                variant="outline"
-                size="sm"
-                :disabled="!selectedFile"
-                @click="copyContent"
-              >
-                复制
-              </UiButton>
-              <UiButton
-                variant="danger"
-                size="sm"
-                :disabled="!selectedFile"
-                @click="deleteFile"
-              >
-                删除
-              </UiButton>
-              <UiButton
-                variant="primary"
-                :disabled="!selectedFile || !isDirty"
-                :title="selectedFile ? '保存 (Ctrl+S)' : ''"
-                @click="saveFile"
-              >
-                保存
-              </UiButton>
-            </div>
+      <main class="tvs-editor-panel" aria-label="变量文件内容">
+        <header class="tvs-editor__toolbar">
+          <div class="tvs-editor__title">
+            <span class="tvs-pane-label">变量文件内容</span>
+            <span class="tvs-editor__filename">
+              <span class="material-symbols-outlined">description</span>
+              {{ selectedFile || "未选择文件" }}
+            </span>
+            <span v-if="selectedFile" class="tvs-editor__stats">
+              {{ lineCount }} 行 · {{ fileContent.length }} 字符
+            </span>
+            <span v-if="selectedFile && validationWarnings.length > 0" class="tvs-editor__warning">
+              {{ validationWarnings.length }} 处格式提示
+            </span>
           </div>
 
-          <UiBadge
-            v-if="statusMessage"
-            :variant="getStatusVariant(statusType)"
-            class="tvs-status-badge"
-            role="status"
-            aria-live="polite"
-          >
-            {{ statusMessage }}
-          </UiBadge>
-
-          <UiEmptyState
-            v-if="!selectedFile"
-            title="未选择文件"
-            description="从左侧列表选择一个变量文件开始编辑，或新建一个文件。"
-            class="tvs-editor__hint"
-          >
-            <template #icon>
-              <span class="material-symbols-outlined">arrow_back</span>
-            </template>
-          </UiEmptyState>
-
-          <div v-else class="tvs-editor__workspace">
-            <UiTextarea
-              id="tvs-file-content-editor"
-              v-model="fileContent"
-              class="tvs-editor__textarea"
-              resize="none"
-              spellcheck="false"
-              placeholder="# 注释以 # 开头&#10;KEY=VALUE"
-              @keydown="handleEditorKeydown"
-            />
-
-            <div class="tvs-editor__footer">
-              <span class="tvs-editor__stats">
-                {{ lineCount }} 行 · {{ fileContent.length }} 字符
-              </span>
-            </div>
+          <div class="tvs-editor__actions">
+            <UiBadge
+              v-if="statusMessage"
+              :variant="getStatusVariant(statusType)"
+              class="tvs-status-badge"
+              role="status"
+              aria-live="polite"
+            >
+              {{ statusMessage }}
+            </UiBadge>
+            <UiButton variant="outline" size="sm" :disabled="!isDirty" @click="resetContent">
+              撤销
+            </UiButton>
+            <UiButton variant="outline" size="sm" :disabled="!selectedFile" @click="copyContent">
+              复制
+            </UiButton>
+            <UiButton variant="danger" size="sm" :disabled="!selectedFile" @click="deleteFile">
+              删除文件
+            </UiButton>
           </div>
+        </header>
+
+        <UiEmptyState
+          v-if="!selectedFile"
+          title="未选择文件"
+          description="从左侧列表选择一个变量文件开始编辑，或新建一个文件。"
+          class="tvs-editor__hint"
+        >
+          <template #icon>
+            <span class="material-symbols-outlined">arrow_back</span>
+          </template>
+        </UiEmptyState>
+
+        <div v-else class="tvs-editor__workspace">
+          <UiTextarea
+            id="tvs-file-content-editor"
+            v-model="fileContent"
+            class="tvs-editor__textarea"
+            resize="none"
+            spellcheck="false"
+            placeholder="# 注释以 # 开头&#10;KEY=VALUE"
+            @keydown="handleEditorKeydown"
+          />
+
+          <div class="tvs-editor__footer"></div>
         </div>
       </main>
     </div>
@@ -304,11 +183,10 @@ import { tvsApi } from "@/api";
 import UiBadge from "@/components/ui/UiBadge.vue";
 import UiButton from "@/components/ui/UiButton.vue";
 import UiEmptyState from "@/components/ui/UiEmptyState.vue";
-import UiField from "@/components/ui/UiField.vue";
 import UiIconButton from "@/components/ui/UiIconButton.vue";
 import UiInput from "@/components/ui/UiInput.vue";
+import UiPageActions from "@/components/ui/UiPageActions.vue";
 import UiTextarea from "@/components/ui/UiTextarea.vue";
-import { useConsoleCollapse } from "@/composables/useConsoleCollapse";
 import { askConfirm } from "@/platform/feedback/feedbackBus";
 import { showMessage } from "@/utils";
 import { createLogger } from "@/utils/logger";
@@ -333,10 +211,6 @@ const newFileInputRef = ref<InstanceType<typeof UiInput> | null>(null);
 const statusMessage = ref("");
 const statusType = ref<"info" | "success" | "error">("info");
 let statusTimer: ReturnType<typeof setTimeout> | null = null;
-
-const { collapsed: sidebarCollapsed, toggle: toggleSidebar } = useConsoleCollapse(
-  "tvs-files"
-);
 
 const isDirty = computed(() => fileContent.value !== originalContent.value);
 
@@ -616,125 +490,95 @@ onBeforeRouteLeave(async () => {
 
 <style scoped>
 .tvs-files-editor-page {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
+  min-height: 0;
 }
 
-.tvs-files-editor-page > .description {
+.tvs-page-summary {
   margin: 0;
+  color: var(--secondary-text);
+  font-size: var(--font-size-helper);
 }
 
-.tvs-files-editor-page > .description code {
+.tvs-page-summary code {
   display: inline-flex;
   align-items: center;
   min-height: 20px;
-  padding: 0 var(--space-2);
-  background: color-mix(in srgb, var(--primary-text) 5%, transparent);
+  padding: 0 var(--space-1);
   border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
   border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--primary-text) 4%, transparent);
+  color: var(--primary-text);
   font-family: var(--font-mono);
   font-size: var(--font-size-helper);
 }
 
-/* ── 双列布局（参考 .daily-notes-manager / VcptavernEditor 的本地 grid 定义；
-      .dual-pane 是 VcptavernEditor 的 scoped 类，无法跨组件复用） ── */
 .tvs-files-editor {
-  --tvs-panel-viewport-gap: var(--space-4);
   --tvs-panel-height: calc(
     var(--app-viewport-height, 100vh) -
     var(--app-top-bar-height, 60px) -
-    var(--tvs-panel-viewport-gap) * 2
+    var(--space-6)
   );
   display: grid;
-  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
-  gap: var(--space-5);
-  align-items: start;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: var(--space-4);
+  align-items: stretch;
+  min-height: min(680px, var(--tvs-panel-height));
 }
 
-.tvs-files-editor.is-sidebar-collapsed {
-  grid-template-columns: 56px minmax(0, 1fr);
+.tvs-console,
+.tvs-editor-panel {
+  min-height: 0;
+  height: var(--tvs-panel-height);
 }
 
-.sidebar-header-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-/* ── 左侧：操作台（参考 FolderList / VcptavernEditor 的控制台模式） ── */
 .tvs-console {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
-  position: sticky;
-  top: var(--tvs-panel-viewport-gap);
-  align-self: start;
-  height: var(--tvs-panel-height);
+  gap: var(--space-3);
   overflow: hidden;
-  padding: var(--space-5);
-  border-radius: var(--radius-xl);
-  transition: padding var(--transition-fast);
 }
 
-.tvs-console.is-collapsed {
-  padding: var(--space-3) 0;
-  gap: 0;
-  align-items: center;
-}
-
-.tvs-console__section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
-.tvs-console__label {
-  color: var(--highlight-text);
-  font-size: var(--font-size-caption);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.tvs-console__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-}
-
-.tvs-console__header h3 {
-  margin: 0;
-  font-size: var(--font-size-emphasis);
-  color: var(--primary-text);
-}
-
-.tvs-file-count {
-  font-size: var(--font-size-helper);
-  color: var(--secondary-text);
-  font-weight: 500;
-}
-
-.tvs-search-box {
-  display: flex;
-  gap: var(--space-2);
-}
-
-.tvs-search-input {
-  flex: 1;
-  min-width: 0;
-}
-
-.tvs-console__actions {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: var(--space-2);
+.tvs-search {
+  position: relative;
   flex-shrink: 0;
 }
 
+.search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  z-index: 1;
+  transform: translateY(-50%);
+  color: var(--secondary-text);
+  font-size: 18px !important;
+  pointer-events: none;
+}
+
+.tvs-search-input {
+  width: 100%;
+  padding-left: 34px;
+  padding-right: 34px;
+}
+
+.search-clear {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.tvs-new-file {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
+}
+
 .tvs-new-file__actions {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: var(--space-2);
 }
 
@@ -745,15 +589,15 @@ onBeforeRouteLeave(async () => {
 }
 
 .tvs-file-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: var(--space-2);
-  overflow-y: auto;
-  flex: 1;
   min-height: 0;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
 }
 
 .tvs-file-list-item {
@@ -762,38 +606,37 @@ onBeforeRouteLeave(async () => {
 }
 
 .tvs-file-row {
-  flex: 1;
-  width: 100%;
+  box-sizing: border-box;
   display: flex;
+  width: 100%;
+  min-height: 36px;
   align-items: center;
   gap: var(--space-2);
   padding: 0 var(--space-3);
-  border: 1px solid var(--border-color);
+  border: 1px solid color-mix(in srgb, var(--border-color) 76%, transparent);
   border-radius: var(--radius-md);
-  background: transparent;
+  background: color-mix(in srgb, var(--primary-text) 1.6%, transparent);
   color: var(--primary-text);
   text-align: left;
   cursor: pointer;
-  box-sizing: border-box;
-  min-height: 36px;
   transition:
     border-color var(--transition-fast),
     background-color var(--transition-fast);
 }
 
 .tvs-file-row:hover {
-  background: var(--accent-bg);
+  background: color-mix(in srgb, var(--accent-bg) 52%, transparent);
 }
 
 .tvs-file-row.is-active {
-  border-color: color-mix(in srgb, var(--highlight-text) 52%, var(--border-color));
-  background: color-mix(in srgb, var(--highlight-text) 10%, transparent);
+  border-color: color-mix(in srgb, var(--highlight-text) 46%, var(--border-color));
+  background: color-mix(in srgb, var(--highlight-text) 8%, transparent);
 }
 
 .tvs-file-icon {
-  font-size: var(--font-size-emphasis) !important;
-  color: var(--secondary-text);
   flex-shrink: 0;
+  color: var(--secondary-text);
+  font-size: 18px !important;
 }
 
 .tvs-file-row.is-active .tvs-file-icon {
@@ -802,105 +645,80 @@ onBeforeRouteLeave(async () => {
 
 .tvs-file-name {
   flex: 1;
-  font-family: var(--font-mono);
-  font-weight: 500;
-  color: var(--primary-text);
-  line-height: 1.3;
+  min-width: 0;
   overflow: hidden;
+  color: var(--primary-text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-helper);
+  font-weight: 500;
+  line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.tvs-file-row.is-active .tvs-file-name {
-  font-weight: 600;
-}
-
 .tvs-file-dirty {
-  color: var(--warning-color);
-  font-size: var(--font-size-helper);
-  line-height: 1;
   flex-shrink: 0;
+  color: var(--warning-color);
+  font-size: var(--font-size-caption);
+  font-weight: 650;
 }
 
-/* ── 右侧：编辑器 ── */
 .tvs-editor-panel {
-  min-width: 0;
-  display: flex;
-}
-
-.tvs-editor {
-  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
-  height: var(--tvs-panel-height);
+  min-width: 0;
   overflow: hidden;
-  padding: var(--space-5);
-  border-radius: var(--radius-xl);
+  border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--primary-text) 1.4%, transparent);
 }
 
 .tvs-editor__toolbar {
   display: flex;
+  flex-shrink: 0;
+  align-items: center;
   justify-content: space-between;
-  align-items: flex-start;
-  gap: var(--space-4);
-  flex-wrap: wrap;
-  padding-bottom: var(--space-4);
-  border-bottom: 1px solid var(--border-color);
+  gap: var(--space-3);
+  min-height: 48px;
+  padding: 0 var(--space-4);
 }
 
 .tvs-editor__title {
   display: flex;
-  align-items: flex-start;
-  gap: var(--space-3);
-  flex: 1;
   min-width: 0;
-}
-
-.tvs-editor__title-icon {
-  color: var(--highlight-text);
-  font-size: var(--font-size-display) !important;
-  flex-shrink: 0;
-}
-
-.tvs-editor__title-main {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-  min-width: 0;
-  flex: 1;
-}
-
-.tvs-editor__title-main h3 {
-  margin: 0;
-  font-size: var(--font-size-title);
-  color: var(--primary-text);
-  line-height: 1.2;
-}
-
-.tvs-editor__meta {
-  display: flex;
   align-items: center;
   gap: var(--space-2);
   flex-wrap: wrap;
 }
 
+.tvs-pane-label {
+  color: var(--primary-text);
+  font-size: var(--font-size-emphasis);
+  font-weight: 650;
+}
+
 .tvs-editor__filename {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--secondary-text);
   font-family: var(--font-mono);
   font-size: var(--font-size-helper);
+}
+
+.tvs-editor__filename .material-symbols-outlined {
   color: var(--secondary-text);
-  padding: 2px 10px;
-  background: var(--surface-overlay-soft);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  word-break: break-all;
+  font-size: 16px !important;
 }
 
 .tvs-editor__actions {
   display: flex;
-  gap: var(--space-2);
-  flex-wrap: wrap;
   flex-shrink: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
 }
 
 .tvs-editor__hint {
@@ -910,98 +728,82 @@ onBeforeRouteLeave(async () => {
 }
 
 .tvs-editor__workspace {
-  flex: 1;
-  min-height: 0;
   display: flex;
+  flex: 1;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: 0;
+  min-height: 0;
   overflow: hidden;
 }
 
 .tvs-editor__textarea {
   flex: 1;
   width: 100%;
-  height: auto;
-  min-height: 0;
-}
-
-.tvs-editor__textarea :deep(.ui-textarea) {
   height: 100%;
-  max-height: none;
   min-height: 0;
+  max-height: none;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   font-family: var(--font-mono);
   font-size: var(--font-size-body);
-  line-height: 1.75;
+  line-height: 1.72;
   tab-size: 4;
-  border-radius: var(--radius-md);
 }
 
 .tvs-editor__footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--space-3);
-  padding: var(--space-2) var(--space-3);
-  font-size: var(--font-size-helper);
-  color: var(--secondary-text);
-  flex-wrap: wrap;
-  border-top: 1px solid var(--border-color);
-  background: color-mix(in srgb, var(--primary-text) 2%, transparent);
-  border-radius: var(--radius-md);
+  display: none;
 }
 
 .tvs-editor__stats {
+  color: var(--secondary-text);
   font-family: var(--font-mono);
+  font-size: var(--font-size-helper);
+}
+
+.tvs-editor__warning {
+  color: var(--warning-color);
+  font-weight: 600;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (max-width: 1024px) {
-  .tvs-files-editor,
-  .tvs-files-editor.is-sidebar-collapsed {
+  .tvs-files-editor {
     grid-template-columns: 1fr;
   }
 
-  .tvs-console {
-    position: static;
+  .tvs-console,
+  .tvs-editor-panel {
     height: auto;
-    max-height: none;
   }
 
   .tvs-file-list {
     max-height: 320px;
   }
 
-  .tvs-console,
-  .tvs-editor {
-    padding: var(--space-4);
-  }
-
-  .tvs-editor {
-    height: auto;
-    overflow: visible;
+  .tvs-editor__textarea {
+    min-height: 420px;
   }
 
   .tvs-editor__textarea {
-    height: auto;
-    min-height: 360px;
-  }
-
-  .tvs-editor__textarea :deep(.ui-textarea) {
-    min-height: 360px;
     resize: vertical;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .tvs-console,
-  .tvs-file-row {
-    transition: none;
   }
 }
 
 @media (max-width: 768px) {
   .tvs-editor__toolbar {
-    flex-direction: column;
     align-items: stretch;
+    flex-direction: column;
+    padding: var(--space-3);
   }
 
   .tvs-editor__actions {
@@ -1010,6 +812,14 @@ onBeforeRouteLeave(async () => {
 
   .tvs-editor__actions :deep(.ui-button) {
     flex: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinning,
+  .tvs-file-row {
+    transition: none;
+    animation: none;
   }
 }
 </style>


### PR DESCRIPTION
## 这次改了什么

这次主要继续打磨 AdminPanel 的界面一致性，并补上主题快捷调整能力；后续追加了 RAG 调参工作台和日记 / 知识库左侧筛选的细节优化。

### 主题与顶栏

- 在顶栏右侧增加 VCP 官网、GitHub 仓库入口。
- 新增“快捷外观”侧边抽屉，可快速调整：
  - 亮色 / 暗色
  - 预设主题
  - 圆角
  - 密度
  - 字体
  - 内容宽度
  - 外壳布局
- 保留完整主题编辑器页面，并在快捷抽屉中提供跳转入口。
- 优化主题编辑器布局，调整快速外观、预设主题卡片、标题区和分区切换样式。
- 补全主题预设 CSS，让快捷面板切换预设后，页面主题和主题编辑器选中态保持同步。
- 所有预设主题默认圆角统一为“圆润”。

### 页面打磨

- 优化工具箱管理页面的文件选择、编辑区、Block 配置节奏。
- 优化工具列表配置页面的搜索、左侧选择区和右侧预览区。
- 优化语义组编辑器、Agent 信箱、Agent 积分榜、高级变量编辑器等页面的视觉层级。
- 优化思维链编辑器和知识库相关面板，减少厚重卡片和重复边框。
- 继续对齐已完成的语义模型路由器页面风格。

### 本次追加

- 重新整理 RAG 参数调优页：
  - 左侧预设操作台更紧凑，去掉不必要的折叠入口和重复标题。
  - 预设刷新放到页面顶栏动作区。
  - 大章节开头改为轻量圆角标题块，内部参数继续用分割线组织。
  - 上下文折叠层减少嵌套框和厚重数值容器，滑杆与数值输入更轻量。
- 调整日记管理 / 知识库管理左侧目录筛选：
  - 搜索筛选文字与下方操作台小标题对齐。
  - 搜索框与下方目录列表左侧外沿对齐。
  - 收紧搜索框与列表之间的间距。

### 同步上游

- 已合并最新 `origin/main`，包含 `f729ee3c 引入通知离线补发功能`。

## 设计方向

- 优先使用已有 Ui* 原语，减少页面内重复造控件。
- 页面局部样式主要负责布局，不重复定义整套按钮、输入框、卡片视觉。
- 降低大面积主题色背景，主题色主要用于主按钮、选中态、focus 和状态强调。
- 控件高度、间距、图标大小继续按 28 / 32 / 36px 和 8 / 12 / 16px 的节奏收敛。
- hover / focus / active 保持单层反馈，避免多层描边或双 hover。
- 复杂配置页继续向“左侧导航 / 列表 + 右侧编辑区”的结构收敛。

## 验证

- `cd AdminPanel-Vue && npx vue-tsc --noEmit`

## 备注

- 当前分支已合并最新 `origin/main`。
- 本 PR 不包含 `AdminPanel-Vue/dist` 构建产物。
