### PR TITLE
fix(VCPClawMail): prevent short-lived WS connections from resetting retry backoff

### DIFF
--- a/Plugin.js
+++ b/Plugin.js
@@ -684,6 +684,7 @@ class PluginManager extends EventEmitter {
 
                     // --- 注入 VectorDBManager ---
                     if (
+                        manifest.requiresKnowledgeBaseManager === true ||
                         manifest.name === 'RAGDiaryPlugin' ||
                         manifest.name === 'DailyNote' ||
                         manifest.name === 'DailyNoteManager'

--- a/Plugin/VCPClawMail/VCPClawMail.js
+++ b/Plugin/VCPClawMail/VCPClawMail.js
@@ -54,6 +54,8 @@ const MIN_FALLBACK_POLL_INTERVAL_MS = 5 * 60_000;
 const DEFAULT_POLL_LIMIT = 20;
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 const WS_RECONNECT_BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000, 60_000];
+const WS_STABLE_CONNECTION_MS = 20_000;
+const WS_RECONNECT_JITTER_MIN_RATIO = 0.8;
 const INJECTED_PROMPT_START = '<<<[VCP_CLAWMAIL_INJECTED_PROMPT]>>>';
 const INJECTED_PROMPT_END = '<<<[END_VCP_CLAWMAIL_INJECTED_PROMPT]>>>';
 const MAIL_CONTENT_START = '<<<[VCP_CLAWMAIL_MAIL_CONTENT]>>>';
@@ -1585,6 +1587,7 @@ function getWsState(user) {
       retries: 0,
       lastConnectedAt: null,
       lastDisconnectedAt: null,
+      connectedAtMs: null,
       lastError: null,
       lastMailAt: null,
       lastMailId: null
@@ -1597,9 +1600,20 @@ function scheduleWsReconnect(user, reason = 'unknown') {
   const state = getWsState(user);
   if (state.stopped) return;
   if (wsReconnectTimers.has(user)) return;
-  const delay = WS_RECONNECT_BACKOFF_MS[Math.min(state.retries, WS_RECONNECT_BACKOFF_MS.length - 1)];
+
+  const baseDelay = WS_RECONNECT_BACKOFF_MS[
+    Math.min(state.retries, WS_RECONNECT_BACKOFF_MS.length - 1)
+  ];
+  const delay = Math.round(
+    baseDelay * (
+      WS_RECONNECT_JITTER_MIN_RATIO
+      + Math.random() * (1 - WS_RECONNECT_JITTER_MIN_RATIO)
+    )
+  );
+
   state.retries += 1;
   console.warn(`[VCPClawMail] WebSocket 将在 ${delay}ms 后重连: user=${user}, reason=${reason}`);
+
   const timer = setTimeout(() => {
     wsReconnectTimers.delete(user);
     connectWsForUser(user).catch(error => {
@@ -1610,6 +1624,7 @@ function scheduleWsReconnect(user, reason = 'unknown') {
       scheduleWsReconnect(user, error.message);
     });
   }, delay);
+
   if (timer.unref) timer.unref();
   wsReconnectTimers.set(user, timer);
 }
@@ -1811,6 +1826,7 @@ async function refreshAfterMailPush(user, mailId) {
 async function connectWsForUser(user) {
   const state = getWsState(user);
   if (state.stopped || state.connecting || state.connected) return;
+
   const client = getClient(user);
   if (!client.ws || typeof client.ws.connect !== 'function') {
     state.lastError = '当前 SDK 未暴露 client.ws.connect。';
@@ -1819,6 +1835,7 @@ async function connectWsForUser(user) {
   }
 
   state.connecting = true;
+
   try {
     client.ws.onMessage(({ mailId } = {}) => {
       state.lastMailAt = new Date().toISOString();
@@ -1829,24 +1846,43 @@ async function connectWsForUser(user) {
     });
 
     client.ws.onDisconnect((reason) => {
+      const disconnectedAtMs = Date.now();
+      const uptimeMs = state.connectedAtMs
+        ? disconnectedAtMs - state.connectedAtMs
+        : 0;
+
+      if (uptimeMs >= WS_STABLE_CONNECTION_MS) {
+        state.retries = 0;
+      }
+
       state.connected = false;
       state.connecting = false;
-      state.lastDisconnectedAt = new Date().toISOString();
+      state.connectedAtMs = null;
+      state.lastDisconnectedAt = new Date(disconnectedAtMs).toISOString();
       state.lastError = reason || null;
-      console.warn(`[VCPClawMail] WebSocket 已断开: user=${user}, reason=${reason || 'unknown'}`);
+
+      console.warn(
+        `[VCPClawMail] WebSocket 已断开: user=${user}, `
+        + `reason=${reason || 'unknown'}, uptimeMs=${uptimeMs}`
+      );
+
       scheduleWsReconnect(user, reason || 'disconnect');
     });
 
     await client.ws.connect();
+
+    const connectedAtMs = Date.now();
     state.connected = true;
     state.connecting = false;
-    state.retries = 0;
-    state.lastConnectedAt = new Date().toISOString();
+    state.connectedAtMs = connectedAtMs;
+    state.lastConnectedAt = new Date(connectedAtMs).toISOString();
     state.lastError = null;
+
     log(`WebSocket 即达监听已连接: user=${user}`);
   } catch (error) {
     state.connected = false;
     state.connecting = false;
+    state.connectedAtMs = null;
     state.lastError = error.message;
     throw error;
   }
@@ -1887,6 +1923,8 @@ function stopWsListeners() {
     state.stopped = true;
     state.connected = false;
     state.connecting = false;
+    state.connectedAtMs = null;
+
     try {
       const client = clients.get(user);
       if (client?.ws && typeof client.ws.disconnect === 'function') {


### PR DESCRIPTION
## 问题

VCPClawMail 的 WebSocket 即达监听在连接短暂成功后快速断开（如 CONNACK 后 2~3 秒收到 1006）时，
会立即将 `state.retries` 归零，导致退避数组 [1s, 2s, 5s, 10s, 30s, 60s] 永远停留在首档。
五个邮箱账号使用完全相同的固定延迟，同步断线后形成锁相惊群式重连风暴。

## 修复内容

1. **移除 CONNACK 后立即清零 retries 的逻辑**
   - 连接成功只记录 `connectedAtMs` 时间戳，不再认为握手 = 稳定。

2. **在断开回调中按 uptime 判断是否清零**
   - 若连接存活 ≥ 20 秒（`WS_STABLE_CONNECTION_MS`），认为旧失败已过时，清零 retries。
   - 若连接仅存活数秒，保留累计失败次数，让退避正常推进。

3. **为重连延迟加入有限 jitter**
   - 实际等待 = 原档位 × random(0.8, 1.0)，不超过原上限 60 秒。
   - 五个邮箱的重连时刻不再完全同步。

4. **stopWsListeners 清除 `connectedAtMs`**
   - 维护"非连接态无连接起点"不变量。

## 测试

- 本地 PM2 重启后五个邮箱均正常完成 CONNACK → AES → Heartbeat。
- 低频轮询 / 子邮箱自动投递 / 邮件 HTTP API 均未受影响。
- `node --check` 语法验证通过。

## 未解决

- 首个 1006 的远端根因（网易 WuKongIM / 会话残留）不在本次修复范围。
- SDK `timeDiff` 的 uint64 回绕仅为日志现象，不参与重连决策。

说来，由于难以对网易邮箱的连接逻辑进行完美匹配，本次修改只是尝试增加了鲁棒性。
以我的观感，似乎是如果node进程被同步占据了一段时间后，直接强制用pm2命令重启，会比较容易出现这个问题。而且，出现这个问题后，只是restart似乎没法解决，非要kill后再度启动才能解决（存疑）。


附带改动
- `Plugin.js`：我自己的某个插件开发，需要只读知识库，于是加了一行通用性质的代码，或许是可以merge的。这与本次 WebSocket 修复无逻辑依赖。