### PR TITLE
feat: 新增 VCPQQBotServer 插件 - QQ单聊/群聊接入VCP

### DIFF
--- a/Plugin/VCPQQBotServer/README.md
+++ b/Plugin/VCPQQBotServer/README.md
@@ -1,0 +1,492 @@
+# VCPQQBotServer
+
+VCPQQBotServer 是一个 VCP `hybridservice` 插件，把腾讯 QQBot 的**单聊（C2C）和群聊（GROUP）**都接入 VCP 主服务器。
+
+闭环流程（单聊与群聊共用同一条链路，只是触发条件不同）：
+
+```text
+QQ 用户单聊 / 群里@机器人（或在追问窗口内说话）
+  -> QQBot Gateway WebSocket
+  -> VCPQQBotServer
+  -> VCP 主服务器 /v1/chat/completions 非流请求
+  -> VCP 工具循环 / 记忆 / RAG / 预处理器
+  -> AI 普通自然语言回复
+  -> VCPQQBotServer 自动拆分文本与图片
+  -> QQ 单聊/群聊文本 / 图片消息
+```
+
+AI 不需要通过工具调用来“回复 QQ”。AI 只要正常输出自然语言即可；插件会自动把非流式回复发送回 QQ 用户/群聊。
+
+群里**主动发消息**（不是回复，而是 AI 自己发起，如早报/通知）才需要工具调用，见下方「群聊能力」一节的 `broadcast_to_groups` / `broadcast_draft_file`。
+
+---
+
+## 文件结构
+
+```text
+Plugin/VCPQQBotServer/
+├── plugin-manifest.json      # VCP 插件声明
+├── VCPQQBotServer.js         # 主实现：QQ Gateway + VCP Chat 桥接 + QQ 回复发送
+├── config.env                # 本机真实配置（含密钥，勿公开）
+├── config.env.example        # 可公开的配置模板
+├── ws链接qqbot文档.md        # QQBot WebSocket 官方文档摘录
+└── bot-node-sdk-main/        # 腾讯官方 Node SDK 源码参考
+```
+
+---
+
+## 已实现能力
+
+### 0. 群聊（GROUP_AT_MESSAGE_CREATE）—— 已实现，不是"未来计划"
+
+群聊与单聊走同一条桥接链路，区别在于"什么时候唤醒 AI 回复"：
+
+- **必须 @ 机器人才会回复**（QQ 群消息默认不会让 bot 接所有话，否则会刷屏）。
+- @机器人后，插件会打开一个**"追问窗口"**：接下来 `QQBotGroupEngageWindow` 条群消息内（默认10条），不用再@也会继续接话；超过这个窗口数就关闭，要再@才会唤醒。
+- 每次 bot 实际回复一次，追问窗口会重置（重新计数）。
+- 其他机器人在欢迎语里用纯文字提到本机器人名字（没有走QQ平台结构化@）的情况，靠 `QQBotDisplayName` 识别。
+
+**AI 主动给群发消息**（不是回复用户，是早报/通知场景）用以下两个工具命令：
+
+| 命令 | 用途 |
+|---|---|
+| `broadcast_to_groups` | 直接传 `content` 文本，发给所有已知群（或 `QQBotBroadcastGroups` 指定的群） |
+| `broadcast_draft_file` | 读取 `draft_morning_brief.txt` 文件内容发送，用于"先写文案再发送"的两步式早报流程（两步必须分两轮消息，详见下方说明） |
+
+群推送目标群单：默认是"自动注册的群"——bot 收到过消息的任何群都会被自动记下来，不用手动配置；如果只想推送给指定几个群，才需要填 `QQBotBroadcastGroups`。
+
+### 1. QQ 单聊 Gateway 接入
+
+插件启动后会：
+
+1. 读取 `QQAppID` 与 `QQAppSecret` / `QQBotToken`。
+2. 请求 QQBot Gateway 地址。
+3. 建立 WebSocket。
+4. 处理 `Hello`、`Identify`、`Heartbeat`、`Heartbeat ACK`、`Reconnect`、`Invalid Session`。
+5. 监听 `C2C_MESSAGE_CREATE`（单聊）与 `GROUP_AT_MESSAGE_CREATE`（群聊@）事件。
+
+### 2. 直接调用 VCP 主服务器聊天入口
+
+收到 QQ 单聊消息后，插件会直接访问本机 VCP 主服务器：
+
+```text
+POST http://127.0.0.1:${PORT}/v1/chat/completions
+Authorization: Bearer ${Key}
+```
+
+其中 `PORT` 和 `Key` 由 VCP 插件系统自动注入，不需要在插件配置中重复填写。
+
+请求固定为非流式：
+
+```json
+{
+  "messages": [],
+  "stream": false,
+  "user": "qq_c2c_${openid}"
+}
+```
+
+这意味着 QQ 单聊可以直接使用 VCP 原有能力，包括：
+
+- VCP 工具协议文本解析
+- 同步 / 异步工具调用
+- 记忆与 RAG
+- 消息预处理器
+- 占位符系统
+- 模型路由与主服务器配置
+
+### 3. AI 普通回复自动转 QQ 消息
+
+AI 正常输出文本即可，例如：
+
+```text
+已经完成了，这是生成结果：
+
+![图片](http://127.0.0.1:5890/pw=xxx/images/demo.png)
+
+如果还需要修改风格，我可以继续处理。
+```
+
+插件会自动切成：
+
+1. QQ 文本消息：`已经完成了，这是生成结果：`
+2. QQ 图片消息：`demo.png`
+3. QQ 文本消息：`如果还需要修改风格，我可以继续处理。`
+
+### 4. 图片 URL 自动识别
+
+非流式 AI 回复中会识别三类图片写法：
+
+#### 裸 URL
+
+```text
+http://127.0.0.1:5890/pw=xxx/images/a.png
+```
+
+#### Markdown 图片
+
+```markdown
+![图](http://127.0.0.1:5890/pw=xxx/images/a.png)
+```
+
+#### HTML 图片
+
+```html
+<img src="http://127.0.0.1:5890/pw=xxx/images/a.png">
+```
+
+支持的图片扩展名：
+
+- `.png`
+- `.jpg`
+- `.jpeg`
+- `.gif`
+- `.webp`
+- `.bmp`
+
+默认策略是尽量发送真正的 QQ 图片消息，而不是把图片地址当文字发出去。
+
+图片发送优先级：
+
+1. 如果 URL 是 VCP 本地图床地址（形如 `/pw=.../images/...`），插件会解析到服务器本地文件，直接用 QQ `/files` 的 `file_data` base64 上传。
+2. 如果原图直传失败，会用 `sharp` 在内存里压缩到约 150KB 再直传。GIF 会跳过压缩，避免动图丢帧。
+3. 如果不是本地图床图片，或本地直传与压缩都失败，才回退到 QQ `/files` 的 URL 上传模式。
+4. 如果最终仍失败，插件只记录日志并静默跳过图片，**不会**向群里或单聊发送 `[图片: URL]` / `图片：URL` 这类纯文本链接。
+
+⚠️ VCP 内部生成的图片 URL 通常带鉴权参数（如 `pw=xxx`）。配置 `QQBotPublicBaseUrl`（如 `https://yourdomain.com`）后，插件在 URL 上传兜底时会把这种内部 URL 转换成公开的 `/stickers/` 路径，避免把鉴权参数交给 QQ 侧抓取。
+
+### 5. 文本分段
+
+QQ 文本回复会按 `QQBotMaxReplyChars` 自动分段。
+
+切分优先级：
+
+1. 双换行段落
+2. 单换行
+3. 中文 / 英文句号、问号、感叹号
+4. 硬切字符
+
+连续发送会按 `QQBotSendDelayMs` 间隔等待，降低触发 QQ 频控的概率。
+
+---
+
+## 配置方法
+
+复制配置模板：
+
+```bash
+cp Plugin/VCPQQBotServer/config.env.example Plugin/VCPQQBotServer/config.env
+```
+
+然后编辑：
+
+```env
+QQAppID=
+QQAppSecret=
+QQBotToken=
+QQBotAuthMode=bot_app_token
+QQBotSandbox=false
+QQBotIntents=GROUP_AND_C2C_EVENT
+QQBotModel=
+QQBotSystemPrompt=你是接入 QQ 单聊的 VCPQQBot。你正在通过 VCP 主服务器与 QQ 用户聊天。你可以自然聊天，也可以使用 VCP 工具协议完成任务。若回复中包含图片 URL、Markdown 图片或 HTML img 标签，系统会自动转成 QQ 图片发送。回复应适合 QQ 聊天场景，避免一次性输出过长文本。
+QQBotAllowList=
+QQBotHistoryTurns=8
+QQBotMaxReplyChars=1200
+QQBotSendDelayMs=800
+QQBotRequestTimeoutMs=300000
+QQBotImageMode=upload
+QQBotUploadImages=true
+DebugMode=false
+QQBotGroupEngageWindow=10
+QQBotDisplayName=
+QQBotBroadcastGroups=
+QQBotPublicBaseUrl=
+```
+
+---
+
+## 关键配置说明
+
+| 配置项 | 说明 |
+|---|---|
+| `QQAppID` | QQBot AppID |
+| `QQAppSecret` | QQBot Secret 或 Token，默认会参与 `Bot {QQAppID}.{Token}` 鉴权 |
+| `QQBotToken` | 可选，填写后优先于 `QQAppSecret` |
+| `QQBotAuthMode` | `bot_app_token` 或 `access_token` |
+| `QQBotSandbox` | 是否使用沙箱 Gateway 与 API |
+| `QQBotIntents` | 单聊至少需要 `GROUP_AND_C2C_EVENT` |
+| `QQBotModel` | 发送到 VCP 主服务器的模型名，留空则使用主服务器默认策略 |
+| `QQBotSystemPrompt` | QQ 单聊入口专用系统提示词 |
+| `QQBotAllowList` | 允许自动聊天的 QQ 用户 openid，逗号分隔；留空允许全部 |
+| `QQBotHistoryTurns` | 每个 QQ 单聊会话保留最近多少轮上下文 |
+| `QQBotMaxReplyChars` | QQ 文本消息最大分段字符数 |
+| `QQBotSendDelayMs` | 连续发送文本 / 图片之间的延迟 |
+| `QQBotRequestTimeoutMs` | 调用 VCP 主服务器非流聊天的超时时间 |
+| `QQBotImageMode` | `upload` 为尝试转 QQ 图片；`text` 为只发送 URL 文本 |
+| `DebugMode` | 输出调试日志 |
+| `QQBotGroupEngageWindow` | 群里@后，继续免@接话的消息条数；0=每次都要@ |
+| `QQBotDisplayName` | bot 在群里显示的昵称（识别"被纯文字提及但非结构化@"的边界情况用） |
+| `QQBotBroadcastGroups` | 主动推送限定的目标群 openid，逗号分隔；留空则推给自动注册的所有群 |
+| `QQBotPublicBaseUrl` | 把内部带鉴权参数的图片 URL 转成公开 `/stickers/` 路径，避免群聊裂图 |
+
+---
+
+## 鉴权模式说明
+
+### bot_app_token
+
+默认模式：
+
+```text
+Authorization: Bot {QQAppID}.{QQBotToken或QQAppSecret}
+Identify token: Bot {QQAppID}.{QQBotToken或QQAppSecret}
+```
+
+适用于当前本地官方 SDK 参考实现。
+
+### access_token
+
+```text
+Authorization: QQBot {QQBotToken或QQAppSecret}
+Identify token: QQBot {QQBotToken或QQAppSecret}
+```
+
+如果 QQ 开放平台当前应用要求 AccessToken 模式，可以切换为：
+
+```env
+QQBotAuthMode=access_token
+QQBotToken=你的AccessToken
+```
+
+---
+
+## QQ 开放平台权限
+
+单聊能力依赖：
+
+```text
+GROUP_AND_C2C_EVENT
+```
+
+对应 intent：
+
+```text
+1 << 25
+```
+
+如果应用没有该权限，Gateway 可能返回无权限 intent 或直接断开。遇到连接失败时，请先减少 `QQBotIntents`，确认开放平台已开通对应事件订阅权限。
+
+---
+
+## 图片发送说明
+
+当前实现使用新版 QQ 群聊/C2C 富媒体接口：
+
+```text
+POST /v2/groups/{group_openid}/files
+POST /v2/groups/{group_openid}/messages
+POST /v2/users/{openid}/files
+POST /v2/users/{openid}/messages
+```
+
+图片发送流程：
+
+1. 从 AI 回复中识别图片 URL。
+2. 如果是 VCP 本地图床图片，读取本地文件并调用 `/files`，传入 `file_type=1`、`file_data=<base64>`、`srv_send_msg=false`。
+3. 如果原图直传失败，尝试用 `sharp` 压缩后再次用 `file_data` 上传。
+4. 如果无法定位本地文件或 `file_data` 路径全失败，使用 URL 上传兜底：`file_type=1`、`url=<publicUrl>`、`srv_send_msg=false`。
+5. 从返回中读取 `file_info`。
+6. 调用 `/messages`，使用 `msg_type=7` 和 `media.file_info` 发送真正的 QQ 图片消息。
+7. 如全部失败，静默跳过图片，只记日志，绝不发送图片 URL 文本。
+
+如果腾讯接口字段变化，需要重点检查 `uploadGroupImageByFileData()`、`uploadC2CImageByFileData()`、`uploadGroupImageSmart()`、`uploadC2CImageSmart()`、`sendGroupImage()` 和 `sendC2CImage()`。
+
+---
+
+## 与 VCP 工具调用的关系
+
+QQBot 插件不把“回复 QQ”暴露成必须调用的 VCP 工具。
+
+正确行为：
+
+```text
+QQ 用户：帮我生成一张猫猫图
+AI：好的，我来生成。
+AI：<<<[TOOL_REQUEST]>>> ... 调用生图工具 ...
+AI：生成好了：![图](http://...)
+插件：自动把文本和图片发回 QQ
+```
+
+也就是说：
+
+- 工具调用仍然由 VCP 主服务器文本协议处理。
+- QQ 回复由插件在非流式最终结果阶段自动完成。
+- AI 不需要显式调用 `VCPQQBotServer` 来发消息。
+
+---
+
+## 状态查看
+
+插件提供动态占位符：
+
+```text
+{{VCPQQBotStatus}}
+{{VCPQQRecentMessages}}
+```
+
+也提供一个只读状态工具：
+
+```text
+<<<[TOOL_REQUEST]>>>
+tool_name:「始」VCPQQBotServer「末」,
+command:「始」status「末」
+<<<[END_TOOL_REQUEST]>>>
+```
+
+这个工具仅用于排障查看状态，不用于正常聊天回复。
+
+## 群聊主动推送（早报/通知）
+
+AI 想**主动**给群发消息（不是回复用户的提问，是自己发起，比如定时早报）时用这两个命令：
+
+**直接发文本**：
+
+```text
+<<<[TOOL_REQUEST]>>>
+tool_name:「始」VCPQQBotServer「末」,
+command:「始」broadcast_to_groups「末」,
+content:「始」早上好！今天是2026年6月27日，祝大家工作顺利～「末」
+<<<[END_TOOL_REQUEST]>>>
+```
+
+**两步式早报（先写文案到草稿文件，再发送）**：
+
+第一步，把文案写进绝对路径 `<VCP根目录>/Plugin/VCPQQBotServer/draft_morning_brief.txt`（用 ServerFileOperator/DevFileOperator 的写文件命令，**填绝对路径，不要写相对路径**）。
+
+第二步，发送草稿文件内容：
+
+```text
+<<<[TOOL_REQUEST]>>>
+tool_name:「始」VCPQQBotServer「末」,
+command:「始」broadcast_draft_file「末」
+<<<[END_TOOL_REQUEST]>>>
+```
+
+⚠️ **这两步必须分在两轮不同的 AI 消息里**：第一轮只发 WriteFile，等结果真正返回确认写入成功；第二轮再单独发 broadcast_draft_file。**千万不要把这两个 TOOL_REQUEST 写在同一轮消息里一起发出**——VCP 对同一轮消息里的多个工具调用是用 `Promise.all` 并发执行的（见 `modules/vcpLoop/toolExecutor.js`），写文件（要启动新进程，有一定耗时）和读文件（常驻服务，几乎瞬间响应）会赛跑，读操作很可能先于写操作完成而报 `ENOENT`（2026-06-27 实测踩过这个坑）。
+
+两步式的意义：撰写和发送可以分给不同 agent/不同时机做，避免一个长任务里既要想文案又要管发送状态——但前提是真的分两轮，不是写在一轮里假装两步。
+
+---
+
+## 常见问题
+
+### 1. 插件启动但不连接 Gateway
+
+检查：
+
+- `QQAppID` 是否填写。
+- `QQAppSecret` 或 `QQBotToken` 是否填写。
+- `QQBotAuthMode` 是否符合当前开放平台鉴权方式。
+- `QQBotSandbox` 是否和应用环境一致。
+
+### 2. Gateway 报 invalid intents 或断开
+
+检查：
+
+- `QQBotIntents` 是否只保留已授权事件。
+- 单聊是否已开通 `GROUP_AND_C2C_EVENT`。
+- 可先只配置：
+
+```env
+QQBotIntents=GROUP_AND_C2C_EVENT
+```
+
+### 3. QQ 用户发消息后没有 AI 回复
+
+检查：
+
+- VCP 主服务器是否已启动。
+- 插件状态中 `VCP 端口` 是否存在。
+- 插件状态中 `VCP Key` 是否为 `FOUND`。
+- `QQBotAllowList` 是否限制了当前用户 openid。
+- VCP 主服务器 `/v1/chat/completions` 是否能正常非流响应。
+
+### 4. AI 回复了图片 URL，但 QQ 没发图
+
+检查：
+
+- `QQBotImageMode` 是否为 `upload`。
+- 如果是 VCP 图床 URL，确认 `/pw=.../images/...` 后面的本地文件真实存在。
+- 如果文件名是模型编出来的，确认 `resolveEmojiFile()` 是否能模糊匹配到真实文件名。
+- `sharp` 是否安装；未安装时仍会尝试原图直传和 URL 上传，但没有压缩兜底。
+- QQ 群聊/C2C 文件接口是否返回 `file_info`。
+- `QQBotPublicBaseUrl` 是否填写；它只影响 URL 上传兜底，本地 `file_data` 直传不依赖它。
+- 腾讯接口是否变更了字段或路径。
+
+失败时插件会静默跳过图片，不会回退发送图片 URL 文本。群里看到文字部分但没有图时，先看 VCP 日志里的 `发送群图片失败(静默跳过,不发文本链接)` 或 `发送 QQ 图片失败(静默跳过,不发文本链接)`。
+
+### 5. `broadcast_draft_file` 报 ENOENT 找不到草稿文件，但文件确实存在
+
+几乎一定是**两步发在了同一轮 AI 消息里**（见上方「群聊主动推送」一节的警告）：VCP 并发执行同一轮内的多个工具调用，WriteFile 还没写完，broadcast_draft_file 已经在读了。解法：把 WriteFile 和 broadcast_draft_file 拆成两轮分别发送，确认第一轮的写入结果真正返回后才发第二轮。
+
+### 6. `broadcast_to_groups` / `broadcast_draft_file` 对某个群返回 400/其他错误码
+
+插件会把 QQ API 返回的真实错误码和消息体一起报出来（如 `HTTP 400 {"code":xxx,"message":"..."}`），照着这个真实错误信息判断，而不要凭空猜测。常见原因包括：bot 已被移出该群、bot 在该群被禁言、消息内容触发频控/敏感词过滤、群 openid 已失效（很久没收到该群消息）。先看插件返回的具体错误码再排查，不要跳过这一步直接猜。
+
+### 7. 为什么不是流式回复
+
+当前单聊优先稳定闭环，使用非流式是为了：
+
+- 等 VCP 工具循环完整结束。
+- 一次性拿到最终 AI 回复。
+- 统一解析文本、Markdown 图片、HTML 图片和裸 URL。
+- 按 QQ 消息类型有序发送文本与图片。
+
+后续如果需要“边生成边发 QQ”，可以另做流式适配，但图片解析与工具循环完成时机要更谨慎。
+
+---
+
+## 开发与校验
+
+语法检查：
+
+```bash
+node --check Plugin/VCPQQBotServer/VCPQQBotServer.js
+```
+
+Manifest 校验：
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('Plugin/VCPQQBotServer/plugin-manifest.json','utf8')); console.log('manifest ok')"
+```
+
+重启 VCP 主服务器后，插件会自动被加载。
+
+---
+
+## 当前边界
+
+- ✅ 已实现 `C2C_MESSAGE_CREATE`（单聊自动回复）。
+- ✅ 已实现 `GROUP_AT_MESSAGE_CREATE`（群聊@唤醒 + 追问窗口免@接话，见上方「群聊能力」一节）。
+- ✅ 已实现群聊主动推送（`broadcast_to_groups` / `broadcast_draft_file`）。
+- 暂未实现频道 `AT_MESSAGE_CREATE` 自动回复（频道≠群，QQ频道是另一套场景，目前没接）。
+- 暂未实现用户发来的 QQ 图片转 VCP 多模态输入，仅会把附件元数据写入用户消息。
+- QQ 图片发送接口按当前新版 C2C 文档经验实现，如平台字段变动需按真实返回调整。
+
+> ⚠️ 这份文档曾经长期写着"群聊未实现"，但实际群聊早就在线上跑着。维护这份文档时务必先去服务器核对 `config.env` 和真实日志，而不是凭旧文档的记忆去判断功能边界。
+
+---
+
+## 推荐上线步骤
+
+1. 填写 `config.env`。
+2. 确认 QQ 开放平台启用单聊与群聊事件（`GROUP_AND_C2C_EVENT`）。
+3. 先设置 `DebugMode=true`。
+4. 重启 VCP 主服务器。
+5. 通过状态工具或占位符确认 Gateway 已连接。
+6. 用白名单 openid 单聊测试纯文本。
+7. 把 bot 拉进测试群，@它测试群聊回复，确认 `QQBotGroupEngageWindow` 的免@追问窗口生效。
+8. 测试 VCP 工具调用，例如搜索、文件、图片生成。
+9. 测试 AI 回复中的裸图片 URL、Markdown 图片、HTML 图片；本地图床表情包应走 `file_data` 直传，外部图片或直传失败时才依赖 `QQBotPublicBaseUrl` 的 URL 兜底。
+10. 测试群聊主动推送 `broadcast_to_groups`。
+11. 稳定后设置 `DebugMode=false`。

--- a/Plugin/VCPQQBotServer/VCPQQBotServer.js
+++ b/Plugin/VCPQQBotServer/VCPQQBotServer.js
@@ -1,0 +1,1623 @@
+const axios = require('axios');
+const WebSocket = require('ws');
+const pluginManager = require('../../Plugin.js');
+
+const INTENTS = {
+  GUILDS: 1 << 0,
+  GUILD_MEMBERS: 1 << 1,
+  GUILD_MESSAGES: 1 << 9,
+  GUILD_MESSAGE_REACTIONS: 1 << 10,
+  DIRECT_MESSAGE: 1 << 12,
+  GROUP_AND_C2C_EVENT: 1 << 25,
+  INTERACTION: 1 << 26,
+  MESSAGE_AUDIT: 1 << 27,
+  FORUMS_EVENT: 1 << 28,
+  AUDIO_ACTION: 1 << 29,
+  PUBLIC_GUILD_MESSAGES: 1 << 30
+};
+
+const OPCODE = {
+  DISPATCH: 0,
+  HEARTBEAT: 1,
+  IDENTIFY: 2,
+  RESUME: 6,
+  RECONNECT: 7,
+  INVALID_SESSION: 9,
+  HELLO: 10,
+  HEARTBEAT_ACK: 11
+};
+
+const DEFAULT_SYSTEM_PROMPT = '你是黑哥VCP，一个接入QQ单聊的AI助手。你正在通过VCP主服务器与QQ用户聊天。你可以自然聊天，也可以使用VCP工具协议完成任务。若回复中包含图片URL、Markdown图片或HTML img标签，系统会自动转成QQ图片发送。回复应适合QQ聊天场景，避免一次性输出过长文本。';
+const STATUS_PLACEHOLDER = '{{VCPQQBotStatus}}';
+const RECENT_PLACEHOLDER = '{{VCPQQRecentMessages}}';
+
+let config = {};
+const KNOWN_GROUPS_FILE = __dirname + '/known_groups.json';
+let knownGroups = new Set(); // 自动注册的群 openid
+
+function loadKnownGroups() {
+  try {
+    const data = require('fs').readFileSync(KNOWN_GROUPS_FILE, 'utf8');
+    JSON.parse(data).forEach(id => knownGroups.add(id));
+  } catch (e) { /* 文件不存在时忽略 */ }
+}
+
+function saveKnownGroup(groupId) {
+  if (!groupId || knownGroups.has(groupId)) return;
+  knownGroups.add(groupId);
+  try {
+    require('fs').writeFileSync(KNOWN_GROUPS_FILE,
+      JSON.stringify([...knownGroups], null, 2), 'utf8');
+  } catch (e) { warn('保存群 ID 失败:', e.message); }
+}
+
+const groupEngageWindows = new Map(); // groupOpenid → 剩余主动参与消息条数
+const groupLastAtMsgId = new Map();   // groupOpenid → {msgId, ts}  最近@mention的msg_id
+const groupMsgSeqCounters = new Map();// `groupOpenid:msgId` → seq 计数器（QQ去重要求每条递增）
+
+function getNextMsgSeq(groupOpenid, msgId) {
+  if (!msgId) return undefined;
+  const key = groupOpenid + ':' + msgId;
+  const seq = (groupMsgSeqCounters.get(key) || 0) + 1;
+  groupMsgSeqCounters.set(key, seq);
+  return seq;
+}
+
+// C2C 被动消息也需 msg_seq 递增:同一 msg_id 多次被动回复(文字+图片多part)
+// 必须每次用不同 msg_seq,否则 QQ 返回 50015014 系统繁忙 / 400
+const c2cMsgSeqCounters = new Map();
+function getC2CMsgSeq(openid, msgId) {
+  if (!msgId) return undefined;
+  const key = openid + ':' + msgId;
+  const seq = (c2cMsgSeqCounters.get(key) || 0) + 1;
+  c2cMsgSeqCounters.set(key, seq);
+  return seq;
+}
+let debugMode = false;
+let accessTokenCache = { token: null, expiresAt: 0 };
+let ws = null;
+let heartbeatTimer = null;
+let reconnectTimer = null;
+let stopped = false;
+let connecting = false;
+let retryCount = 0;
+let latestSeq = null;
+let sessionId = '';
+let readyUser = null;
+let heartbeatInterval = 45000;
+let lastHeartbeatAckAt = null;
+let lastConnectedAt = null;
+let lastDisconnectedAt = null;
+let lastError = null;
+let processingLocks = new Set();
+let histories = new Map();
+let recentMessages = [];
+
+function log(...args) {
+  if (debugMode) console.log('[VCPQQBotServer]', ...args);
+}
+
+function warn(...args) {
+  console.warn('[VCPQQBotServer]', ...args);
+}
+
+function normalizeBoolean(value, fallback = false) {
+  if (value === undefined || value === null || value === '') return fallback;
+  if (typeof value === 'boolean') return value;
+  return String(value).trim().toLowerCase() === 'true';
+}
+
+function normalizeInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function splitList(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.map(String).map(v => v.trim()).filter(Boolean);
+  return String(value).split(/[,;\n]/).map(v => v.trim()).filter(Boolean);
+}
+
+function getBaseUrl() {
+  return normalizeBoolean(config.QQBotSandbox, false)
+    ? 'https://sandbox.api.sgroup.qq.com'
+    : 'https://api.sgroup.qq.com';
+}
+
+function getGatewayUrlApi() {
+  return `${getBaseUrl()}/gateway/bot`;
+}
+
+function getTokenValue() {
+  return String(config.QQBotToken || config.QQAppSecret || '').trim();
+}
+
+async function getAppAccessToken() {
+  if (accessTokenCache.token && Date.now() < accessTokenCache.expiresAt) {
+    return accessTokenCache.token;
+  }
+  const appId = String(config.QQAppID || '').trim();
+  const clientSecret = String(config.QQAppSecret || '').trim();
+  if (!appId || !clientSecret) {
+    warn('缺少 QQAppID 或 QQAppSecret，无法获取 AppAccessToken，回退到 getTokenValue。');
+    return getTokenValue();
+  }
+  try {
+    const response = await axios.post('https://bots.qq.com/app/getAppAccessToken', {
+      appId,
+      clientSecret
+    }, {
+      timeout: 15000
+    });
+    const data = response.data;
+    if (data.access_token) {
+      const expiresIn = (data.expires_in || 7200) - 60;
+      accessTokenCache.token = data.access_token;
+      accessTokenCache.expiresAt = Date.now() + expiresIn * 1000;
+      log('已获取新的 AppAccessToken。');
+      return data.access_token;
+    }
+    throw new Error(`获取 AppAccessToken 返回格式异常：${JSON.stringify(data)}`);
+  } catch (error) {
+    warn('获取 AppAccessToken 失败:', error.message);
+    return getTokenValue();
+  }
+}
+
+async function getBotAuthorization() {
+  const appId = String(config.QQAppID || '').trim();
+  const token = getTokenValue();
+  const mode = String(config.QQBotAuthMode || 'bot_app_token').trim().toLowerCase();
+  if (mode === 'access_token') {
+    const accessToken = await getAppAccessToken();
+    return `QQBot ${accessToken}`;
+  }
+  return `Bot ${appId}.${token}`;
+}
+
+async function getIdentifyToken() {
+  return await getBotAuthorization();
+}
+
+async function getRequestHeaders(extra = {}) {
+  return {
+    Authorization: await getBotAuthorization(),
+    'Content-Type': 'application/json',
+    'User-Agent': 'VCPQQBotServer/0.1.0',
+    ...extra
+  };
+}
+
+function computeIntents() {
+  const names = splitList(config.QQBotIntents || 'GROUP_AND_C2C_EVENT');
+  let value = 0;
+  for (const name of names) {
+    const key = name.trim();
+    if (Object.prototype.hasOwnProperty.call(INTENTS, key)) value |= INTENTS[key];
+  }
+  return value || INTENTS.GROUP_AND_C2C_EVENT;
+}
+
+function mask(value) {
+  const text = String(value || '');
+  if (!text) return 'NOT_CONFIGURED';
+  if (text.length <= 4) return '*'.repeat(text.length);
+  return `${text.slice(0, 2)}***${text.slice(-2)}`;
+}
+
+function addRecent(item) {
+  recentMessages.push({
+    time: new Date().toISOString(),
+    ...item
+  });
+  const keep = normalizeInteger(config.QQBotRecentKeep, 50);
+  if (recentMessages.length > keep) recentMessages = recentMessages.slice(-keep);
+  updatePlaceholders();
+}
+
+function buildStatusText() {
+  const lines = [];
+  lines.push('# VCPQQBotServer 状态');
+  lines.push('');
+  lines.push(`- Gateway：${ws && ws.readyState === WebSocket.OPEN ? 'connected' : connecting ? 'connecting' : 'disconnected'}`);
+  lines.push(`- 已停止：${stopped ? '是' : '否'}`);
+  lines.push(`- 重试次数：${retryCount}`);
+  lines.push(`- 最近 seq：${latestSeq ?? '无'}`);
+  lines.push(`- session_id：${sessionId || '无'}`);
+  lines.push(`- Bot 用户：${readyUser ? `${readyUser.username || 'unknown'} (${readyUser.id || 'unknown'})` : '未知'}`);
+  lines.push(`- 心跳间隔：${heartbeatInterval}ms`);
+  lines.push(`- 最近心跳 ACK：${lastHeartbeatAckAt || '无'}`);
+  lines.push(`- 最近连接：${lastConnectedAt || '无'}`);
+  lines.push(`- 最近断开：${lastDisconnectedAt || '无'}`);
+  lines.push(`- 最近错误：${lastError || '无'}`);
+  lines.push(`- VCP 端口：${config.PORT || '未注入'}`);
+  lines.push(`- VCP Key：${config.Key ? 'FOUND' : 'NOT FOUND'}`);
+  lines.push(`- QQAppID：${mask(config.QQAppID)}`);
+  lines.push(`- Intents：${config.QQBotIntents || 'GROUP_AND_C2C_EVENT'} (${computeIntents()})`);
+  lines.push(`- 历史会话数：${histories.size}`);
+  lines.push(`- 最近消息数：${recentMessages.length}`);
+  return lines.join('\n');
+}
+
+function buildRecentText() {
+  const lines = [];
+  lines.push('# VCPQQBot 最近单聊消息');
+  lines.push('');
+  if (recentMessages.length === 0) {
+    lines.push('暂无消息。');
+    return lines.join('\n');
+  }
+  lines.push('| # | 时间 | 方向 | openid | 类型 | 内容 |');
+  lines.push('|---:|---|---|---|---|---|');
+  recentMessages.slice(-20).forEach((msg, index) => {
+    lines.push(`| ${index + 1} | ${escapeMd(msg.time)} | ${escapeMd(msg.direction || '')} | ${escapeMd(msg.openid || '')} | ${escapeMd(msg.type || '')} | ${escapeMd(truncateInline(msg.content || msg.error || '', 120))} |`);
+  });
+  return lines.join('\n');
+}
+
+function escapeMd(value) {
+  return String(value ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function truncateInline(value, max) {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}
+
+function updatePlaceholders() {
+  pluginManager.staticPlaceholderValues.set(STATUS_PLACEHOLDER, {
+    value: buildStatusText(),
+    serverId: 'local'
+  });
+  pluginManager.staticPlaceholderValues.set(RECENT_PLACEHOLDER, {
+    value: buildRecentText(),
+    serverId: 'local'
+  });
+}
+
+async function initialize(initialConfig = {}) {
+  config = initialConfig || {};
+  debugMode = normalizeBoolean(config.DebugMode, false);
+  loadKnownGroups();
+  stopped = false;
+  updatePlaceholders();
+
+  if (!config.QQAppID || !getTokenValue()) {
+    lastError = '缺少 QQAppID 或 QQAppSecret/QQBotToken，VCPQQBotServer 不会连接 Gateway。';
+    warn(lastError);
+    updatePlaceholders();
+    return;
+  }
+  if (!config.PORT || !config.Key) {
+    lastError = '缺少 VCP 注入的 PORT 或 Key，无法调用主服务器聊天入口。';
+    warn(lastError);
+    updatePlaceholders();
+    return;
+  }
+
+  log('初始化完成，准备连接 QQ Gateway。');
+  connectGateway().catch(error => {
+    lastError = error.message;
+    warn('Gateway 首次连接失败:', error.message);
+    scheduleReconnect(error.message);
+  });
+}
+
+async function fetchGatewayInfo() {
+  const response = await axios.get(getGatewayUrlApi(), {
+    headers: await getRequestHeaders({ Accept: 'application/json' }),
+    timeout: 15000
+  });
+  if (!response.data || !response.data.url) {
+    throw new Error(`获取 Gateway 地址失败：${JSON.stringify(response.data)}`);
+  }
+  return response.data;
+}
+
+async function connectGateway() {
+  if (stopped || connecting) return;
+  if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) return;
+
+  connecting = true;
+  clearReconnectTimer();
+
+  try {
+    const gateway = await fetchGatewayInfo();
+    const url = gateway.url;
+    log('Gateway 信息:', gateway);
+    await openGatewaySocket(url);
+  } finally {
+    connecting = false;
+  }
+}
+
+function openGatewaySocket(url) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    ws = new WebSocket(url);
+
+    ws.on('open', () => {
+      lastConnectedAt = new Date().toISOString();
+      lastError = null;
+      log('Gateway WebSocket 已打开。');
+      updatePlaceholders();
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    });
+
+    ws.on('message', data => {
+      handleGatewayMessage(data).catch(error => {
+        lastError = error.message;
+        warn('处理 Gateway 消息失败:', error.message);
+        updatePlaceholders();
+      });
+    });
+
+    ws.on('close', (code, reason) => {
+      lastDisconnectedAt = new Date().toISOString();
+      const reasonText = reason ? reason.toString() : '';
+      log('Gateway WebSocket 关闭:', code, reasonText);
+      clearHeartbeat();
+      ws = null;
+      updatePlaceholders();
+      if (!stopped) scheduleReconnect(`close:${code}:${reasonText}`);
+    });
+
+    ws.on('error', error => {
+      lastError = error.message;
+      warn('Gateway WebSocket 错误:', error.message);
+      updatePlaceholders();
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    });
+  });
+}
+
+async function handleGatewayMessage(data) {
+  const payload = parsePayload(data);
+  if (!payload) return;
+
+  if (typeof payload.s === 'number') latestSeq = payload.s;
+
+  switch (payload.op) {
+    case OPCODE.HELLO:
+      heartbeatInterval = normalizeInteger(payload.d && payload.d.heartbeat_interval, heartbeatInterval);
+      if (sessionId && latestSeq !== null) await sendResume();
+      else await sendIdentify();
+      break;
+    case OPCODE.HEARTBEAT:
+      sendHeartbeat();
+      break;
+    case OPCODE.HEARTBEAT_ACK:
+      lastHeartbeatAckAt = new Date().toISOString();
+      updatePlaceholders();
+      break;
+    case OPCODE.RECONNECT:
+      warn('QQ Gateway 要求重连。');
+      reconnectNow('server_reconnect');
+      break;
+    case OPCODE.INVALID_SESSION:
+      warn('QQ Gateway Invalid Session，清理会话后重连。');
+      sessionId = '';
+      latestSeq = null;
+      reconnectNow('invalid_session');
+      break;
+    case OPCODE.DISPATCH:
+      handleDispatch(payload);
+      break;
+    default:
+      log('忽略 Gateway op:', payload.op, payload.t || '');
+      break;
+  }
+}
+
+function parsePayload(data) {
+  try {
+    const text = Buffer.isBuffer(data) ? data.toString('utf8') : String(data);
+    return JSON.parse(text);
+  } catch (error) {
+    warn('Gateway payload 解析失败:', error.message);
+    return null;
+  }
+}
+
+async function sendIdentify() {
+  const payload = {
+    op: OPCODE.IDENTIFY,
+    d: {
+      token: await getIdentifyToken(),
+      intents: computeIntents(),
+      shard: [0, 1],
+      properties: {
+        $os: process.platform,
+        $browser: 'VCPQQBotServer',
+        $device: 'VCPQQBotServer'
+      }
+    }
+  };
+  sendWs(payload);
+  startHeartbeat();
+  log('已发送 Identify。');
+}
+
+async function sendResume() {
+  const payload = {
+    op: OPCODE.RESUME,
+    d: {
+      token: await getIdentifyToken(),
+      session_id: sessionId,
+      seq: latestSeq || 0
+    }
+  };
+  sendWs(payload);
+  startHeartbeat();
+  log('已发送 Resume。');
+}
+
+function sendHeartbeat() {
+  sendWs({
+    op: OPCODE.HEARTBEAT,
+    d: latestSeq
+  });
+}
+
+function startHeartbeat() {
+  clearHeartbeat();
+  const interval = Math.max(5000, heartbeatInterval || 45000);
+  heartbeatTimer = setInterval(() => {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    sendHeartbeat();
+  }, interval);
+  if (heartbeatTimer.unref) heartbeatTimer.unref();
+}
+
+function clearHeartbeat() {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+}
+
+function sendWs(payload) {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+  ws.send(JSON.stringify(payload));
+  return true;
+}
+
+function handleDispatch(payload) {
+  const eventType = payload.t;
+  if (eventType === 'READY') {
+    sessionId = payload.d && payload.d.session_id ? payload.d.session_id : sessionId;
+    readyUser = payload.d && payload.d.user ? payload.d.user : readyUser;
+    retryCount = 0;
+    sendHeartbeat();
+    updatePlaceholders();
+    log('Gateway READY:', payload.d);
+    return;
+  }
+
+  if (eventType === 'RESUMED') {
+    retryCount = 0;
+    updatePlaceholders();
+    log('Gateway RESUMED。');
+    return;
+  }
+
+  if (eventType === 'C2C_MESSAGE_CREATE') {
+    const event = normalizeC2CEvent(payload);
+    if (!event) return;
+    handleC2CMessage(event).catch(error => {
+      lastError = error.message;
+      warn('处理 C2C 消息失败:', error.message);
+      addRecent({
+        direction: 'error',
+        openid: event.openid,
+        type: 'C2C_MESSAGE_CREATE',
+        error: error.message
+      });
+    });
+    return;
+  }
+
+  if (eventType === 'GROUP_AT_MESSAGE_CREATE') {
+    const event = normalizeGroupAtEvent(payload);
+    if (!event) return;
+    if (event.messageId) {
+      groupLastAtMsgId.set(event.groupOpenid, { msgId: event.messageId, ts: Date.now() });
+    }
+    event.replyMsgId = event.messageId;
+    // 立即预设窗口，避免 AI 处理期间的跟进消息漏掉
+    const preWindowSizeAt = normalizeInteger(config.QQBotGroupEngageWindow, 0);
+    if (preWindowSizeAt > 0) {
+      groupEngageWindows.set(event.groupOpenid, preWindowSizeAt);
+    }
+    handleGroupAtMessage(event).catch(error => {
+      lastError = error.message;
+      warn('处理群@消息失败:', error.message);
+    });
+    return;
+  }
+
+  if (eventType === 'GROUP_MESSAGE_CREATE') {
+    log('[GMC] 收到群消息，group:', (payload.d||{}).group_openid, 'content:', String((payload.d||{}).content||'').slice(0,40));
+    const d = payload.d || {};
+    saveKnownGroup(d.group_openid || d.group_id);
+    const content = String(d.content || '');
+    const mentions = Array.isArray(d.mentions) ? d.mentions : [];
+    const botId = readyUser && readyUser.id ? String(readyUser.id) : '';
+    // 只处理 @机器人 的消息（mentions 标记 bot:true，或内容含 <@!botId>，或文本含机器人显示名——兼容机器人间@不带结构化mention的情况）
+    const botDisplayName = String(config.QQBotDisplayName || '').trim();
+    const isBotMentioned = mentions.some(m => m.bot === true)
+      || (botId && content.includes('<@!' + botId + '>'))
+      || (botDisplayName && content.includes('@' + botDisplayName));
+    if (debugMode) {
+      log('[DBG] GROUP_MESSAGE_CREATE content:', content.slice(0, 80),
+          'botId:', botId, 'mentioned:', isBotMentioned,
+          'mentions:', JSON.stringify(mentions).slice(0, 120));
+    }
+    const engageWindow = normalizeInteger(config.QQBotGroupEngageWindow, 0);
+    const remaining = groupEngageWindows.get(d.group_openid || d.group_id || '') || 0;
+    const shouldRespond = isBotMentioned || remaining > 0;
+    log('[DBG-WIN] group:', d.group_openid, 'remaining:', remaining, 'shouldRespond:', shouldRespond, 'engageWindow:', engageWindow);
+
+    // 每来一条消息都消耗窗口（无论是否响应）
+    if (remaining > 0) {
+      groupEngageWindows.set(d.group_openid || d.group_id || '', remaining - 1);
+    }
+
+    if (!shouldRespond) return;
+
+    const event = normalizeGroupAtEvent(payload);
+    if (!event) return;
+
+    if (isBotMentioned) {
+      // @mention：保存 msg_id，供窗口期回复使用
+      if (event.messageId) {
+        groupLastAtMsgId.set(event.groupOpenid, { msgId: event.messageId, ts: Date.now() });
+      }
+      event.replyMsgId = event.messageId;
+      // 立即预设窗口，避免 AI 处理期间的跟进消息漏掉
+      const preWindowSize = normalizeInteger(config.QQBotGroupEngageWindow, 0);
+      if (preWindowSize > 0) {
+        groupEngageWindows.set(event.groupOpenid, preWindowSize);
+        log('[DBG-WIN-SET] @mention 预设窗口 group:', event.groupOpenid, 'size:', preWindowSize);
+      }
+    } else {
+      // 窗口期：走主动消息，无需 msg_id（需"机器人主动在群聊内发言"权限）
+      event.replyMsgId = null;
+    }
+
+    handleGroupAtMessage(event).catch(error => {
+      lastError = error.message;
+      warn('处理群消息失败:', error.message);
+    });
+    return;
+  }
+
+  if (eventType === 'GROUP_MEMBER_ADD') {
+    handleGroupMemberAdd(payload).catch(error => {
+      lastError = error.message;
+      warn('处理群成员加入失败:', error.message);
+    });
+    return;
+  }
+
+  log('忽略 Dispatch:', eventType);
+}
+
+function normalizeC2CEvent(payload) {
+  const d = payload.d || {};
+  const author = d.author || {};
+  const openid = d.openid || d.author_openid || d.user_openid || author.user_openid || author.openid || author.id;
+  const content = String(d.content || d.text || '').trim();
+  const messageId = d.id || d.msg_id || payload.id || '';
+  const attachments = Array.isArray(d.attachments) ? d.attachments : [];
+  if (!openid) {
+    warn('C2C 事件缺少 openid:', d);
+    return null;
+  }
+  return {
+    eventId: payload.id || '',
+    eventType: payload.t,
+    seq: payload.s,
+    openid: String(openid),
+    messageId: String(messageId || ''),
+    content,
+    attachments,
+    author,
+    raw: d
+  };
+}
+
+function isAllowedOpenid(openid) {
+  const allowList = splitList(config.QQBotAllowList);
+  if (allowList.length === 0) return true;
+  return allowList.includes(String(openid));
+}
+
+async function handleC2CMessage(event) {
+  if (!isAllowedOpenid(event.openid)) {
+    log('跳过未授权 openid:', event.openid);
+    addRecent({
+      direction: 'in_ignored',
+      openid: event.openid,
+      type: event.eventType,
+      content: event.content || '[非文本消息]'
+    });
+    return;
+  }
+
+  const lockKey = `c2c:${event.openid}`;
+  if (processingLocks.has(lockKey)) {
+    await sendC2CText(event.openid, '我正在处理你上一条消息，请稍等一下。', event.messageId);
+    return;
+  }
+
+  processingLocks.add(lockKey);
+  addRecent({
+    direction: 'in',
+    openid: event.openid,
+    type: event.eventType,
+    content: event.content || summarizeAttachments(event.attachments)
+  });
+
+  try {
+    const userText = buildUserMessageText(event);
+    appendHistory(event.openid, { role: 'user', content: userText });
+
+    const aiText = await callVcpChat(event.openid);
+    appendHistory(event.openid, { role: 'assistant', content: aiText });
+
+    addRecent({
+      direction: 'out_ai',
+      openid: event.openid,
+      type: 'assistant',
+      content: aiText
+    });
+
+    await sendAiReplyToQQ(event.openid, aiText, event.messageId);
+  } catch (error) {
+    lastError = error.message;
+    warn('C2C 对话处理失败:', error.message);
+    await sendC2CText(event.openid, `处理消息时出错：${error.message}`, event.messageId).catch(sendError => {
+      warn('发送错误提示失败:', sendError.message);
+    });
+  } finally {
+    processingLocks.delete(lockKey);
+    updatePlaceholders();
+  }
+}
+
+function normalizeGroupAtEvent(payload) {
+  const d = payload.d || {};
+  const author = d.author || {};
+  const groupOpenid = d.group_openid || d.group_id;
+  const memberOpenid = author.member_openid || author.user_openid || author.openid;
+  // 去掉开头的 @bot mention token（<@!xxx> 格式）
+  const content = String(d.content || '').replace(/^<@!\w+>\s*/, '').trim();
+  const messageId = d.id || d.msg_id || '';
+  const attachments = Array.isArray(d.attachments) ? d.attachments : [];
+  if (!groupOpenid) {
+    warn('GROUP_AT 事件缺少 group_openid:', d);
+    return null;
+  }
+  return {
+    eventId: payload.id || '',
+    eventType: payload.t,
+    seq: payload.s,
+    groupOpenid: String(groupOpenid),
+    memberOpenid: memberOpenid ? String(memberOpenid) : 'unknown',
+    messageId: String(messageId),
+    content,
+    attachments,
+    author,
+    raw: d
+  };
+}
+
+async function handleGroupAtMessage(event) {
+  const lockKey = `group:${event.groupOpenid}`;
+  if (processingLocks.has(lockKey)) {
+    await sendGroupText(event.groupOpenid, '我正在处理上一条消息，请稍等...', null);
+    return;
+  }
+  processingLocks.add(lockKey);
+
+  addRecent({
+    direction: 'in',
+    openid: `${event.groupOpenid}/${event.memberOpenid}`,
+    type: 'GROUP_AT_MESSAGE_CREATE',
+    content: event.content || '[附件消息]'
+  });
+
+  try {
+    const historyKey = `group_${event.groupOpenid}`;
+    const lines = [
+      `QQ群 openid：${event.groupOpenid}`,
+      `发言成员 openid：${event.memberOpenid}`
+    ];
+    if (event.content) {
+      lines.push('');
+      lines.push('成员消息（群@消息）：');
+      lines.push(event.content);
+    }
+
+    appendHistory(historyKey, { role: 'user', content: lines.join('\n') });
+    const aiText = await callVcpChat(historyKey);
+    appendHistory(historyKey, { role: 'assistant', content: aiText });
+
+    addRecent({
+      direction: 'out_ai',
+      openid: event.groupOpenid,
+      type: 'assistant',
+      content: aiText
+    });
+
+    const delayMs = normalizeInteger(config.QQBotSendDelayMs, 800);
+    if (delayMs > 0) await sleep(delayMs);
+
+    const replyId = event.replyMsgId ?? event.messageId;
+    const parts = splitAiReplyToParts(aiText);
+    if (parts.length === 0) {
+      await sendGroupText(event.groupOpenid, aiText || '（空回复）', replyId);
+    } else {
+      for (const [i, part] of parts.entries()) {
+        if (i > 0 && delayMs > 0) await sleep(delayMs);
+        if (part.type === 'image') {
+          if (String(config.QQBotImageMode || 'upload').toLowerCase() === 'text') {
+            await sendGroupText(event.groupOpenid, part.url, replyId);
+          } else {
+            await sendGroupImage(event.groupOpenid, part.url, replyId);
+          }
+        } else if (part.type === 'text' && part.text) {
+          await sendGroupText(event.groupOpenid, part.text, replyId);
+        }
+      }
+    }
+  } catch (error) {
+    lastError = error.message;
+    const errBody = error.response?.data ? JSON.stringify(error.response.data).slice(0, 300) : '';
+    warn('群@消息处理失败:', error.message, errBody);
+    const replyId = event.replyMsgId ?? event.messageId;
+    await sendGroupText(event.groupOpenid, `处理消息时出错：${error.message}`, replyId).catch(e => {
+      warn('发送群错误提示失败:', e.message);
+    });
+  } finally {
+    processingLocks.delete(lockKey);
+    // 机器人回复后重置参与窗口
+    const windowSize = normalizeInteger(config.QQBotGroupEngageWindow, 0);
+    if (windowSize > 0) {
+      groupEngageWindows.set(event.groupOpenid, windowSize);
+      log('[DBG-WIN-RST] 回复后重置窗口 group:', event.groupOpenid, 'size:', windowSize);
+    }
+    updatePlaceholders();
+  }
+}
+
+async function handleGroupMemberAdd(payload) {
+  const d = payload.d || {};
+  const groupOpenid = d.group_openid || d.group_id;
+  const memberOpenid = d.op_member_openid || d.member_openid;
+  const eventId = payload.id || '';
+  if (!groupOpenid) return;
+
+  const delayMs = normalizeInteger(config.QQBotSendDelayMs, 800);
+  if (delayMs > 0) await sleep(delayMs);
+
+  const welcomeMsg = [
+    '欢迎新成员加入！👋',
+    '🎮 群文件里有各种游戏资源，进群先去翻翻！',
+    '📢 记得看群公告，里面有重要规则和活动信息！',
+    '🌐 群主博客：https://your-domain.com/'
+  ].join('\n');
+  await sendGroupText(groupOpenid, welcomeMsg, null, eventId);
+
+  addRecent({
+    direction: 'out',
+    openid: groupOpenid,
+    type: 'group_welcome',
+    content: `新成员 ${memberOpenid || 'unknown'} 进群`
+  });
+}
+
+function summarizeAttachments(attachments) {
+  if (!attachments || attachments.length === 0) return '[空消息]';
+  return `[附件 ${attachments.length} 个]`;
+}
+
+function buildUserMessageText(event) {
+  const lines = [];
+  lines.push(`QQ 单聊用户 openid：${event.openid}`);
+  if (event.author && Object.keys(event.author).length > 0) {
+    lines.push(`QQ 用户信息：${JSON.stringify(event.author)}`);
+  }
+  if (event.content) {
+    lines.push('');
+    lines.push('用户消息：');
+    lines.push(event.content);
+  }
+  if (event.attachments && event.attachments.length > 0) {
+    lines.push('');
+    lines.push('用户发送的附件：');
+    event.attachments.forEach((att, index) => {
+      lines.push(`${index + 1}. ${JSON.stringify(att)}`);
+    });
+  }
+  return lines.join('\n');
+}
+
+function appendHistory(openid, message) {
+  const key = String(openid);
+  const history = histories.get(key) || [];
+  history.push(message);
+  const turns = normalizeInteger(config.QQBotHistoryTurns, 8);
+  const maxMessages = Math.max(2, turns * 2);
+  histories.set(key, history.slice(-maxMessages));
+}
+
+function getHistory(openid) {
+  return histories.get(String(openid)) || [];
+}
+
+async function callVcpChat(openid) {
+  const port = config.PORT;
+  const key = config.Key;
+  if (!port || !key) throw new Error('VCP PORT 或 Key 未注入。');
+
+  const systemPrompt = String(config.QQBotSystemPrompt || DEFAULT_SYSTEM_PROMPT).trim();
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    ...getHistory(openid)
+  ];
+
+  const payload = {
+    messages,
+    stream: false,
+    user: `qq_c2c_${openid}`,
+    vcpchatExtensions: {
+      frontend: 'VCPQQBotServer',
+      conversationKey: `qq_c2c_${openid}`,
+      qqOpenid: openid
+    }
+  };
+
+  if (config.QQBotModel) payload.model = String(config.QQBotModel).trim();
+
+  const response = await axios.post(`http://127.0.0.1:${port}/v1/chat/completions`, payload, {
+    headers: {
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json'
+    },
+    timeout: normalizeInteger(config.QQBotRequestTimeoutMs, 300000)
+  });
+
+  const rawText = extractAssistantText(response.data);
+  if (!rawText) throw new Error(`VCP 主服务器返回空回复：${JSON.stringify(response.data).slice(0, 500)}`);
+  // 兜底:剥离任何残留工具协议块,群里只发可见自然语言
+  return sanitizeForQQ(rawText);
+}
+
+// 兜底:剥离所有 VCP 工具协议块,保证群里绝不出现 <<<[...>>> / [本轮工具调用摘要:] 等标记。
+// 即使主服务 clientResponseRenderer 漏处理,这层是最后防线。
+function sanitizeForQQ(text) {
+  if (!text || typeof text !== 'string') return text;
+  let out = text;
+  // 完整工具请求块(含 _ESCAPE 变体)
+  out = out.replace(/<{2,4}\[TOOL_REQUEST(?:_ESCAPE)?\]>{2,4}[\s\S]*?<{2,4}\[END_TOOL_REQUEST(?:_ESCAPE)?\]>{2,4}/g, '');
+  // 工具调用摘要块
+  out = out.replace(/\[本轮工具调用摘要[:：]\][\s\S]*?\[本轮工具调用摘要结束\]/g, '');
+  // 角色分割标记
+  out = out.replace(/<{2,4}\[(?:END_)?ROLE_DIVIDE_USER\]>{2,4}/g, '');
+  // VCP 工具信息展示块
+  out = out.replace(/<!--\s*VCP_TOOL_PAYLOAD\s*-->[\s\S]*?(?=<{2,4}\[END_|$)/g, '');
+  // 多余空行压缩
+  out = out.replace(/\n{3,}/g, '\n\n');
+  return out.trim();
+}
+
+function extractAssistantText(data) {
+  if (!data) return '';
+  if (typeof data === 'string') return data;
+  const choice = Array.isArray(data.choices) ? data.choices[0] : null;
+  const message = choice && choice.message ? choice.message : null;
+  const content = message ? message.content : data.content || data.result || data.message;
+  return contentToText(content).trim();
+}
+
+function contentToText(content) {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map(part => {
+      if (!part) return '';
+      if (typeof part === 'string') return part;
+      if (part.type === 'text') return part.text || '';
+      if (part.text) return part.text;
+      if (part.type === 'image_url' && part.image_url && part.image_url.url) return part.image_url.url;
+      return '';
+    }).filter(Boolean).join('\n');
+  }
+  if (content && typeof content === 'object') {
+    if (typeof content.text === 'string') return content.text;
+    try {
+      return JSON.stringify(content);
+    } catch (_) {
+      return String(content);
+    }
+  }
+  return '';
+}
+
+async function sendAiReplyToQQ(openid, aiText, msgId) {
+  const parts = splitAiReplyToParts(aiText);
+  if (parts.length === 0) {
+    await sendC2CText(openid, aiText || '（空回复）', msgId);
+    return;
+  }
+
+  const delayMs = normalizeInteger(config.QQBotSendDelayMs, 800);
+  for (const [index, part] of parts.entries()) {
+    if (index > 0 && delayMs > 0) await sleep(delayMs);
+    if (part.type === 'image') {
+      if (String(config.QQBotImageMode || 'upload').toLowerCase() === 'text') {
+        await sendC2CText(openid, part.url, msgId);
+      } else {
+        await sendC2CImage(openid, part.url, msgId);
+      }
+    } else if (part.text && part.text.trim()) {
+      await sendC2CText(openid, part.text.trim(), msgId);
+    }
+  }
+}
+
+function splitAiReplyToParts(text) {
+  const raw = String(text || '');
+  const tokens = [];
+  const ranges = [];
+
+  const patterns = [
+    /!\[[^\]]*]\((https?:\/\/[^\s)]+)\)/gi,
+    /<img\b[^>]*\bsrc=["'](https?:\/\/[^"']+)["'][^>]*>/gi,
+    /(https?:\/\/[^\s"'<>，。！？）\]\}]+?\.(?:png|jpe?g|gif|webp|bmp)(?:\?[^\s"'<>，。！？）\]\}]*)?)/gi
+  ];
+
+  for (const pattern of patterns) {
+    let match;
+    while ((match = pattern.exec(raw))) {
+      const url = match[1];
+      if (!url) continue;
+      ranges.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        url
+      });
+    }
+  }
+
+  ranges.sort((a, b) => a.start - b.start || b.end - a.end);
+  const selected = [];
+  let cursor = 0;
+  for (const range of ranges) {
+    if (range.start < cursor) continue;
+    selected.push(range);
+    cursor = range.end;
+  }
+
+  cursor = 0;
+  for (const range of selected) {
+    const before = raw.slice(cursor, range.start);
+    pushTextParts(tokens, cleanupText(before));
+    tokens.push({ type: 'image', url: range.url });
+    cursor = range.end;
+  }
+  pushTextParts(tokens, cleanupText(raw.slice(cursor)));
+
+  return mergeAdjacentText(tokens);
+}
+
+function cleanupText(text) {
+  return String(text || '')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function pushTextParts(parts, text) {
+  if (!text) return;
+  const maxChars = normalizeInteger(config.QQBotMaxReplyChars, 1200);
+  for (const chunk of splitLongText(text, maxChars)) {
+    if (chunk.trim()) parts.push({ type: 'text', text: chunk.trim() });
+  }
+}
+
+function splitLongText(text, maxChars) {
+  const result = [];
+  const normalized = String(text || '').trim();
+  if (!normalized) return result;
+
+  const paragraphs = normalized.split(/\n{2,}/);
+  for (const paragraph of paragraphs) {
+    pushChunk(result, paragraph.trim(), maxChars);
+  }
+  return result;
+}
+
+function pushChunk(result, text, maxChars) {
+  if (!text) return;
+  if (text.length <= maxChars) {
+    result.push(text);
+    return;
+  }
+
+  const lines = text.split(/\n/);
+  if (lines.length > 1) {
+    let buffer = '';
+    for (const line of lines) {
+      if ((buffer + '\n' + line).trim().length > maxChars) {
+        if (buffer.trim()) result.push(buffer.trim());
+        buffer = line;
+      } else {
+        buffer = buffer ? `${buffer}\n${line}` : line;
+      }
+    }
+    if (buffer.trim()) result.push(buffer.trim());
+    return;
+  }
+
+  const sentences = text.split(/(?<=[。！？.!?])/);
+  if (sentences.length > 1) {
+    let buffer = '';
+    for (const sentence of sentences) {
+      if ((buffer + sentence).length > maxChars) {
+        if (buffer.trim()) result.push(buffer.trim());
+        buffer = sentence;
+      } else {
+        buffer += sentence;
+      }
+    }
+    if (buffer.trim()) result.push(buffer.trim());
+    return;
+  }
+
+  for (let i = 0; i < text.length; i += maxChars) {
+    result.push(text.slice(i, i + maxChars));
+  }
+}
+
+function mergeAdjacentText(parts) {
+  const result = [];
+  for (const part of parts) {
+    const last = result[result.length - 1];
+    if (part.type === 'text' && last && last.type === 'text') {
+      last.text = `${last.text}\n\n${part.text}`.trim();
+    } else {
+      result.push(part);
+    }
+  }
+  return result;
+}
+
+async function sendC2CText(openid, content, msgId) {
+  const payload = {
+    msg_type: 0,
+    content: String(content || '')
+  };
+  if (msgId) {
+    payload.msg_id = String(msgId);
+    payload.msg_seq = getC2CMsgSeq(openid, msgId);
+  }
+
+  const response = await axios.post(`${getBaseUrl()}/v2/users/${encodeURIComponent(openid)}/messages`, payload, {
+    headers: await getRequestHeaders(),
+    timeout: 30000
+  });
+
+  addRecent({
+    direction: 'out',
+    openid,
+    type: 'text',
+    content
+  });
+  return response.data;
+}
+
+/** 提取 axios 请求失败的真实原因：QQ API 通常在 response.data 里给 {code,message}，
+ *  之前只拿 e.message 会丢掉这些信息，变成没法诊断的 "Request failed with status code 400"。 */
+function formatSendError(e) {
+  if (e && e.response) {
+    const status = e.response.status;
+    let detail = '';
+    try {
+      const data = e.response.data;
+      detail = typeof data === 'string' ? data : JSON.stringify(data);
+    } catch { /* ignore */ }
+    return `HTTP ${status}${detail ? ' ' + detail : ''}`;
+  }
+  return e && e.message ? e.message : String(e);
+}
+
+async function sendGroupText(groupOpenid, content, msgId, eventId) {
+  const payload = {
+    msg_type: 0,
+    content: String(content || '')
+  };
+  if (msgId) {
+    payload.msg_id = String(msgId);
+    payload.msg_seq = getNextMsgSeq(groupOpenid, msgId);
+  } else if (eventId) {
+    payload.event_id = String(eventId);
+  }
+
+  const response = await axios.post(
+    `${getBaseUrl()}/v2/groups/${encodeURIComponent(groupOpenid)}/messages`,
+    payload,
+    { headers: await getRequestHeaders(), timeout: 30000 }
+  );
+  addRecent({
+    direction: 'out',
+    openid: groupOpenid,
+    type: 'group_text',
+    content
+  });
+  return response.data;
+}
+
+// 表情包文件名模糊匹配:flash模型常编造不存在的文件名(如比心.jpeg,实际只有比心.png),
+// 导致QQ拉取404。上传前检查文件是否存在,不存在按相似度匹配真实文件。
+const fs = require('fs');
+const path = require('path');
+let sharp;
+try { sharp = require('../../node_modules/sharp'); } catch (_) { sharp = null; } // 图片压缩兜底,可选
+const IMAGE_ROOT = path.join(__dirname, '..', '..', 'image');
+const emojiDirCache = new Map(); // dir -> 文件名数组
+
+function listEmojiDir(dirRel) {
+  if (emojiDirCache.has(dirRel)) return emojiDirCache.get(dirRel);
+  const absDir = path.join(IMAGE_ROOT, dirRel);
+  let files = [];
+  try { files = fs.readdirSync(absDir).filter(f => fs.statSync(path.join(absDir, f)).isFile()); }
+  catch (_) { files = []; }
+  emojiDirCache.set(dirRel, files);
+  return files;
+}
+
+// Levenshtein编辑距离(小规模文件名用,性能可接受)
+function editDistance(a, b) {
+  const m = a.length, n = b.length;
+  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = a[i-1] === b[j-1] ? dp[i-1][j-1] : 1 + Math.min(dp[i-1][j-1], dp[i-1][j], dp[i][j-1]);
+    }
+  }
+  return dp[m][n];
+}
+
+// 解析子路径(如 通用表情包/比心.jpeg),检查文件是否存在,不存在模糊匹配。
+// 返回修正后的子路径(可能换文件名),匹配不到返回原值(让上游404回退)。
+function resolveEmojiFile(subpath) {
+  if (!subpath) return subpath;
+  const absPath = path.join(IMAGE_ROOT, subpath);
+  try {
+    if (fs.existsSync(absPath)) return subpath; // 文件存在,无需修正
+  } catch (_) {}
+  // 拆出目录和文件名
+  const sep = subpath.lastIndexOf('/');
+  const dirRel = sep >= 0 ? subpath.slice(0, sep) : '';
+  const fileName = sep >= 0 ? subpath.slice(sep + 1) : subpath;
+  const files = listEmojiDir(dirRel);
+  if (files.length === 0) return subpath;
+  // 优先级1:同名不同扩展名(比心.jpeg -> 比心.png)
+  const dot = fileName.lastIndexOf('.');
+  const stem = dot > 0 ? fileName.slice(0, dot) : fileName;
+  const sameStem = files.filter(f => {
+    const fd = f.lastIndexOf('.');
+    return (fd > 0 ? f.slice(0, fd) : f) === stem;
+  });
+  if (sameStem.length > 0) {
+    return (dirRel ? dirRel + '/' : '') + sameStem[0];
+  }
+  // 优先级2:编辑距离最近(阈值<=2,避免离谱匹配)
+  let best = null, bestDist = 3;
+  for (const f of files) {
+    const d = editDistance(fileName, f);
+    if (d < bestDist) { bestDist = d; best = f; }
+  }
+  if (best) {
+    return (dirRel ? dirRel + '/' : '') + best;
+  }
+  return subpath; // 匹配不到,返回原值
+}
+
+// 从 imageUrl 解析本地文件路径(复用 resolveEmojiFile 模糊匹配),读为 Buffer。
+// 返回 {buf, subpath} 或 null(非本地URL/文件不存在)。
+function readLocalImage(imageUrl) {
+  const m = String(imageUrl || '').match(/\/pw=[^/]+\/images\/(.+)$/);
+  if (!m) return null; // 非鉴权图片URL,无法定位本地文件
+  const subpath = resolveEmojiFile(m[1]);
+  const absPath = path.join(IMAGE_ROOT, subpath);
+  try {
+    if (!fs.existsSync(absPath)) return null;
+    const buf = fs.readFileSync(absPath);
+    return { buf, subpath };
+  } catch (_) { return null; }
+}
+
+// 用 sharp 压缩图片到目标大小(默认150KB)。GIF 跳过(动图压缩丢帧)。
+// 返回压缩后的 Buffer,失败返回 null。
+async function compressImage(buf, targetKB = 150) {
+  if (!sharp || !buf) return null;
+  const subpath = arguments[2] || '';
+  if (/\.gif$/i.test(subpath)) return null; // GIF 不压缩
+  try {
+    const targetBytes = targetKB * 1024;
+    // 先尝试 jpeg 质量80,再降;png 用调色板
+    let out = await sharp(buf, { animated: false })
+      .resize({ width: 400, withoutEnlargement: true }) // 限制宽度,表情包够用
+      .jpeg({ quality: 80, mozjpeg: true })
+      .toBuffer();
+    if (out.length > targetBytes) {
+      out = await sharp(buf, { animated: false })
+        .resize({ width: 320, withoutEnlargement: true })
+        .jpeg({ quality: 60, mozjpeg: true })
+        .toBuffer();
+    }
+    return out;
+  } catch (e) {
+    warn('sharp压缩失败:', e.message);
+    return null;
+  }
+}
+
+// file_data base64 直传上传(群)。返回 file_info 或抛错。
+async function uploadGroupImageByFileData(groupOpenid, buf) {
+  const payload = {
+    file_type: 1,
+    file_data: buf.toString('base64'),
+    srv_send_msg: false
+  };
+  const response = await axios.post(
+    `${getBaseUrl()}/v2/groups/${encodeURIComponent(groupOpenid)}/files`,
+    payload,
+    { headers: await getRequestHeaders(), timeout: 60000 }
+  );
+  return response.data;
+}
+
+// file_data base64 直传上传(C2C)。返回 file_info 或抛错。
+async function uploadC2CImageByFileData(openid, buf) {
+  const payload = {
+    file_type: 1,
+    file_data: buf.toString('base64'),
+    srv_send_msg: false
+  };
+  const response = await axios.post(
+    `${getBaseUrl()}/v2/users/${encodeURIComponent(openid)}/files`,
+    payload,
+    { headers: await getRequestHeaders(), timeout: 60000 }
+  );
+  return response.data;
+}
+
+// 统一的 file_data 直传 + 压缩兜底(群)。返回 file_info 或 null。
+async function uploadGroupImageSmart(groupOpenid, imageUrl) {
+  const local = readLocalImage(imageUrl);
+  if (local) {
+    // 优先 file_data 直传原图
+    try {
+      const up = await uploadGroupImageByFileData(groupOpenid, local.buf);
+      const fi = up.file_info || up.fileInfo || up.data?.file_info || up.data?.fileInfo;
+      if (fi) { console.log("[VCPQQBotServer] 群图片file_data直传成功:", local.subpath, "("+local.buf.length+"字节)"); return fi; }
+      throw new Error('群file_data上传未返回file_info');
+    } catch (e1) {
+      // 原图失败(可能过大) -> sharp压缩再直传
+      const compressed = await compressImage(local.buf, 150, local.subpath);
+      if (compressed) {
+        try {
+          const up2 = await uploadGroupImageByFileData(groupOpenid, compressed);
+          const fi2 = up2.file_info || up2.fileInfo || up2.data?.file_info || up2.data?.fileInfo;
+          if (fi2) return fi2;
+        } catch (e2) {
+          warn('群图片压缩后直传仍失败:', e2.message);
+        }
+      }
+      // 压缩也失败或不可用,回退URL方式
+      warn('群图片file_data直传失败,回退URL方式:', e1.message);
+    }
+  }
+  // 非本地URL 或 file_data全失败 -> 回退URL上传
+  const publicUrl = toPublicImageUrl(imageUrl) || imageUrl;
+  const payload = { file_type: 1, url: publicUrl, srv_send_msg: false };
+  const response = await axios.post(
+    `${getBaseUrl()}/v2/groups/${encodeURIComponent(groupOpenid)}/files`,
+    payload,
+    { headers: await getRequestHeaders(), timeout: 60000 }
+  );
+  const fi = response.data.file_info || response.data.fileInfo || response.data?.file_info || response.data?.fileInfo;
+  return fi || null;
+}
+
+// 统一的 file_data 直传 + 压缩兜底(C2C)。返回 file_info 或 null。
+async function uploadC2CImageSmart(openid, imageUrl) {
+  const local = readLocalImage(imageUrl);
+  if (local) {
+    try {
+      const up = await uploadC2CImageByFileData(openid, local.buf);
+      const fi = up.file_info || up.fileInfo || up.data?.file_info || up.data?.fileInfo;
+      if (fi) { console.log("[VCPQQBotServer] C2C图片file_data直传成功:", local.subpath, "("+local.buf.length+"字节)"); return fi; }
+      throw new Error('C2C file_data上传未返回file_info');
+    } catch (e1) {
+      const compressed = await compressImage(local.buf, 150, local.subpath);
+      if (compressed) {
+        try {
+          const up2 = await uploadC2CImageByFileData(openid, compressed);
+          const fi2 = up2.file_info || up2.fileInfo || up2.data?.file_info || up2.data?.fileInfo;
+          if (fi2) return fi2;
+        } catch (e2) {
+          warn('C2C图片压缩后直传仍失败:', e2.message);
+        }
+      }
+      warn('C2C图片file_data直传失败,回退URL方式:', e1.message);
+    }
+  }
+  const publicUrl = toPublicImageUrl(imageUrl) || imageUrl;
+  const payload = { file_type: 1, url: publicUrl, srv_send_msg: false };
+  const response = await axios.post(
+    `${getBaseUrl()}/v2/users/${encodeURIComponent(openid)}/files`,
+    payload,
+    { headers: await getRequestHeaders(), timeout: 60000 }
+  );
+  const fi = response.data.file_info || response.data.fileInfo || response.data?.file_info || response.data?.fileInfo;
+  return fi || null;
+}
+
+function toPublicImageUrl(url) {
+  // 把 VCP 鉴权图片 URL 转成 Nginx /stickers/ 公开路径
+  // 输入: https://domain:6005/pw=KEY/images/subdir/file.ext
+  // 输出: https://domain/stickers/<encoded subpath>
+  // 修复:对中文子路径做 encodeURI,否则 QQ 服务器拉取时 express.static 中文路径返回 400
+  const m = String(url || '').match(/\/pw=[^/]+\/images\/(.+)$/);
+  if (!m) return url;
+  const base = String(config.QQBotPublicBaseUrl || '').replace(/\/$/, '');
+  if (!base) return url; // 未配置则不转换
+  return `${base}/stickers/${encodeURI(resolveEmojiFile(m[1]))}`;
+}
+
+async function uploadGroupImageByUrl(groupOpenid, imageUrl) {
+  const payload = {
+    file_type: 1,
+    url: imageUrl,
+    srv_send_msg: false
+  };
+  const response = await axios.post(
+    `${getBaseUrl()}/v2/groups/${encodeURIComponent(groupOpenid)}/files`,
+    payload,
+    { headers: await getRequestHeaders(), timeout: 60000 }
+  );
+  return response.data;
+}
+
+async function sendGroupImage(groupOpenid, imageUrl, msgId, eventId) {
+  try {
+    const fileInfo = await uploadGroupImageSmart(groupOpenid, imageUrl);
+    if (!fileInfo) throw new Error('群图片上传未返回 file_info(直传+URL均失败)');
+
+    const payload = { msg_type: 7, media: { file_info: fileInfo } };
+    if (msgId) {
+      payload.msg_id = String(msgId);
+      payload.msg_seq = getNextMsgSeq(groupOpenid, msgId);
+    } else if (eventId) {
+      payload.event_id = String(eventId);
+    }
+
+    const response = await axios.post(
+      `${getBaseUrl()}/v2/groups/${encodeURIComponent(groupOpenid)}/messages`,
+      payload,
+      { headers: await getRequestHeaders(), timeout: 30000 }
+    );
+    addRecent({ direction: 'out', openid: groupOpenid, type: 'group_image', content: imageUrl });
+    return response.data;
+  } catch (error) {
+    // 修复:回退时禁止泄露鉴权URL(pw=KEY)。优先用已转换的公开URL;
+    // 若未配置 QQBotPublicBaseUrl 导致 publicUrl 为原始鉴权URL,则发占位提示,绝不把密钥发到群里。
+    // 硬约束:绝不回退成 [图片: URL] 文本链接(QQ显示不了,只显示一行字)。
+    // 上传失败静默跳过(只记日志),群里只看到文字部分或啥都不发。
+    warn('发送群图片失败(静默跳过,不发文本链接):', imageUrl, error.message);
+    return null;
+  }
+}
+
+async function sendC2CImage(openid, imageUrl, msgId) {
+  try {
+    const fileInfo = await uploadC2CImageSmart(openid, imageUrl);
+    if (!fileInfo) throw new Error('图片上传未返回 file_info(直传+URL均失败)');
+
+    const payload = {
+      msg_type: 7,
+      media: {
+        file_info: fileInfo
+      }
+    };
+    if (msgId) {
+      payload.msg_id = String(msgId);
+      payload.msg_seq = getC2CMsgSeq(openid, msgId);
+    }
+
+    const response = await axios.post(`${getBaseUrl()}/v2/users/${encodeURIComponent(openid)}/messages`, payload, {
+      headers: await getRequestHeaders(),
+      timeout: 30000
+    });
+
+    addRecent({
+      direction: 'out',
+      openid,
+      type: 'image',
+      content: imageUrl
+    });
+    return response.data;
+  } catch (error) {
+    // 修复:同 sendGroupImage,回退禁止泄露鉴权URL。
+    // 硬约束:同 sendGroupImage,绝不回退成 [图片: URL] 文本链接。静默跳过。
+    warn('发送 QQ 图片失败(静默跳过,不发文本链接):', imageUrl, error.message);
+    return null;
+  }
+}
+
+async function uploadC2CImageByUrl(openid, imageUrl) {
+  const payload = {
+    file_type: 1,
+    url: imageUrl,
+    srv_send_msg: false
+  };
+
+  const response = await axios.post(`${getBaseUrl()}/v2/users/${encodeURIComponent(openid)}/files`, payload, {
+    headers: await getRequestHeaders(),
+    timeout: 60000
+  });
+  return response.data;
+}
+
+function reconnectNow(reason) {
+  clearHeartbeat();
+  if (ws) {
+    try {
+      ws.close();
+    } catch (_) {}
+    ws = null;
+  }
+  scheduleReconnect(reason);
+}
+
+function scheduleReconnect(reason) {
+  if (stopped) return;
+  clearReconnectTimer();
+  const delays = [1000, 2000, 5000, 10000, 30000, 60000];
+  const delay = delays[Math.min(retryCount, delays.length - 1)];
+  retryCount += 1;
+  lastError = reason || lastError;
+  updatePlaceholders();
+  warn(`将在 ${delay}ms 后重连 QQ Gateway，原因：${reason || 'unknown'}`);
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connectGateway().catch(error => {
+      lastError = error.message;
+      warn('重连 QQ Gateway 失败:', error.message);
+      scheduleReconnect(error.message);
+    });
+  }, delay);
+  if (reconnectTimer.unref) reconnectTimer.unref();
+}
+
+function clearReconnectTimer() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function processToolCall(params = {}) {
+  const command = String(params.command || params.cmd || 'status').trim();
+  switch (command) {
+    case 'status':
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `${buildStatusText()}\n\n${buildRecentText()}`
+          }
+        ],
+        meta: {
+          plugin: 'VCPQQBotServer',
+          command: 'status'
+        }
+      };
+    case 'broadcast_to_groups': {
+      const content = String(params.content || '').trim();
+      if (!content) throw new Error('broadcast_to_groups 缺少 content 参数');
+      // 优先用 config 配置的群，没配置则用自动注册的群
+      const configGroups = splitList(config.QQBotBroadcastGroups);
+      const targetGroups = configGroups.length > 0 ? configGroups : [...knownGroups];
+      if (targetGroups.length === 0) throw new Error('未找到目标群，请先让 bot 在群里收到消息，或在 QQBotBroadcastGroups 配置群 ID');
+      const results = [];
+      for (const gid of targetGroups) {
+        const id = String(gid).trim();
+        if (!id) continue;
+        try {
+          await sendGroupText(id, content, null, null);
+          results.push(`✅ 群 ${id.slice(0, 8)}...: 发送成功`);
+        } catch (e) {
+          results.push(`❌ 群 ${id.slice(0, 8)}...: ${formatSendError(e)}`);
+        }
+      }
+      return {
+        content: [{ type: 'text', text: '群播结果（共' + targetGroups.length + '个群）：\n' + results.join('\n') }],
+        meta: { plugin: 'VCPQQBotServer', command: 'broadcast_to_groups', groups: targetGroups.length }
+      };
+    }
+    case 'broadcast_draft_file': {
+      const draftPath = __dirname + '/draft_morning_brief.txt';
+      let content;
+      try {
+        content = require('fs').readFileSync(draftPath, 'utf8').trim();
+      } catch (e) {
+        throw new Error('broadcast_draft_file 读取草稿文件失败: ' + e.message);
+      }
+      if (!content) throw new Error('broadcast_draft_file 草稿文件为空，请先执行撰写步骤');
+      const configGroups = splitList(config.QQBotBroadcastGroups);
+      const targetGroups = configGroups.length > 0 ? configGroups : [...knownGroups];
+      if (targetGroups.length === 0) throw new Error('未找到目标群，请先让 bot 在群里收到消息，或在 QQBotBroadcastGroups 配置群 ID');
+      const results = [];
+      for (const gid of targetGroups) {
+        const id = String(gid).trim();
+        if (!id) continue;
+        try {
+          await sendGroupText(id, content, null, null);
+          results.push('✅ 群 ' + id.slice(0, 8) + '...: 发送成功');
+        } catch (e) {
+          results.push('❌ 群 ' + id.slice(0, 8) + '...: ' + formatSendError(e));
+        }
+      }
+      return {
+        content: [{ type: 'text', text: '草稿群播结果（共' + targetGroups.length + '个群）：' + '\n' + results.join('\n') }],
+        meta: { plugin: 'VCPQQBotServer', command: 'broadcast_draft_file', groups: targetGroups.length }
+      };
+    }
+    default:
+      throw new Error(`未知 command: ${command}。QQ 单聊回复不需要工具调用，AI 正常输出自然语言即可。`);
+  }
+}
+
+async function shutdown() {
+  stopped = true;
+  clearHeartbeat();
+  clearReconnectTimer();
+  processingLocks.clear();
+  if (ws) {
+    try {
+      ws.close();
+    } catch (_) {}
+    ws = null;
+  }
+  updatePlaceholders();
+}
+
+module.exports = {
+  initialize,
+  processToolCall,
+  shutdown,
+  _private: {
+    splitAiReplyToParts,
+    extractAssistantText,
+    computeIntents,
+    buildUserMessageText
+  }
+};

