### PR TITLE
feat(MetaThinking): use description field for Auto-mode chain embedding

### DIFF
--- a/AdminPanel-Vue/src/features/thinking-chains-editor/useThinkingChainsEditor.ts
+++ b/AdminPanel-Vue/src/features/thinking-chains-editor/useThinkingChainsEditor.ts
@@ -16,11 +16,13 @@ interface ThinkingChain {
   theme: string
   clusters: string[]
   kSequence: number[]
+  description: string
 }
 
 interface ThinkingChainRecord {
   clusters?: string[]
   kSequence?: number[]
+  description?: string
 }
 
 type ThinkingChainConfig = string[] | ThinkingChainRecord
@@ -94,6 +96,7 @@ function normalizeThinkingChain(
     theme,
     clusters,
     kSequence: buildNormalizedKSequence(clusters, sourceKSequence),
+    description: Array.isArray(config) ? '' : (config?.description ?? ''),
   }
 }
 
@@ -158,6 +161,7 @@ export function useThinkingChainsEditor() {
         chainsObj[normalizedTheme] = {
           clusters: [...chain.clusters],
           kSequence: [...normalizedKSequence],
+          ...(chain.description ? { description: chain.description } : {}),
         }
       })
 
@@ -184,6 +188,7 @@ export function useThinkingChainsEditor() {
       theme: '新主题',
       clusters: [],
       kSequence: [],
+      description: '',
     })
   }
 

--- a/AdminPanel-Vue/src/views/ThinkingChainsEditor.vue
+++ b/AdminPanel-Vue/src/views/ThinkingChainsEditor.vue
@@ -73,6 +73,22 @@
                 />
               </UiField>
 
+              <UiField
+                class="theme-description-editor"
+                label="Auto模式描述"
+                :for-id="`thinking-desc-${index}`"
+                size="sm"
+              >
+                <UiInput
+                  :id="`thinking-desc-${index}`"
+                  v-model.trim="chain.description"
+                  type="text"
+                  size="sm"
+                  placeholder="关键词描述，用于Auto选链向量化（留空则用主题名）"
+                  @click.stop
+                />
+              </UiField>
+
               <div class="cluster-picker-entry">
                 <UiButton
                   variant="outline"

--- a/Plugin/RAGDiaryPlugin/MetaThinkingManager.js
+++ b/Plugin/RAGDiaryPlugin/MetaThinkingManager.js
@@ -77,7 +77,9 @@ class MetaThinkingManager {
                 continue;
             }
 
-            const themeVector = await this.ragPlugin.getSingleEmbeddingCached(chainName);
+            const chainConfig = this.metaThinkingChains.chains[chainName];
+            const embeddingText = (typeof chainConfig === 'object' && chainConfig?.description) || chainName;
+            const themeVector = await this.ragPlugin.getSingleEmbeddingCached(embeddingText);
             if (themeVector) {
                 this.metaChainThemeVectors[chainName] = themeVector;
                 console.log(`[MetaThinkingManager] -> 已为元思考主题 "${chainName}" 成功获取向量。`);


### PR DESCRIPTION
## 概述Auto模式下 metaChainThemeVectors 原先直接对 chainName 字符串（如"investigation"）做 embedding，语义密度极低。
本 PR 为每条链新增可选 description 字段，MetaThinkingManager 优先用 description 做 embedding，无 description 时 fallback 到 chainName。同时在管理面板思维链编辑器中新增对应的编辑入口。
改动文件
Plugin/RAGDiaryPlugin/MetaThinkingManager.js

_buildAndSaveMetaChainThemeCache: 读取 chainConfig.description 作为 embedding 文本，fallback 到 chainName

AdminPanel-Vue/src/features/thinking-chains-editor/useThinkingChainsEditor.ts

ThinkingChain 接口新增 description: string
normalizeThinkingChain 加载时读取 description
saveThinkingChains 序列化时保留 description（空值不写入）
addThinkingChain 初始化 description 为空字符串

AdminPanel-Vue/src/views/ThinkingChainsEditor.vue

新增 "Auto模式描述" 输入框（位于主题名称下方）

兼容性

向下兼容：无 description 时 fallback 到 chainName，行为不变
缓存自动失效：json 修改后 hash 变化，重启时自动重建向量
不含 dist/ 产物（需 maintainer 自行 build）
不含 meta_thinking_chains.json 数据变更（通过面板 GUI 填写）

已验证效果。
面板构建就不pr了，反正小修改，等下次面板更新pr的时候会被一起build的