### PR TITLE
fix(sar): use filtered modelList in isModelMatch

### DIFF
--- a/modules/sarPromptManager.js
+++ b/modules/sarPromptManager.js
@@ -115,10 +115,10 @@ class SarPromptManager {
     isModelMatch(modelList, normalizedModel, matchMode = 'exact') {
         const filtered = modelList.filter(m => m.length > 0); // 过滤空字符串
         if (matchMode === 'includes') {
-            return modelList.some(m => normalizedModel.includes(m));
+            return filtered.some(m => normalizedModel.includes(m));
         }
         // 默认精确匹配（含未知matchMode值的fallback）
-        return modelList.includes(normalizedModel);
+        return filtered.includes(normalizedModel);
     }
 
     getSarPrompt(modelName) {


### PR DESCRIPTION
### 修复说明

修复 PR #404 中 `isModelMatch()` 方法的一个遗漏 bug（感谢 @sayrui 的 code review 指出）。

### Bug描述

`isModelMatch()` 中创建了 `filtered` 变量用于过滤空字符串，但后续的 `.some()` 和 `.includes()` 调用仍然引用的是原始 `modelList` 而非 `filtered`。

### 影响

当 models 数组中意外包含空字符串时（例如用户输入 `"gpt-4,,"` 产生 `["gpt-4", "", ""]`）：
- includes 模式下：`normalizedModel.includes("")` 恒为 true → 所有模型都会被匹配 → 注入到非预期的模型
- exact 模式下：不受影响（Array.includes 不会将空字符串匹配到非空模型名）

### 修复

将 `.some()` 和 `.includes()` 的引用从 `modelList` 改为 `filtered`：

```javascript
isModelMatch(modelList, normalizedModel, matchMode = 'exact') {
    const filtered = modelList.filter(m => m.length > 0);
    if (matchMode === 'includes') {
        return filtered.some(m => normalizedModel.includes(m));  // ← 修复
    }
    return filtered.includes(normalizedModel);  // ← 修复
}
```

### 改动文件

| 文件 | 改动 |
|------|------|
| `modules/sarPromptManager.js` | `isModelMatch()` 中 2处 `modelList` → `filtered` |