### PR TITLE
fix

### DIFF
--- a/Plugin/DailyNoteSearcher/DailyNoteSearcher.js
+++ b/Plugin/DailyNoteSearcher/DailyNoteSearcher.js
@@ -217,6 +217,15 @@ function getServiceEndpoint() {
     return `http://${serviceConfig.host}:${serviceConfig.port}/search`;
 }
 
+// When PM2 sends SIGTERM, server.js gracefulShutdown() may take longer than
+// PM2's kill_timeout (15s) to reach Phase 8 (plugin shutdown). Register an
+// early SIGTERM listener to kill the child process before Node.js is force-killed.
+process.on('SIGTERM', () => {
+    if (serviceProcess && !serviceProcess.killed) {
+        serviceProcess.kill();
+    }
+});
+
 module.exports = {
     initialize,
     processToolCall,

--- a/TDBKnowledge.js
+++ b/TDBKnowledge.js
@@ -381,6 +381,7 @@ class TDBKnowledgeManager {
                 abs_path = excluded.abs_path,
                 status = 'pending',
                 priority = MAX(priority, excluded.priority),
+                retry_count = 0,
                 last_error = NULL,
                 locked_at = NULL,
                 next_attempt_at = excluded.next_attempt_at,


### PR DESCRIPTION
## TL;DR

Two bugs fixed with minimal changes (10 lines added, 0 deleted):

### Bug 1: TDB ingest queue retry_count not reset on re-enqueue

**Root cause**: When _enqueueIngestJob() re-queues a file that previously failed (e.g. due to embedding API errors), the ON CONFLICT clause resets status, last_error, and locked_at, but **does not reset etry_count**. This means:

1. Embedding API fails (e.g. wrong URL) → file retries queueMaxRetries (5) times → status = 'failed', etry_count = 5
2. User fixes the API URL and restarts
3. _scanInitialFiles() re-queues the file → ON CONFLICT sets status = 'pending' but etry_count stays at 5
4. Any transient embedding failure → etryCount = 5 + 1 = 6 >= 5 → **immediate permanent failure**
5. User is forced to delete the entire TDB store and re-vectorize from scratch

**Fix**: Add etry_count = 0 to the ON CONFLICT UPDATE SET clause (1 line).

### Bug 2: DailyNoteSearcher orphaned Rust process on PM2 restart

**Root cause**: server.js gracefulShutdown() Phase 3 waits up to 30s for active requests to drain, but PM2's kill_timeout is only 15s. PM2 force-kills Node.js before Phase 8 (pluginManager.shutdownAllPlugins()) can call DailyNoteSearcher.shutdown(). The spawned Rust child process (DailyNoteSearcher.exe --serve) becomes orphaned, holding port 38765. Next startup → EADDRINUSE.

**Fix**: Register a module-level SIGTERM listener in DailyNoteSearcher.js that kills the child process immediately on signal receipt, before gracefulShutdown() begins its lengthy drain phase (9 lines).