### PR TITLE
优化，加点ignore规则

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ multimodal-config.json
 *.sqlite3-shm
 *.sqlite3-wal
 *.db
+# SQLite sidecar：主库运行期间产生的 WAL / shared memory
+*.db-shm
+*.db-wal
 DebugLog/
 dailynote/*
 !dailynote/VCP桌面知识/
@@ -171,6 +174,7 @@ dailynote/*
 !dailynote/VCP开发/**
 ip_blacklist.json
 /VectorStore
+/VectorStoreTDB/
 
 # 插件缓存文件
 Plugin/ArtistMatcher/artist_cache.json
@@ -208,6 +212,15 @@ Plugin/UrlFetch/browser-profiles
 Plugin/ChromeBridge/ChromeScripts
 Plugin/ChromeBridge/managed-extension-stage
 Plugin/ChromeBridge/managed-profile
+Plugin/VCPTimeLine/config.json
+
+# Agent 插件执行态
+Plugin/AgentAssistant/agent_scores.json
+Plugin/AgentDream/dream_logs/
+Plugin/AgentDream/dream_schedule_state.json
+
+# ChromeBridge 单次运行令牌
+Plugin/ChromeBridge/managed-runtime-token.json
 
 # ===== 图片 / 媒体 =====
 # 忽略通用表情包目录下的所有内容...
@@ -221,6 +234,20 @@ image/fluxgen/
 image/gptimagegen/
 image/agnesgen/
 image/zimageturbogen/
+image/comfycloud/
+image/comfyuigen/
+image/doubaogen/
+image/geminiimagegen/
+image/nanobananagen/
+image/novelaigen/
+image/qwenimagegen/
+image/sensegen/
+image/webuigen/
+image/zimagegen/
+
+# 网络抓取图片输出
+image/urlfetch/
+
 # 忽略 B站截图的图片
 image/bilibili/
 


### PR DESCRIPTION
## 背景

VCPToolBox 的多个插件会在实际运行时生成本地缓存、会话状态、
向量索引、浏览器运行资料、Agent 执行日志、邮件附件和图像输出。

这些内容通常具有以下特征：

- 与具体部署实例绑定，可能包含隐私或认证状态；
- 高频变化，容易持续污染 Git 工作区；
- 多数能够由知识源、配置或运行过程重新生成；
- 不应和插件源码、默认模板及知识源文件混入同一版本控制边界。

## 改动内容

在 `.gitignore` 中补充生成型运行时数据的忽略规则，覆盖：

- SQLite WAL / SHM sidecar 文件；
- `VectorStoreTDB` 本地向量索引；
- AgentDream 执行日志与调度状态；
- AgentAssistant 动态评分状态；
- VCPTimeLine 本地实例配置；
- ChromeBridge 单次运行 token；
- 图像生成器与 UrlFetch 的输出目录。

补充：另外，实际上Knowledge的TDBdocs，VCP百科全书，VCP知识 这三个文件以外的文件说不定也可以ignore，但是我不确定，不动了。