### PR TITLE
feat: 新增 You.com 联网搜索插件（参照 TavilySearch）

### DIFF
--- a/Plugin/YoucomSearch/YoucomSearch.js
+++ b/Plugin/YoucomSearch/YoucomSearch.js
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+'use strict';
+
+const axios = require('axios');
+const stdin = require('process').stdin;
+
+const YOUCOM_SEARCH_URL = 'https://ydc-index.io/v1/search';
+const DEFAULT_COUNT = 10;
+const MAX_COUNT = 20;
+const VALID_FRESHNESS = ['day', 'week', 'month', 'year'];
+
+/**
+ * 格式化单条搜索结果（网页或新闻）为 Markdown 列表项。
+ * 对缺失字段进行防御处理，永不抛出异常。
+ */
+function formatOneResult(index, item) {
+    item = item || {};
+    const title = (typeof item.title === 'string' && item.title.trim()) ? item.title : '(无标题)';
+    const url = (typeof item.url === 'string') ? item.url : '';
+
+    let md = `${index}. **[${title}](${url})**\n`;
+
+    if (typeof item.description === 'string' && item.description.trim()) {
+        md += `   ${item.description}\n`;
+    }
+
+    const rawSnippets = Array.isArray(item.snippets) ? item.snippets : [];
+    const snippets = rawSnippets.filter(s => typeof s === 'string' && s.trim().length > 0);
+    if (snippets.length > 0) {
+        snippets.forEach(s => {
+            md += `   - ${s.trim()}\n`;
+        });
+    }
+
+    md += '\n';
+    return md;
+}
+
+/**
+ * 将 You.com 搜索响应格式化为 Markdown。
+ * 纯函数：不发起任何网络请求，对 null/undefined/畸形结构进行防御处理。
+ */
+function formatYoucomResults(response) {
+    const results = (response && typeof response === 'object') ? response.results : null;
+    const web = (results && Array.isArray(results.web)) ? results.web : [];
+    const news = (results && Array.isArray(results.news)) ? results.news : [];
+
+    if (web.length === 0 && news.length === 0) {
+        return '未找到相关搜索结果。\n';
+    }
+
+    let md = '';
+    let index = 0;
+
+    if (web.length > 0) {
+        md += `### 网页结果\n`;
+        web.forEach(item => {
+            index += 1;
+            md += formatOneResult(index, item);
+        });
+    }
+
+    if (news.length > 0) {
+        md += `### 新闻结果\n`;
+        news.forEach(item => {
+            index += 1;
+            md += formatOneResult(index, item);
+        });
+    }
+
+    return md;
+}
+
+/**
+ * 解析 YoucomKey：支持逗号分隔的多个 Key，随机挑选一个使用（与 TavilyKey 逻辑一致）。
+ * 返回 { key, allKeys } 或 { error }，从不抛出异常。
+ * allKeys 包含所有候选 Key（用于后续对错误消息做防泄露脱敏），不仅仅是被选中的那一个。
+ */
+function resolveApiKey(rawKey) {
+    if (!rawKey || typeof rawKey !== 'string' || !rawKey.trim()) {
+        return { error: 'YoucomKey environment variable not set.' };
+    }
+
+    if (rawKey.includes(',')) {
+        const keys = rawKey.split(',').map(k => k.trim()).filter(k => k.length > 0);
+        if (keys.length === 0) {
+            return { error: 'YoucomKey environment variable is empty or contains only commas.' };
+        }
+        return { key: keys[Math.floor(Math.random() * keys.length)], allKeys: keys };
+    }
+
+    const trimmed = rawKey.trim();
+    return { key: trimmed, allKeys: [trimmed] };
+}
+
+/**
+ * 对外部错误消息中可能出现的 API Key 原文进行脱敏替换，防止密钥通过底层 HTTP 库的
+ * 错误信息（例如冗长的请求回显）意外泄露到插件输出中。
+ */
+function redactSecrets(message, secrets) {
+    if (typeof message !== 'string' || !Array.isArray(secrets)) {
+        return message;
+    }
+    let sanitized = message;
+    for (const secret of secrets) {
+        if (typeof secret === 'string' && secret.length > 0 && sanitized.includes(secret)) {
+            sanitized = sanitized.split(secret).join('[REDACTED]');
+        }
+    }
+    return sanitized;
+}
+
+/**
+ * 归一化 count 参数：非数字/负数/零 -> 默认值 10；超过上限 -> 截断为 20。
+ */
+function normalizeCount(count) {
+    let n = parseInt(count, 10);
+    if (isNaN(n) || n <= 0) {
+        n = DEFAULT_COUNT;
+    }
+    if (n > MAX_COUNT) {
+        n = MAX_COUNT;
+    }
+    return n;
+}
+
+/**
+ * 默认的 HTTP GET 实现（生产环境使用）。测试中会注入替身函数，不发起真实网络请求。
+ */
+async function defaultHttpGet(url, config) {
+    return axios.get(url, config);
+}
+
+/**
+ * 对单个子查询发起 You.com 搜索请求，返回响应体（response.data）。
+ * 可能抛出异常（网络错误/HTTP 错误），由调用方通过 Promise.allSettled 或 try/catch 处理。
+ */
+async function fetchSubQuery(subQuery, apiKey, extraParams, httpGet) {
+    const response = await httpGet(YOUCOM_SEARCH_URL, {
+        headers: { 'X-API-Key': apiKey },
+        params: Object.assign({ query: subQuery }, extraParams),
+        timeout: 25000
+    });
+    return (response && response.data) ? response.data : null;
+}
+
+/**
+ * You.com 搜索核心逻辑。接受可注入的 httpGet（用于测试，避免真实网络请求）。
+ * 支持使用 || 分隔的多个查询并发搜索。
+ * 契约：永不抛出异常，永远返回 {status:"success", result} 或 {status:"error", error}。
+ * 契约：任何输出字符串中都不得包含 apiKey 原文。
+ */
+async function searchYoucom(query, options = {}, httpGet = defaultHttpGet) {
+    // 声明在 try 之外，以便 catch 块也能用它对错误消息脱敏（即使异常发生在解析 Key 之后）。
+    let secretsToRedact = [];
+    try {
+        const { apiKey: rawApiKey, count, freshness, country, language } = options || {};
+
+        const resolvedKey = resolveApiKey(rawApiKey);
+        if (resolvedKey.error) {
+            return { status: 'error', error: resolvedKey.error };
+        }
+        const apiKey = resolvedKey.key;
+        secretsToRedact = resolvedKey.allKeys || [apiKey];
+
+        const rawQuery = (typeof query === 'string') ? query : '';
+        const subQueries = rawQuery.split('||').map(q => q.trim()).filter(q => q.length > 0);
+
+        if (subQueries.length === 0) {
+            return { status: 'error', error: "No valid search query after splitting by '||'" };
+        }
+
+        const normalizedCount = normalizeCount(count);
+        const extraParams = { count: normalizedCount };
+        if (typeof freshness === 'string' && VALID_FRESHNESS.includes(freshness)) {
+            extraParams.freshness = freshness;
+        }
+        if (typeof country === 'string' && country.trim()) {
+            extraParams.country = country.trim();
+        }
+        if (typeof language === 'string' && language.trim()) {
+            extraParams.language = language.trim();
+        }
+
+        if (subQueries.length === 1) {
+            const data = await fetchSubQuery(subQueries[0], apiKey, extraParams, httpGet);
+            return { status: 'success', result: formatYoucomResults(data) };
+        }
+
+        // 多个子查询 => 并发搜索
+        const settled = await Promise.allSettled(
+            subQueries.map(subQuery =>
+                fetchSubQuery(subQuery, apiKey, extraParams, httpGet).then(data => ({ subQuery, data }))
+            )
+        );
+
+        let markdownResult = '';
+        const failedResults = [];
+        let hasAnySuccess = false;
+
+        settled.forEach((result, idx) => {
+            if (result.status === 'fulfilled') {
+                hasAnySuccess = true;
+                const { subQuery, data } = result.value;
+                markdownResult += `## 🔍 查询: ${subQuery}\n\n`;
+                markdownResult += formatYoucomResults(data);
+                markdownResult += '\n\n---\n\n';
+            } else {
+                const rawReasonMessage = (result.reason && result.reason.message) ? result.reason.message : '未知错误';
+                const reasonMessage = redactSecrets(rawReasonMessage, secretsToRedact);
+                failedResults.push({ subQuery: subQueries[idx], error: reasonMessage });
+            }
+        });
+
+        if (failedResults.length > 0) {
+            markdownResult += `## ⚠️ 以下查询失败\n\n`;
+            for (const fail of failedResults) {
+                markdownResult += `### 查询: ${fail.subQuery}\n`;
+                markdownResult += `错误: ${fail.error}\n\n`;
+            }
+        }
+
+        if (!hasAnySuccess) {
+            const firstError = failedResults.length > 0 ? failedResults[0].error : '未知错误';
+            return { status: 'error', error: `Youcom Search Error: ${firstError}` };
+        }
+
+        return { status: 'success', result: markdownResult };
+    } catch (e) {
+        const rawMessage = (e && e.message) ? e.message : 'An unknown error occurred.';
+        const message = redactSecrets(rawMessage, secretsToRedact);
+        return { status: 'error', error: `Youcom Search Error: ${message}` };
+    }
+}
+
+async function main() {
+    let inputData = '';
+    stdin.setEncoding('utf8');
+
+    stdin.on('data', function (chunk) {
+        inputData += chunk;
+    });
+
+    stdin.on('end', async function () {
+        let output;
+
+        try {
+            if (!inputData.trim()) {
+                throw new Error('No input data received from stdin.');
+            }
+
+            const data = JSON.parse(inputData);
+
+            output = await searchYoucom(data.query, {
+                apiKey: process.env.YoucomKey,
+                count: data.count,
+                freshness: data.freshness,
+                country: data.country,
+                language: data.language
+            });
+        } catch (e) {
+            let errorMessage;
+            if (e instanceof SyntaxError) {
+                errorMessage = 'Invalid JSON input.';
+            } else if (e instanceof Error) {
+                errorMessage = e.message;
+            } else {
+                errorMessage = 'An unknown error occurred.';
+            }
+            output = { status: 'error', error: `Youcom Search Error: ${errorMessage}` };
+        }
+
+        // Output JSON to stdout
+        process.stdout.write(JSON.stringify(output, null, 2));
+    });
+}
+
+if (require.main === module) {
+    main().catch(error => {
+        // Catch any unhandled promise rejections from main
+        process.stdout.write(JSON.stringify({ status: 'error', error: `Unhandled Plugin Error: ${error.message || error}` }));
+        process.exit(1); // Indicate failure
+    });
+}
+
+module.exports = {
+    formatYoucomResults,
+    searchYoucom
+};