--- a/Plugin/VCPQQBotServer/config.env.example
+++ b/Plugin/VCPQQBotServer/config.env.example
@@ -1,0 +1,82 @@
+# 从 QQ 开放平台获取 QQBot 鉴权
+# https://q.qq.com/qqbot/openclaw/index.html
+
+# QQBot AppID 和 Secret/Token
+QQAppID=
+QQAppSecret=
+
+# 可选：显式 Token；不填时使用 QQAppSecret
+QQBotToken=
+
+# 鉴权模式：
+# bot_app_token: 使用 Authorization/Identify token = Bot {QQAppID}.{QQBotToken或QQAppSecret}
+# access_token: 使用 token = QQBot {QQBotToken或QQAppSecret}
+QQBotAuthMode=bot_app_token
+
+# false=正式环境，true=沙箱环境
+QQBotSandbox=false
+
+# 单聊能力至少需要 GROUP_AND_C2C_EVENT；如无权限会导致 Gateway 拒绝连接
+QQBotIntents=GROUP_AND_C2C_EVENT
+
+# QQ 单聊入口默认模型；为空时由主 VCP/上游默认策略决定
+QQBotModel=
+
+# QQ 单聊入口系统提示词
+QQBotSystemPrompt=你是接入 QQ 单聊的 VCPQQBot。你正在通过 VCP 主服务器与 QQ 用户聊天。你可以自然聊天，也可以使用 VCP 工具协议完成任务。若回复中包含图片 URL、Markdown 图片或 HTML img 标签，系统会自动转成 QQ 图片发送。回复应适合 QQ 聊天场景，避免一次性输出过长文本。
+
+# 允许触发自动聊天的 QQ 用户 openid，逗号分隔；留空表示允许全部
+QQBotAllowList=
+
+# 每个 QQ 单聊会话保留最近多少轮 user/assistant 历史
+QQBotHistoryTurns=8
+
+# QQ 文本回复分段最大字符数
+QQBotMaxReplyChars=1200
+
+# 连续发送 QQ 消息间隔，避免频控
+QQBotSendDelayMs=800
+
+# 调用 VCP 主服务器 /v1/chat/completions 的超时
+QQBotRequestTimeoutMs=300000
+
+# AI 回复图片 URL 处理模式。
+# upload: 生产推荐。插件会尽量把图片转成真正的 QQ 图片消息：
+#   1) VCP 本地图床 URL -> 读取本地文件 -> QQ /files file_data(base64) 直传
+#   2) 原图直传失败 -> sharp 内存压缩到约150KB -> 再 file_data 直传
+#   3) 非本地图或直传全失败 -> QQ /files URL 上传兜底
+#   4) 仍失败 -> 静默跳过图片，绝不发送 [图片: URL] 文本链接
+# text: 调试用。只把图片 URL 当文本发送；群聊/生产环境不建议开启。
+QQBotImageMode=upload
+
+# 是否启用图片上传链路。当前实现使用 QQ /files 的 file_data 与 url 两种字段，
+# 不使用 multipart/form-data。生产保持 true。
+QQBotUploadImages=true
+
+# 调试日志
+DebugMode=false
+
+# ── 群聊相关（已实现，不只是单聊）──────────────────────────
+# bot 在群里被 @ 一次后，继续"无需再 @"参与接话的消息条数。
+# 例：设为10，@bot说话后，bot会持续关注该群接下来10条消息，期间无需再@也会接话；
+# 第10条之后窗口关闭，需要再 @ 才会唤醒。设为0=关闭追问窗口，每次都要@才回复。
+QQBotGroupEngageWindow=10
+
+# 机器人在 QQ 群里显示的昵称（纯文本，不带@符号）。
+# 用途：识别"其他机器人欢迎语里用纯文字提到本机器人名字"这种没有结构化@的情况
+# （结构化@由 QQ 平台自动识别，不需要这个；这个字段是给"文字提及但没真正@"的边界情况用的）。
+QQBotDisplayName=
+
+# 定时任务/早报等场景下，主动推送消息的目标群 openid，逗号分隔。
+# 留空 = 用"自动注册的群"（bot 收到过消息的群会被自动记录，无需手动配置）。
+# 只有当你想限定推送范围（比如只推送到指定几个群，不是bot加入的所有群）才需要填。
+QQBotBroadcastGroups=
+
+# 表情包/图片的公开访问域名（如 https://yourdomain.com）。
+# 用途：只影响 URL 上传兜底路径。
+# VCP 内部生成的图片URL通常带鉴权参数；当无法走本地 file_data 直传时，
+# 插件会把 /pw=.../images/<subpath> 转成 https://yourdomain.com/stickers/<subpath>，
+# 再让 QQ 服务器抓取这个公开 URL。
+# 留空 = 不转换；URL 兜底可能因为鉴权参数或 QQ 侧下载超时而失败。
+# 注意：最终失败也只会静默跳过图片，不会向 QQ 发送 [图片: URL] 文本链接。
+QQBotPublicBaseUrl=

