### PR TITLE
chore: ignore local knowledge while preserving official roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,6 +251,20 @@ image/urlfetch/
 # 忽略 B站截图的图片
 image/bilibili/
 
+# ===== 本地知识库 =====
+# knowledge 默认为本地私有数据，不进入 Git
+/knowledge/*
+
+# 上游官方维护的知识目录
+!/knowledge/TDBdocs/
+!/knowledge/TDBdocs/**
+
+!/knowledge/VCP百科全书/
+!/knowledge/VCP百科全书/**
+
+!/knowledge/VCP知识/
+!/knowledge/VCP知识/**
+
 # ===== IDE / OS 文件 =====
 .vscode/
 .DS_Store


### PR DESCRIPTION
改动说明

默认忽略仓库根目录 knowledge/ 下的本地知识库内容，避免用户导入的TDB文档、Skills、论文和个人知识意外进入Git暂存区。
显式保留上游官方维护的三个知识目录：
knowledge/TDBdocs/
knowledge/VCP百科全书/
knowledge/VCP知识/
规则锚定到仓库根目录，不影响插件或其他子模块中可能存在的同名目录。
问题背景

当前 .gitignore 未覆盖 knowledge/。当用户执行 git add .、stash或部署分支更新流程时，本地导入的知识库可能被批量加入索引。大型知识库会产生数百乃至数千个无关状态项，增加误提交、stash膨胀和更新冲突风险。

实现方式

使用 /knowledge/* 默认屏蔽根目录下所有知识子项，再通过目录节点与递归内容两层否定规则，重新开放三个官方目录。

验证结果

本地 knowledge/Skills/ 与论文目录能够命中忽略规则。
三个官方目录均命中对应的白名单规则。
PR仅修改 .gitignore，不改动任何现有知识文件。
git diff --check 通过。