--- a/Plugin/YoucomSearch/plugin-manifest.json
+++ b/Plugin/YoucomSearch/plugin-manifest.json
@@ -1,0 +1,29 @@
+{
+  "manifestVersion": "1.0.0",
+  "name": "YoucomSearch",
+  "displayName": "You.com 搜索插件",
+  "version": "0.1.0",
+  "description": "使用 You.com API 进行网络搜索。AI可以指定搜索查询、返回结果数量、时效范围、国家及语言，获取网页与新闻结果。支持使用 || 分隔多个关键词进行并发搜索，所有结果同时返回。",
+  "author": "Emos21",
+  "pluginType": "synchronous",
+  "entryPoint": {
+    "type": "nodejs",
+    "command": "node YoucomSearch.js"
+  },
+  "communication": {
+    "protocol": "stdio",
+    "timeout": 30000
+  },
+  "configSchema": {
+      "YoucomKey": "string"
+  },
+  "capabilities": {
+    "invocationCommands": [
+      {
+        "commandIdentifier": "YoucomSearch",
+        "description": "调用此工具使用 You.com API 进行网络搜索，返回网页及新闻结果。重要提示：请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。请在您的回复中，使用以下精确格式来请求搜索，确保所有参数值都用「始」和「末」准确包裹：\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」YoucomSearch「末」,\nquery:「始」(必需) 搜索的关键词或问题，支持使用 || 分隔多个关键词进行并发搜索「末」,\ncount:「始」(可选, 默认为 10) 返回的最大结果数量，范围 1-20，超出上限将自动截断为 20。「末」,\nfreshness:「始」(可选) 限定结果的时效范围，只允许 'day'（一天内）、'week'（一周内）、'month'（一月内）、'year'（一年内）之一。「末」,\ncountry:「始」(可选) 搜索结果的国家来源，使用 ISO 国家代码，例如 'CN'（中国）、'US'（美国）。「末」,\nlanguage:「始」(可选) 搜索结果的语言，使用 ISO 语言代码，例如 'zh-Hans'、'en'。「末」\n<<<[END_TOOL_REQUEST]>>>\n\n重要提示给AI：\n当此工具执行完毕后，您将收到包含搜索结果的JSON对象。请基于这些结果回答用户的问题或完成相关任务。\n请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。",
+        "example": "```text\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」YoucomSearch「末」,\nquery:「始」最近一周的AI技术进展「末」,\ncount:「始」5「末」,\nfreshness:「始」week「末」\n<<<[END_TOOL_REQUEST]>>>\n```"
+      }
+    ]
+  }
+}