--- a/Plugin/VCPQQBotServer/plugin-manifest.json
+++ b/Plugin/VCPQQBotServer/plugin-manifest.json
@@ -1,0 +1,156 @@
+{
+  "manifestVersion": "1.0.0",
+  "name": "VCPQQBotServer",
+  "displayName": "VCP QQBot 单聊/群聊桥接服务",
+  "version": "0.1.0",
+  "description": "常驻连接腾讯 QQBot Gateway，接收 QQ 单聊与群聊 @ 消息后转发到 VCP 主服务器 /v1/chat/completions，并将非流式 AI 回复拆分为 QQ 文本与真正的 QQ 图片消息发回用户。",
+  "author": "VCPToolBox",
+  "pluginType": "hybridservice",
+  "entryPoint": {
+    "type": "nodejs",
+    "script": "VCPQQBotServer.js"
+  },
+  "communication": {
+    "protocol": "direct",
+    "timeout": 120000
+  },
+  "capabilities": {
+    "systemPromptPlaceholders": [
+      {
+        "placeholder": "{{VCPQQBotStatus}}",
+        "description": "QQBot Gateway 连接状态、最近错误、会话与心跳信息。",
+        "isDynamic": true
+      },
+      {
+        "placeholder": "{{VCPQQRecentMessages}}",
+        "description": "最近收到与发送的 QQ 单聊消息摘要。",
+        "isDynamic": true
+      }
+    ],
+    "invocationCommands": [
+      {
+        "command": "status",
+        "description": "查看 VCPQQBotServer 连接状态、最近消息与配置摘要。仅用于排障，不用于正常聊天回复。注意：QQ 单聊/群聊回复都不需要工具调用，AI 只需正常输出自然语言；插件会自动把非流式回复拆分为 QQ 文本与图片消息发回用户。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」VCPQQBotServer「末」,\ncommand:「始」status「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "command": "broadcast_to_groups",
+        "description": "主动向 QQ 群发消息（不是回复用户，是 AI 自己发起，如早报/提醒/通知）。\n- content(必需): 消息内容，纯文本\n推送目标：默认发给所有“自动注册的群”(bot收到过消息的群会被自动记录)；也可在 config.env 的 QQBotBroadcastGroups 指定固定群 openid 列表(逗号分隔)，配置了就只发给这些群。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」VCPQQBotServer「末」,\ncommand:「始」broadcast_to_groups「末」,\ncontent:「始」早上好！今天是2026年6月27日，祝大家工作顺利～「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "command": "broadcast_draft_file",
+        "description": "读取固定草稿文件（绝对路径 <VCP根目录>/Plugin/VCPQQBotServer/draft_morning_brief.txt）的内容，发送到所有已注册QQ群。无需任何参数，用于两步式早报流程的第二步（发送）——第一步要先用别的工具（如 ServerFileOperator/DevFileOperator 的 WriteFile）把早报文案写入该绝对路径文件，这一步只管发送，不管撰写。\n⚠️ 两步必须分在【不同的两轮AI消息】里：第一轮只调用WriteFile、等结果真正返回；第二轮再调用broadcast_draft_file。绝对不能在同一轮消息里把WriteFile和broadcast_draft_file一起发出——VCP对同一轮内的多个工具调用是并发执行的(Promise.all)，写文件和读文件会赛跑，读可能先于写完成而报ENOENT找不到文件。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」VCPQQBotServer「末」,\ncommand:「始」broadcast_draft_file「末」\n<<<[END_TOOL_REQUEST]>>>"
+      }
+    ],
+    "services": [
+      {
+        "serviceName": "QQBotGatewayC2C",
+        "description": "常驻连接 QQBot WebSocket Gateway，监听 C2C_MESSAGE_CREATE 单聊事件。"
+      },
+      {
+        "serviceName": "QQBotVCPChatBridge",
+        "description": "将 QQ 单聊消息作为用户输入发送到 VCP 主服务器非流聊天入口，并把回复转换成 QQ 文本/图片消息。"
+      }
+    ]
+  },
+  "configSchema": {
+    "QQAppID": {
+      "type": "string",
+      "description": "QQBot AppID",
+      "required": true
+    },
+    "QQAppSecret": {
+      "type": "string",
+      "description": "QQBot Secret/Token。默认按 Bot appID.secret 方式鉴权。",
+      "required": true
+    },
+    "QQBotToken": {
+      "type": "string",
+      "description": "可选：显式 QQBot Token；不填时使用 QQAppSecret。"
+    },
+    "QQBotAuthMode": {
+      "type": "string",
+      "description": "鉴权模式：bot_app_token 使用 Bot appID.token；access_token 使用 QQBot access token。",
+      "default": "bot_app_token"
+    },
+    "QQBotSandbox": {
+      "type": "boolean",
+      "description": "是否使用沙箱环境。",
+      "default": false
+    },
+    "QQBotIntents": {
+      "type": "string",
+      "description": "逗号分隔 intents，单聊至少需要 GROUP_AND_C2C_EVENT。",
+      "default": "GROUP_AND_C2C_EVENT"
+    },
+    "QQBotModel": {
+      "type": "string",
+      "description": "转发到 VCP 主服务器的模型名；为空时使用 QQBotSystemPrompt 中指定上下文，模型由上游默认策略决定。"
+    },
+    "QQBotSystemPrompt": {
+      "type": "string",
+      "description": "QQ 单聊入口系统提示词。"
+    },
+    "QQBotAllowList": {
+      "type": "string",
+      "description": "允许自动聊天的用户 openid，逗号分隔；为空表示允许全部。"
+    },
+    "QQBotHistoryTurns": {
+      "type": "integer",
+      "description": "每个 QQ 单聊会话保留最近多少轮 user/assistant 历史。",
+      "default": 8
+    },
+    "QQBotMaxReplyChars": {
+      "type": "integer",
+      "description": "QQ 文本消息分段最大字符数。",
+      "default": 1200
+    },
+    "QQBotSendDelayMs": {
+      "type": "integer",
+      "description": "连续发送 QQ 消息的间隔毫秒，避免频控。",
+      "default": 800
+    },
+    "QQBotRequestTimeoutMs": {
+      "type": "integer",
+      "description": "调用 VCP 主服务器非流聊天超时毫秒。",
+      "default": 300000
+    },
+    "QQBotImageMode": {
+      "type": "string",
+      "description": "AI 回复图片 URL 处理模式：upload 优先转真正的 QQ 图片消息（本地图 file_data 直传、sharp 压缩兜底、URL 上传兜底，最终失败静默）；text 仅发送 URL 文本，仅建议调试使用。",
+      "default": "upload"
+    },
+    "DebugMode": "boolean",
+    "QQBotGroupEngageWindow": {
+      "type": "string",
+      "default": "0",
+      "description": "bot 在回复 @mention 后继续参与的消息条数，0=关闭"
+    },
+    "QQBotUploadImages": {
+      "type": "string",
+      "default": "true",
+      "description": "是否启用图片上传链路。当前实现使用 QQ /files 的 file_data(base64) 与 url 字段，不使用 multipart/form-data。"
+    },
+    "QQBotBroadcastGroups": {
+      "type": "string",
+      "default": "",
+      "description": "定时推送目标群 openid，逗号分隔。留空则用自动注册的群。"
+    },
+    "QQBotPublicBaseUrl": {
+      "type": "string",
+      "default": "",
+      "description": "表情包公开访问基础 URL（如 https://your-domain.com），仅用于 URL 上传兜底时把内部鉴权 URL 转为 /stickers/ 公开路径。file_data 本地直传不依赖它。留空=不转换。"
+    },
+    "QQBotDisplayName": {
+      "type": "string",
+      "default": "",
+      "description": "机器人在QQ群里显示的昵称（用于识别其他机器人@提到本机器人但未生成结构化mention的情况，如Q群管家欢迎语里的纯文本@）。"
+    }
+  },
+  "configSchemaDescriptions": {
+    "QQBotSystemPrompt": "例如：你是接入 QQ 单聊的 VCPQQBot。你可以自然聊天，也可以使用 VCP 工具协议完成任务。若回复中包含图片 URL，系统会自动转成 QQ 图片发送。",
+    "QQBotAllowList": "留空表示任何单聊用户都可触发 VCP 聊天；生产环境建议填写允许的 openid。"
+  }
+}

