### PR TITLE
fix(embedding): strip special token delimiters before embedding API call

### DIFF
--- a/KnowledgeBaseManager.js
+++ b/KnowledgeBaseManager.js
@@ -2285,6 +2285,7 @@ class KnowledgeBaseManager {
         const decorativeEmojis = /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/gu;
         // 1. 移除表情符号, 2. 合并水平空格, 3. 移除换行符周围的空格, 4. 合并多个换行符, 5. 清理首尾
         let cleaned = text.replace(decorativeEmojis, ' ')
+            .replace(/<\|([^|]+)\|>/g, '$1')
             .replace(/[ \t]+/g, ' ')
             .replace(/ *\n */g, '\n')
             .replace(/\n{2,}/g, '\n')

--- a/Plugin/RAGDiaryPlugin/TextSanitizer.js
+++ b/Plugin/RAGDiaryPlugin/TextSanitizer.js
@@ -174,6 +174,7 @@ function sanitizeForEmbedding(content, role) {
     processed = stripHtml(processed);
     processed = stripEmoji(processed);
     processed = stripToolMarkers(processed);
+    processed = processed.replace(/<\|([^|]+)\|>/g, '$1'); // Strip LLM special token delimiters (<|...|>) to prevent embedding API rejection
 
     return processed.trim();
 }

--- a/scripts/repair_database.js
+++ b/scripts/repair_database.js
@@ -24,7 +24,7 @@ try {
 // This function must be an exact copy of the one in KnowledgeBaseManager.js
 function _prepareTextForEmbedding(text) {
     const decorativeEmojis = /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/gu;
-    let cleaned = text.replace(decorativeEmojis, ' ').replace(/\s+/g, ' ').trim();
+    let cleaned = text.replace(decorativeEmojis, ' ').replace(/<\|([^|]+)\|>/g, '$1').replace(/\s+/g, ' ').trim();
     return cleaned.length === 0 ? '[EMPTY_CONTENT]' : cleaned;
 }
 


### PR DESCRIPTION
## 改动说明

在向量化预处理阶段剥离 `<|xxx|>` 格式的LLM特殊token界定符，防止OpenAI Embedding API拒绝包含此格式的文本。

## 问题背景

OpenAI Embedding API（text-embedding-3-small/large）对输入文本中的 `<|...|>` 格式执行双层验证：
1. tiktoken Tokenizer层：检查已注册的特殊token（如 `<|endoftext|>`, `<|im_start|>`）
2. 服务端格式过滤：宽泛拒绝所有符合 `<|...|>` pattern 的字符串

当日记内容讨论LLM特殊token（如安全研究笔记），或引用Danbooru WD-Tagger的分类标记（如 `<|characters|>`, `<|copyrights|>`）时，包含这些格式的chunk向量化会失败（返回null），导致该chunk无法被RAG检索。

## 修复方案

在两个预处理入口点添加正则剥离：`<|xxx|>` → `xxx`（保留语义，移除界定符）

- `TextSanitizer.sanitizeForEmbedding()` — 对话消息向量化路径
- `KnowledgeBaseManager._prepareTextForEmbedding()` — 日记chunk/tag向量化路径
- `scripts/repair_database.js` — 同步副本

## 影响范围

- ✅ 仅影响embedding输入的临时文本处理，不修改日记原文
- ✅ 不影响BM25搜索、LLM阅读（Parent Document Expansion回读原文件）
- ✅ 不与VCP内部协议冲突（VCP使用 `<<<[...]>>>` 格式，regex零交集）
- ✅ 已有stripHtml/stripEmoji/stripToolMarkers先例，为同类操作