--- a/config.env.example
+++ b/config.env.example
@@ -573,6 +573,7 @@ TarEmojiList=通用表情包.txt
 # {{VCPSunoGen}}: Suno AI 音乐生成
 # {{VCPSynapsePusher}}: VCP 日志 Synapse 推送器
 # {{VCPTavilySearch}}: Tavily 搜索
+# {{VCPYoucomSearch}}: You.com 搜索
 # {{VCPUrlFetch}}: URL 内容获取
 # {{VCPLog}}: VCP 日志推送
 # {{VCPVideoGenerator}}: 视频生成器 (Wan2.1)
@@ -721,6 +722,10 @@ WeatherUrl=YOUR_QWEATHER_URL_SUCH_AS_devapi.qweather.com
 # Tavily搜索引擎: 用于提供联网搜索能力。注册并获取Key: https://www.tavily.com/
 
 TavilyKey=YOUR_TAVILY_KEY_SUCH_AS_tvly-xxxxxxxxxxxxxxxxxxxxxxxx
+
+# You.com搜索引擎: 用于提供联网搜索能力。注册并获取Key: https://you.com/platform/api-keys
+
+YoucomKey=YOUR_YOUCOM_KEY_SUCH_AS_ydc-xxxxxxxx
 
 # 硅基流动 (SiliconFlow): 用于图片/视频/重排生成。注册并获取Key: https://siliconflow.cn/
 SILICONFLOW_API_KEY=YOUR_SILICONFLOW_KEY_SUCH_AS_sk-xxxxxxxxxxxxxxxxxxxxxxxx