--- a/Plugin/VCPQQBotServer/ws链接qqbot文档.md
+++ b/Plugin/VCPQQBotServer/ws链接qqbot文档.md
@@ -1,0 +1,321 @@
+事件订阅与通知
+说明
+
+当用户在QQ平台内的一些行为操作或某些接口的有异步返回通知确认机制的场景的时候，QQ 会通过"事件"的方式，通知到开发者服务器，开发者可自行根据具体事件通知来进行下一步响应。譬如用户跟机器人发消息，用户添加机器人好友，机器人被拉入群聊等等事件。
+
+#通用数据结构 Payload
+payload 指的是在 webhook或websocket 连接上传输的数据，网关的上下行消息采用的都是同一个结构，如下：
+
+{
+  "id":"event_id",
+  "op": 0,
+  "d": {},
+  "s": 42,
+  "t": "GATEWAY_EVENT_NAME"
+}
+字段	描述
+id	事件id
+op	指的是 opcode，参考连接维护
+s	下行消息都会有一个序列号，标识消息的唯一性，客户端需要再发送心跳的时候，携带客户端收到的最新的s
+t	代表事件类型。主要用在op为 0 Dispatch 的时候
+d	代表事件内容，不同事件类型的事件内容格式都不同，请注意识别。主要用在op为 0 Dispatch 的时候
+#OpCode 含义
+所有 opcode 列表如下：
+
+CODE	名称	接入方式	客户端行为	描述
+0	Dispatch	webhook/websocket	Receive	服务端进行消息推送
+1	Heartbeat	websocket	Send/Receive	客户端或服务端发送心跳
+2	Identify	websocket	Send	客户端发送鉴权
+6	Resume	websocket	Send	客户端恢复连接
+7	Reconnect	websocket	Receive	服务端通知客户端重新连接
+9	Invalid Session	websocket	Receive	当 identify 或 resume 的时候，如果参数有错，服务端会返回该消息
+10	Hello	websocket	Receive	当客户端与网关建立 ws 连接之后，网关下发的第一条消息
+11	Heartbeat ACK	websocket	Receive/Reply	当发送心跳成功之后，就会收到该消息
+12	HTTP Callback ACK	webhook	Reply	仅用于 http 回调模式的回包，代表机器人收到了平台推送的数据
+13	回调地址验证	webhook	Receive	开放平台对机器人服务端进行验证
+客户端行为含义如下：
+
+Receive 客户端接收到服务端 push 的消息
+
+Send 客户端发送消息
+
+Reply 客户端接收到服务端发送的消息之后的回包（HTTP 回调模式）
+
+#Webhook方式
+QQ机器人开放平台支持通过使用HTTP接口接收事件。开发者可通过管理端 (opens new window)设定回调地址，监听事件等。
+
+目前回调地址允许配置的端口号为： 80、443、8080、8443。
+
+#签名校验
+机器人服务端需要对回调请求进行签名验证以保证数据没有被篡改过。 签名算法
+
+#回调地址及事件监听配置
+开发者需要提供一个HTTPS回调地址。并选定监听的事件类型。开放平台会将事件通过回调的方式推送给机器人。
+
+event_subscription
+配置回调地址后，开放平台会对回调地址进行验证：
+
+请求结构(Payload.d)
+字段	描述
+plain_token	需要计算签名的字符串
+event_ts	计算签名使用时间戳
+返回结果
+字段	描述
+plain_token	需要计算签名的字符串
+signature	签名
+计算过程如下(golang)：
+
+func handleValidation(rw http.ResponseWriter, r *http.Request, botSecret string) {
+	httpBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Println("read http body err", err)
+		return
+	}
+	payload := &Payload{}
+	if err = json.Unmarshal(httpBody, payload); err != nil {
+		log.Println("parse http payload err", err)
+		return
+	}
+	validationPayload := &ValidationRequest{}
+	if 	err = json.Unmarshal(payload.Data, validationPayload);err != nil {
+		log.Println("parse http payload failed:", err)
+		return
+	}
+	seed := botSecret
+	for len(seed) < ed25519.SeedSize {
+		seed = strings.Repeat(seed, 2)
+	}
+	seed = seed[:ed25519.SeedSize]
+	reader := strings.NewReader(seed)
+	// GenerateKey 方法会返回公钥、私钥，这里只需要私钥进行签名生成不需要返回公钥
+	_, privateKey, err := ed25519.GenerateKey(reader)
+	if err != nil {
+		log.Println("ed25519 generate key failed:", err)
+		return
+	}
+	var msg bytes.Buffer
+	msg.WriteString(validationPayload.EventTs)
+	msg.WriteString(validationPayload.PlainToken)
+	signature := hex.EncodeToString(ed25519.Sign(privateKey, msg.Bytes()))
+	if err != nil {
+		log.Println("generate signature failed:", err)
+		return
+	}
+	rspBytes, err := json.Marshal(
+		&ValidationResponse{
+			PlainToken: validationPayload.PlainToken,
+			Signature:  signature,
+		})
+	if err != nil {
+		log.Println("handle validation failed:", err)
+		return
+	}
+	rw.Write(rspBytes)
+}
+
+例如机器人账号
+
+appid: 11111111
+secret: DG5g3B4j9X2KOErG
+回调验证请求：
+
+headers: User-Agent:[QQBot-Callback] X-Bot-Appid:[11111111]
+body: {"d":{"plain_token":"Arq0D5A61EgUu4OxUvOp","event_ts":"1725442341"},"op":13},
+机器人应返回：
+
+body: {"plain_token": "Arq0D5A61EgUu4OxUvOp","signature": "87befc99c42c651b3aac0278e71ada338433ae26fcb24307bdc5ad38c1adc2d01bcfcadc0842edac85e85205028a1132afe09280305f13aa6909ffc2d652c706"}
+#WebSocket方式
+#发起连接到 Gateway
+第一步先调用 获取通用WSS 接入点 | QQ机器人文档 或 获取带分片WSS 接入点 | QQ机器人文档 接口获取网关地址。
+
+会得到一个类似下面这样的地址：
+
+wss://api.sgroup.qq.com/websocket/
+然后进行 websocket 长连接建立，一旦连接成功，就会返回 OpCode 10 Hello 消息。这个消息主要的内容是心跳周期，单位毫秒(milliseconds)，如下：
+
+{
+  "op": 10,
+  "d": {
+    "heartbeat_interval": 45000
+  }
+}
+#登录鉴权获得 Session
+websocket 长连接建立之后，需要进行登录鉴权，登录鉴权成功后会获得一个 session 会话 id，只有登录成功后，QQ后台才会下发事件通知，
+
+发送一个 OpCode 2 Identify 消息， payload 如下：
+
+{
+  "op": 2,
+  "d": {
+    "token": "token string",
+    "intents": 513,
+    "shard": [0, 4],
+    "properties": {
+      "$os": "linux",
+      "$browser": "my_library",
+      "$device": "my_library"
+    }
+  }
+}
+
+字段	描述
+token	格式为"QQBot {AccessToken}"
+intents	是此次连接所需要接收的事件，具体可参考 Intents [事件订阅intents\
+shard	考虑到开发者事件接收时可以实现负载均衡，QQ 提供了分片逻辑，事件通知会落在不同的分片上，该参数是个拥有两个元素的数组。
+例如：[0,4]，代表分为四个片，当前链接是第 0 个片，业务稍后应该继续建立 shard 为[1,4],[2,4],[3,4]的链接，才能完整接收事件，更多详细的内容可以参考 Shard [Shard机制\
+properties	目前无实际作用，可以按照自己的实际情况填写，也可以留空
+鉴权成功之后，QQ 后台会下发一个 Ready Event， payload 如下：
+
+{
+  "op": 0,
+  "s": 1,
+  "t": "READY",
+  "d": {
+    "version": 1,
+    "session_id": "082ee18c-0be3-491b-9d8b-fbd95c51673a",
+    "user": {
+      "id": "6158788878435714165",
+      "username": "群pro测试机器人",
+      "bot": true
+    },
+    "shard": [0, 0]
+  }
+}
+#发送心跳 Ack
+鉴权成功之后，就需要按照周期进行心跳发送。d 为客户端收到的最新的消息的 s，如果是首次连接，d 为传 null， payload 如下：
+
+{
+  "op": 1,
+  "d": 251
+}
+心跳发送成功之后会收到 OpCode 11 Heartbeat ACK 消息， payload 如下：
+
+{
+  "op": 11
+}
+#恢复登录态 Session
+有很多原因可能会导致 websocket 长连接断开，断开之后短时间内重连会补发中间遗漏的事件，以保障业务逻辑的正确性。断开重连 gateway 后不需要发送重新登录 Opcode 2 Identify请求。在连接到 Gateway 之后，需要发送 Opcode 6 Resume消息， payload 如下：
+
+{
+  "op": 6,
+  "d": {
+    "token": "my_token",
+    "session_id": "session_id_i_stored",
+    "seq": 1337
+  }
+}
+其中 seq 指的是在接收事件时候的 s 字段，我们推荐开发者在处理过事件之后记录下 s 这样可以在 resume 的时候传递给 websocket， websocket 会自动补发这个 seq 之后的事件。
+
+恢复成功之后，就开始补发遗漏事件，所有事件补发完成之后，会下发一个 Resumed Event， payload 如下：
+
+{
+  "op": 0,
+  "s": 2002,
+  "t": "RESUMED",
+  "d": ""
+}
+#事件订阅Intents
+事件的 intents 是一个标记位，每一位都代表不同的事件，如果需要接收某类事件，就将该位置为 1。
+
+每个 intents 位代表的是一类事件，可以使用使用 websocket 传输的数据中的 t 字段的值来区分。
+
+事件和位移的关系如下：
+
+GUILDS (1 << 0)
+  - GUILD_CREATE           // 当机器人加入新guild时
+  - GUILD_UPDATE           // 当guild资料发生变更时
+  - GUILD_DELETE           // 当机器人退出guild时
+  - CHANNEL_CREATE         // 当channel被创建时
+  - CHANNEL_UPDATE         // 当channel被更新时
+  - CHANNEL_DELETE         // 当channel被删除时
+
+GUILD_MEMBERS (1 << 1)
+  - GUILD_MEMBER_ADD       // 当成员加入时
+  - GUILD_MEMBER_UPDATE    // 当成员资料变更时
+  - GUILD_MEMBER_REMOVE    // 当成员被移除时
+
+GUILD_MESSAGES (1 << 9)    // 消息事件，仅 *私域* 机器人能够设置此 intents。
+  - MESSAGE_CREATE         // 发送消息事件，代表频道内的全部消息，而不只是 at 机器人的消息。内容与 AT_MESSAGE_CREATE 相同
+  - MESSAGE_DELETE         // 删除（撤回）消息事件
+
+GUILD_MESSAGE_REACTIONS (1 << 10)
+  - MESSAGE_REACTION_ADD    // 为消息添加表情表态
+  - MESSAGE_REACTION_REMOVE // 为消息删除表情表态
+
+DIRECT_MESSAGE (1 << 12)
+  - DIRECT_MESSAGE_CREATE   // 当收到用户发给机器人的私信消息时
+  - DIRECT_MESSAGE_DELETE   // 删除（撤回）消息事件
+
+
+GROUP_AND_C2C_EVENT (1 << 25)
+  - C2C_MESSAGE_CREATE      // 用户单聊发消息给机器人时候
+  - FRIEND_ADD              // 用户添加使用机器人
+  - FRIEND_DEL              // 用户删除机器人
+  - C2C_MSG_REJECT          // 用户在机器人资料卡手动关闭"主动消息"推送
+  - C2C_MSG_RECEIVE         // 用户在机器人资料卡手动开启"主动消息"推送开关
+  - GROUP_AT_MESSAGE_CREATE // 用户在群里@机器人时收到的消息
+  - GROUP_ADD_ROBOT         // 机器人被添加到群聊
+  - GROUP_DEL_ROBOT         // 机器人被移出群聊
+  - GROUP_MSG_REJECT        // 群管理员主动在机器人资料页操作关闭通知
+  - GROUP_MSG_RECEIVE       // 群管理员主动在机器人资料页操作开启通知
+
+INTERACTION (1 << 26)
+  - INTERACTION_CREATE     // 互动事件创建时
+
+MESSAGE_AUDIT (1 << 27)
+  - MESSAGE_AUDIT_PASS     // 消息审核通过
+  - MESSAGE_AUDIT_REJECT   // 消息审核不通过
+
+FORUMS_EVENT (1 << 28)  // 论坛事件，仅 *私域* 机器人能够设置此 intents。
+  - FORUM_THREAD_CREATE     // 当用户创建主题时
+  - FORUM_THREAD_UPDATE     // 当用户更新主题时
+  - FORUM_THREAD_DELETE     // 当用户删除主题时
+  - FORUM_POST_CREATE       // 当用户创建帖子时
+  - FORUM_POST_DELETE       // 当用户删除帖子时
+  - FORUM_REPLY_CREATE      // 当用户回复评论时
+  - FORUM_REPLY_DELETE      // 当用户回复评论时
+  - FORUM_PUBLISH_AUDIT_RESULT      // 当用户发表审核通过时
+
+AUDIO_ACTION (1 << 29)
+  - AUDIO_START             // 音频开始播放时
+  - AUDIO_FINISH            // 音频播放结束时
+  - AUDIO_ON_MIC            // 上麦时
+  - AUDIO_OFF_MIC           // 下麦时
+
+PUBLIC_GUILD_MESSAGES (1 << 30) // 消息事件，此为公域的消息事件
+  - AT_MESSAGE_CREATE       // 当收到@机器人的消息时
+  - PUBLIC_MESSAGE_DELETE   // 当频道的消息被删除时
+#举例
+如开发者需要接收用户 at 机器人的消息，那么就需要在 intents 中设置接收 PUBLIC_GUILD_MESSAGES。则需要先计算 1 << 30 的值。然后与 0 做位或操作，得到最终需要传递的 intents。
+
+如果涉及到多个事件类型的接收，则需要将多个结果做位或操作，如：0|1<<30|1<<1 代表订阅 PUBLIC_GUILD_MESSAGES 和 GUILD_MEMBERS 这两类事件。
+
+#权限
+事件类型的订阅，是有权限控制的，除了 GUILDS，PUBLIC_GUILD_MESSAGES，GUILD_MEMBERS 事件是基础的事件，默认有权限订阅之外，其他的特殊事件，都需要经过申请才能够使用，如果在鉴权的时候传递了无权限的 intents， websocket 会报错，并直接关闭连接。请开发者注意订阅事件的范围需要控制在自己所需要的范围之内。
+
+如果拥有的某个特殊事件类型的权限被取消，则在当前连接上不会报错，但是将不会收到对应的事件类型，如果重新连接，则报错，所以如果开发者的事件类型权限被取消，请及时调整监听事件代码，避免报错导致的无法连接。
+
+#分片连接LoadBalance
+随着bot的增长并被添加到越来越多的频道中，事件越来越多，业务有必要对事件进行水平分割，实现负载均衡。机器人网关实现了一种用户可控制的分片方法，该方法允许跨多个网关连接拆分事件。 分片完全由用户控制，并且不需要在单独的连接之间进行状态共享。
+
+要在连接上启用分片，需要在建立连接的时候指定分片参数，具体参考gateway
+
+#获得合适的分片数
+使用/gateway/bot接口获取网关地址的时候，会同时返回一个建议的 shard数，及最大并发限制。
+
+{
+  "url": "wss://sandbox.api.sgroup.qq.com/websocket",
+  "shards": 1,
+  "session_start_limit": {
+    "total": 1000,
+    "remaining": 1000,
+    "reset_after": 86400000,
+    "max_concurrency": 1
+  }
+}
+#分片规则
+分片是按照频道id进行哈希的，同一个频道的信息会固定从同一个链接推送。具体哈希计算规则如下：
+
+shard_id = (guild_id >> 22) % num_shards
+#最大连接数
+每个机器人创建的连接数不能超过remaining剩余连接数


### PR DESCRIPTION
新增自研插件 VCPQQBotServer,把腾讯QQBot的单聊(C2C)和群聊(GROUP@消息) 接入VCP主服务器,让QQ机器人能用VCP的Agent/工具/记忆能力。

核心功能:
- 常驻连接QQ Gateway WebSocket,接收单聊与群聊@消息
- 转发到VCP /v1/chat/completions,复用VCP工具循环/记忆/RAG
- AI回复自动拆分文本与图片,发真正的QQ图片消息(msg_type:7)
- 表情包图片链路:file_data本地base64直传优先 -> sharp压缩兜底 -> URL上传兜底 -> 失败静默跳过(绝不发[图片:URL]文本链接)
- 表情包文件名模糊匹配(同名不同扩展名优先,治AI编造文件名)
- C2C被动消息msg_seq递增(防QQ 50015014系统繁忙)
- 群聊追问窗口(@后N条消息内自动响应)
- 早报广播(草稿文件发送)
- 安全:回复脱密sanitize,工具协议块不发QQ

文件:
- VCPQQBotServer.js 主实现
- plugin-manifest.json 插件声明(单聊/群聊桥接)
- config.env.example 配置模板(占位符,无真实密钥)
- README.md 完整文档(含图片链路/配置/限制说明)
- ws链接qqbot文档.md QQ官方WebSocket文档摘录

配置:复制config.env.example为config.env,填QQAppID/QQAppSecret等。