--- a/tests/youcomSearch.test.js
+++ b/tests/youcomSearch.test.js
@@ -1,0 +1,493 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { formatYoucomResults, searchYoucom } = require('../Plugin/YoucomSearch/YoucomSearch.js');
+
+const YOUCOM_SEARCH_URL = 'https://ydc-index.io/v1/search';
+const FAKE_KEY = 'ydc-super-secret-test-key-should-never-leak';
+
+function makeWebItem(overrides = {}) {
+    return Object.assign({
+        title: '示例标题',
+        url: 'https://example.com/page',
+        description: '这是一个示例描述。',
+        snippets: ['片段一', '片段二']
+    }, overrides);
+}
+
+// ---------------------------------------------------------------------------
+// formatYoucomResults — pure formatting
+// ---------------------------------------------------------------------------
+
+test('formatYoucomResults: formats web results as a numbered markdown list', () => {
+    const response = {
+        results: {
+            web: [
+                makeWebItem({ title: '第一条', url: 'https://a.example/1', description: '描述一', snippets: ['snip-a'] }),
+                makeWebItem({ title: '第二条', url: 'https://a.example/2', description: '描述二', snippets: ['snip-b'] })
+            ]
+        }
+    };
+    const md = formatYoucomResults(response);
+    assert.match(md, /### 网页结果/);
+    assert.match(md, /1\. \*\*\[第一条\]\(https:\/\/a\.example\/1\)\*\*/);
+    assert.match(md, /描述一/);
+    assert.match(md, /snip-a/);
+    assert.match(md, /2\. \*\*\[第二条\]\(https:\/\/a\.example\/2\)\*\*/);
+    assert.match(md, /描述二/);
+    assert.match(md, /snip-b/);
+});
+
+test('formatYoucomResults: formats news results as a numbered markdown list', () => {
+    const response = {
+        results: {
+            news: [
+                makeWebItem({ title: '新闻标题', url: 'https://news.example/1', description: '新闻描述', snippets: ['新闻片段'] })
+            ]
+        }
+    };
+    const md = formatYoucomResults(response);
+    assert.match(md, /### 新闻结果/);
+    assert.match(md, /1\. \*\*\[新闻标题\]\(https:\/\/news\.example\/1\)\*\*/);
+    assert.match(md, /新闻描述/);
+    assert.match(md, /新闻片段/);
+});
+
+test('formatYoucomResults: web and news together continue numbering across sections', () => {
+    const response = {
+        results: {
+            web: [makeWebItem({ title: 'W1' })],
+            news: [makeWebItem({ title: 'N1' })]
+        }
+    };
+    const md = formatYoucomResults(response);
+    assert.match(md, /1\. \*\*\[W1\]/);
+    assert.match(md, /2\. \*\*\[N1\]/);
+});
+
+test('formatYoucomResults: both web and news absent -> not-found message', () => {
+    const md = formatYoucomResults({ results: {} });
+    assert.equal(md, '未找到相关搜索结果。\n');
+});
+
+test('formatYoucomResults: empty web and news arrays -> not-found message', () => {
+    const md = formatYoucomResults({ results: { web: [], news: [] } });
+    assert.equal(md, '未找到相关搜索结果。\n');
+});
+
+test('formatYoucomResults: missing title falls back to placeholder, still renders url', () => {
+    const md = formatYoucomResults({ results: { web: [makeWebItem({ title: undefined })] } });
+    assert.match(md, /\*\*\[\(无标题\)\]\(https:\/\/example\.com\/page\)\*\*/);
+});
+
+test('formatYoucomResults: missing url renders empty url without throwing', () => {
+    const md = formatYoucomResults({ results: { web: [makeWebItem({ url: undefined })] } });
+    assert.match(md, /\*\*\[示例标题\]\(\)\*\*/);
+});
+
+test('formatYoucomResults: missing description omits the description line', () => {
+    const item = makeWebItem({ description: undefined, snippets: [] });
+    const md = formatYoucomResults({ results: { web: [item] } });
+    assert.match(md, /\*\*\[示例标题\]/);
+    assert.doesNotMatch(md, /这是一个示例描述/);
+});
+
+test('formatYoucomResults: empty snippets array renders no snippet lines', () => {
+    const item = makeWebItem({ snippets: [] });
+    const md = formatYoucomResults({ results: { web: [item] } });
+    assert.doesNotMatch(md, /- 片段/);
+});
+
+test('formatYoucomResults: blank/whitespace-only snippets are filtered out', () => {
+    const item = makeWebItem({ snippets: ['真实片段', '   ', '', '\n\t', 'another'] });
+    const md = formatYoucomResults({ results: { web: [item] } });
+    assert.match(md, /- 真实片段/);
+    assert.match(md, /- another/);
+    // Only the two real snippets should produce "- " bullet lines
+    const bulletLines = md.split('\n').filter(line => line.trim().startsWith('- '));
+    assert.equal(bulletLines.length, 2);
+});
+
+test('formatYoucomResults: unicode/Chinese content is preserved intact', () => {
+    const item = makeWebItem({
+        title: '中文标题🎉',
+        description: '中文描述，包含标点符号——和表情😀。',
+        snippets: ['中文片段一', '日本語スニペット', 'emoji 🚀 snippet']
+    });
+    const md = formatYoucomResults({ results: { web: [item] } });
+    assert.match(md, /中文标题🎉/);
+    assert.match(md, /中文描述，包含标点符号——和表情😀。/);
+    assert.match(md, /中文片段一/);
+    assert.match(md, /日本語スニペット/);
+    assert.match(md, /emoji 🚀 snippet/);
+});
+
+test('formatYoucomResults: defensive against results:null', () => {
+    assert.equal(formatYoucomResults({ results: null }), '未找到相关搜索结果。\n');
+});
+
+test('formatYoucomResults: defensive against web:null and news:null', () => {
+    assert.equal(formatYoucomResults({ results: { web: null, news: null } }), '未找到相关搜索结果。\n');
+});
+
+test('formatYoucomResults: defensive against completely empty/undefined response', () => {
+    assert.equal(formatYoucomResults(undefined), '未找到相关搜索结果。\n');
+    assert.equal(formatYoucomResults(null), '未找到相关搜索结果。\n');
+    assert.equal(formatYoucomResults({}), '未找到相关搜索结果。\n');
+});
+
+// ---------------------------------------------------------------------------
+// searchYoucom — request construction (injected fake httpGet, no network)
+// ---------------------------------------------------------------------------
+
+function makeFakeHttpGet(dataOrFn) {
+    const calls = [];
+    const fn = async (url, config) => {
+        calls.push({ url, config });
+        if (typeof dataOrFn === 'function') {
+            return dataOrFn(url, config, calls.length);
+        }
+        return { data: dataOrFn };
+    };
+    fn.calls = calls;
+    return fn;
+}
+
+test('searchYoucom: sends correct URL, X-API-Key header, and default params', async () => {
+    const fakeGet = makeFakeHttpGet({ results: { web: [makeWebItem()] } });
+    const result = await searchYoucom('测试查询', { apiKey: FAKE_KEY }, fakeGet);
+
+    assert.equal(result.status, 'success');
+    assert.equal(fakeGet.calls.length, 1);
+    const call = fakeGet.calls[0];
+    assert.equal(call.url, YOUCOM_SEARCH_URL);
+    assert.equal(call.config.headers['X-API-Key'], FAKE_KEY);
+    assert.equal(call.config.params.query, '测试查询');
+    assert.equal(call.config.params.count, 10); // default
+});
+
+test('searchYoucom: count caps at 20 when requested higher', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY, count: 999 }, fakeGet);
+    assert.equal(fakeGet.calls[0].config.params.count, 20);
+});
+
+test('searchYoucom: count defaults to 10 when omitted', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(fakeGet.calls[0].config.params.count, 10);
+});
+
+test('searchYoucom: count accepts a valid numeric string', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY, count: '15' }, fakeGet);
+    assert.equal(fakeGet.calls[0].config.params.count, 15);
+});
+
+test('searchYoucom: negative count falls back to default 10', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY, count: -5 }, fakeGet);
+    assert.equal(fakeGet.calls[0].config.params.count, 10);
+});
+
+test('searchYoucom: zero count falls back to default 10', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY, count: 0 }, fakeGet);
+    assert.equal(fakeGet.calls[0].config.params.count, 10);
+});
+
+test('searchYoucom: huge count caps at 20', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY, count: 100000 }, fakeGet);
+    assert.equal(fakeGet.calls[0].config.params.count, 20);
+});
+
+test('searchYoucom: non-numeric count falls back to default 10', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY, count: 'not-a-number' }, fakeGet);
+    assert.equal(fakeGet.calls[0].config.params.count, 10);
+});
+
+test('searchYoucom: freshness passthrough only when provided and valid', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY, freshness: 'week' }, fakeGet);
+    assert.equal(fakeGet.calls[0].config.params.freshness, 'week');
+});
+
+test('searchYoucom: freshness omitted when not provided', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal('freshness' in fakeGet.calls[0].config.params, false);
+});
+
+test('searchYoucom: invalid freshness value is dropped, not passed through', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY, freshness: 'decade' }, fakeGet);
+    assert.equal('freshness' in fakeGet.calls[0].config.params, false);
+});
+
+test('searchYoucom: country passthrough only when provided', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY, country: 'CN' }, fakeGet);
+    assert.equal(fakeGet.calls[0].config.params.country, 'CN');
+});
+
+test('searchYoucom: country omitted when not provided', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal('country' in fakeGet.calls[0].config.params, false);
+});
+
+test('searchYoucom: language passthrough only when provided', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY, language: 'zh-Hans' }, fakeGet);
+    assert.equal(fakeGet.calls[0].config.params.language, 'zh-Hans');
+});
+
+test('searchYoucom: language omitted when not provided', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal('language' in fakeGet.calls[0].config.params, false);
+});
+
+test('searchYoucom: single query performs exactly one request', async () => {
+    const fakeGet = makeFakeHttpGet({ results: { web: [makeWebItem()] } });
+    const result = await searchYoucom('单一查询', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(fakeGet.calls.length, 1);
+    assert.equal(result.status, 'success');
+    assert.match(result.result, /示例标题/);
+});
+
+// ---------------------------------------------------------------------------
+// searchYoucom — || multi-query concurrency
+// ---------------------------------------------------------------------------
+
+test('searchYoucom: || multi-query, all succeed, runs concurrently and merges output', async () => {
+    const fakeGet = makeFakeHttpGet((url, config) => {
+        const q = config.params.query;
+        return { data: { results: { web: [makeWebItem({ title: `结果-${q}` })] } } };
+    });
+    const result = await searchYoucom('查询A || 查询B || 查询C', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'success');
+    assert.equal(fakeGet.calls.length, 3);
+    assert.match(result.result, /查询: 查询A/);
+    assert.match(result.result, /查询: 查询B/);
+    assert.match(result.result, /查询: 查询C/);
+    assert.match(result.result, /结果-查询A/);
+    assert.match(result.result, /结果-查询B/);
+    assert.match(result.result, /结果-查询C/);
+    assert.doesNotMatch(result.result, /以下查询失败/);
+});
+
+test('searchYoucom: || multi-query, some fail, returns partial success plus failure section', async () => {
+    const fakeGet = makeFakeHttpGet(async (url, config) => {
+        const q = config.params.query;
+        if (q === '失败查询') {
+            throw new Error('模拟网络错误');
+        }
+        return { data: { results: { web: [makeWebItem({ title: `成功-${q}` })] } } };
+    });
+    const result = await searchYoucom('成功查询 || 失败查询', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'success');
+    assert.match(result.result, /成功-成功查询/);
+    assert.match(result.result, /以下查询失败/);
+    assert.match(result.result, /失败查询/);
+    assert.match(result.result, /模拟网络错误/);
+});
+
+test('searchYoucom: || multi-query, all fail, returns error status', async () => {
+    const fakeGet = makeFakeHttpGet(async () => {
+        throw new Error('全部失败');
+    });
+    const result = await searchYoucom('查询1 || 查询2', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'error');
+    assert.match(result.error, /Youcom Search Error/);
+    assert.match(result.error, /全部失败/);
+});
+
+test('searchYoucom: query containing only "||" with no real terms returns clean error, no throw', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    const result = await searchYoucom('||', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'error');
+    assert.equal(fakeGet.calls.length, 0);
+});
+
+test('searchYoucom: whitespace-only query returns clean error, no throw', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    const result = await searchYoucom('   \n\t  ', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'error');
+    assert.equal(fakeGet.calls.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// searchYoucom — key handling and error paths
+// ---------------------------------------------------------------------------
+
+test('searchYoucom: missing apiKey returns error object, never throws, never calls httpGet', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    const result = await searchYoucom('some query', {}, fakeGet);
+    assert.equal(result.status, 'error');
+    assert.match(result.error, /YoucomKey environment variable not set/);
+    assert.equal(fakeGet.calls.length, 0);
+});
+
+test('searchYoucom: empty-string apiKey returns error object', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    const result = await searchYoucom('some query', { apiKey: '' }, fakeGet);
+    assert.equal(result.status, 'error');
+    assert.match(result.error, /YoucomKey environment variable not set/);
+});
+
+test('searchYoucom: comma-separated apiKey picks one of the provided keys', async () => {
+    const keys = ['keyA', 'keyB', 'keyC'];
+    const seenKeys = new Set();
+    for (let i = 0; i < 20; i++) {
+        const fakeGet = makeFakeHttpGet({ results: {} });
+        await searchYoucom('q', { apiKey: keys.join(',') }, fakeGet);
+        const usedKey = fakeGet.calls[0].config.headers['X-API-Key'];
+        assert.ok(keys.includes(usedKey));
+        seenKeys.add(usedKey);
+    }
+    // Over 20 tries, expect randomness to surface (not a strict requirement, just sanity)
+    assert.ok(seenKeys.size >= 1);
+});
+
+test('searchYoucom: comma-separated apiKey with only commas/whitespace returns error', async () => {
+    const fakeGet = makeFakeHttpGet({ results: {} });
+    const result = await searchYoucom('q', { apiKey: ' , , ,  ' }, fakeGet);
+    assert.equal(result.status, 'error');
+    assert.equal(fakeGet.calls.length, 0);
+});
+
+test('searchYoucom: httpGet rejection produces a clean error object (single query)', async () => {
+    const fakeGet = makeFakeHttpGet(async () => {
+        throw new Error('connection reset');
+    });
+    const result = await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'error');
+    assert.match(result.error, /Youcom Search Error/);
+    assert.match(result.error, /connection reset/);
+});
+
+test('searchYoucom: malformed response body (missing results) -> not-found, not a throw', async () => {
+    const fakeGet = makeFakeHttpGet({ foo: 'bar' });
+    const result = await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'success');
+    assert.equal(result.result, '未找到相关搜索结果。\n');
+});
+
+test('searchYoucom: empty response body ({}) -> not-found', async () => {
+    const fakeGet = makeFakeHttpGet({});
+    const result = await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'success');
+    assert.equal(result.result, '未找到相关搜索结果。\n');
+});
+
+test('searchYoucom: null response body -> not-found, no throw', async () => {
+    const fakeGet = makeFakeHttpGet(null);
+    const result = await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'success');
+    assert.equal(result.result, '未找到相关搜索结果。\n');
+});
+
+test('searchYoucom: response.data undefined -> not-found, no throw', async () => {
+    const fakeGet = async () => ({});
+    const result = await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'success');
+    assert.equal(result.result, '未找到相关搜索结果。\n');
+});
+
+test('searchYoucom: results:null in response body -> not-found, no throw', async () => {
+    const fakeGet = makeFakeHttpGet({ results: null });
+    const result = await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'success');
+    assert.equal(result.result, '未找到相关搜索结果。\n');
+});
+
+test('searchYoucom: web:null in results -> not-found, no throw', async () => {
+    const fakeGet = makeFakeHttpGet({ results: { web: null } });
+    const result = await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'success');
+    assert.equal(result.result, '未找到相关搜索结果。\n');
+});
+
+test('searchYoucom: httpGet throwing a non-Error value still yields a clean error object', async () => {
+    const fakeGet = async () => { throw 'plain string rejection'; };
+    const result = await searchYoucom('q', { apiKey: FAKE_KEY }, fakeGet);
+    assert.equal(result.status, 'error');
+    assert.match(result.error, /Youcom Search Error/);
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial: never throw, never leak the key
+// ---------------------------------------------------------------------------
+
+test('adversarial: searchYoucom never throws across a battery of hostile inputs', async () => {
+    const hostileInputs = [
+        [undefined, {}],
+        [null, {}],
+        [123, {}],
+        [{}, {}],
+        ['', {}],
+        ['   ', {}],
+        ['||', {}],
+        ['|| || ||', {}],
+        ['query', { count: {} }],
+        ['query', { count: [] }],
+        ['query', { count: null }],
+        ['query', { freshness: 123 }],
+        ['query', { country: 123 }],
+        ['query', { language: {} }],
+        ['query', { apiKey: null }],
+        ['query', { apiKey: 12345 }],
+        ['query', { apiKey: FAKE_KEY, count: NaN }]
+    ];
+
+    for (const [query, options] of hostileInputs) {
+        const fakeGet = makeFakeHttpGet({ results: { web: [makeWebItem()] } });
+        let result;
+        let threw = false;
+        try {
+            result = await searchYoucom(query, options, fakeGet);
+        } catch (e) {
+            threw = true;
+        }
+        assert.equal(threw, false, `searchYoucom threw for query=${JSON.stringify(query)} options=${JSON.stringify(options)}`);
+        assert.ok(result && typeof result === 'object', 'result must be an object');
+        assert.ok(result.status === 'success' || result.status === 'error', 'result must have a valid status');
+    }
+});
+
+test('adversarial: the fake API key never appears in any success or error output', async () => {
+    const scenarios = [
+        // success path
+        async () => searchYoucom('q', { apiKey: FAKE_KEY }, makeFakeHttpGet({ results: { web: [makeWebItem()] } })),
+        // http error path
+        async () => searchYoucom('q', { apiKey: FAKE_KEY }, makeFakeHttpGet(async () => { throw new Error(`failed for key ${FAKE_KEY}`); })),
+        // missing key path
+        async () => searchYoucom('q', {}, makeFakeHttpGet({ results: {} })),
+        // multi-query partial failure path
+        async () => searchYoucom('a || b', { apiKey: FAKE_KEY }, makeFakeHttpGet(async (url, config) => {
+            if (config.params.query === 'b') throw new Error(`bad request using ${FAKE_KEY}`);
+            return { data: { results: { web: [makeWebItem()] } } };
+        }))
+    ];
+
+    for (const scenario of scenarios) {
+        const result = await scenario();
+        const serialized = JSON.stringify(result);
+        assert.equal(serialized.includes(FAKE_KEY), false, `output leaked the API key: ${serialized}`);
+    }
+});
+
+test('adversarial: comma-separated key never leaks any of its component keys in error output', async () => {
+    const keys = ['secret-key-one', 'secret-key-two'];
+    const fakeGet = makeFakeHttpGet(async () => {
+        throw new Error('upstream rejected the request');
+    });
+    const result = await searchYoucom('q', { apiKey: keys.join(',') }, fakeGet);
+    const serialized = JSON.stringify(result);
+    for (const k of keys) {
+        assert.equal(serialized.includes(k), false, `output leaked component key ${k}`);
+    }
+});


### PR DESCRIPTION
关联 Issue: https://github.com/lioensky/VCPToolBox/issues/406

## 变更内容

新增 **You.com 联网搜索插件** `Plugin/YoucomSearch`，完全参照现有 `Plugin/TavilySearch` 的插件形态：

- `plugin-manifest.json` — synchronous + stdio 插件，`configSchema` 含 `YoucomKey`，调用命令 `YoucomSearch`（VCP 工具请求格式，中文说明；参数 query/count/freshness/country/language，query 支持 `||` 分隔多关键词并发）。
- `YoucomSearch.js` — 从 stdin 读取 JSON 请求，调用 `GET https://ydc-index.io/v1/search`（`X-API-Key` 认证，Key 取自 `YoucomKey`，支持逗号分隔多 Key 随机选取），将 `results.web[]`/`results.news[]` 格式化为 Markdown，向 stdout 输出 `{status, result}`；`||` 多查询走 `Promise.allSettled` 并发（部分失败也返回部分结果）。任何错误都转为 `{status:"error"}`，绝不抛出、绝不泄露 Key。
- `config.env.example` — 新增 `YoucomKey`（占位）与 `{{VCPYoucomSearch}}` 占位项。

## 质量保证（严格深度测试）

- `tests/youcomSearch.test.js`（node:test）共 **50 个用例，全部通过**：结果格式化（网页/新闻/编号连续/缺字段/空结果/空白摘要过滤/中文与 emoji）、请求构造（URL/请求头/参数/数量上限 20/默认 10/各种非法 count 回退）、freshness/country/language 透传、`||` 并发（全成功/部分失败/全失败）、Key 处理（未配置/空/逗号分隔随机/不泄露）、错误路径（HTTP 拒绝/响应异常/null）、以及对抗性输入（数字/对象/NaN/仅 `||`/仅空白，保证永不抛出）。
- **测试发现并修复了一个真实的安全问题**：底层 HTTP 错误信息可能把 API Key 原样带进输出，已新增 `redactSecrets` 对所有错误路径（含逗号分隔的每个 Key 分量）做脱敏。
- 真实 stdin→API→stdout 端到端验证：配置 Key 后返回真实结构化结果，未配置时返回干净错误；两种情况均未泄露 Key。

```bash
node --test tests/youcomSearch.test.js
# 端到端（可选，1 次真实调用）
echo '{"query":"You.com 是什么","count":3}' | YoucomKey=<你的Key> node Plugin/YoucomSearch/YoucomSearch.js
```

## 备注

- 纯新增插件，未改动其他插件；无新增 npm 依赖（复用已有的 axios）。
- 多查询输出沿用 Tavily 的 `🔍`/`⚠️` 标记以保持一致的输出风格。

---

**English summary**: Adds a You.com web-search plugin (Plugin/YoucomSearch) mirroring the existing TavilySearch plugin — a synchronous stdio plugin that calls the You.com Search API (X-API-Key from YoucomKey), formats results.web/news to Markdown, supports || multi-query concurrency, and never throws/leaks the key. 50 node:test cases (formatting, request construction, count caps, multi-query, error paths, adversarial inputs) all pass. The deep test battery caught and fixed a real key-leak in error messages (added redaction). Verified end-to-end via the real stdin->API->stdout path. No new dependencies; only the new plugin + a config placeholder touched.
