### PR TITLE
fix(DailyNote): unpack legacy [folder]author in maid even when explicit folder is provided

### DIFF
--- a/Plugin/DailyNote/dailynote.js
+++ b/Plugin/DailyNote/dailynote.js
@@ -615,18 +615,22 @@ async function handleCreateCommand(args) {
 
         const trimmedMaidName = maid.trim();
         const trimmedFolderName = typeof folder === 'string' ? folder.trim() : '';
-        let folderName = trimmedFolderName || trimmedMaidName;
-        let actualMaidName = trimmedMaidName;
-        const tagMatch = trimmedMaidName.match(/^\[(.*?)\](.*)$/);
+        // 解析旧式 [文件夹]作者 格式——闭括号后必须有非空作者名才视为旧格式
+        const tagMatch = trimmedMaidName.match(/^\[([^\]]*)\](.+)$/);
+        let folderName;
+        let actualMaidName;
 
-        if (trimmedFolderName) {
-            debugLog(`Explicit folder provided. Folder: ${folderName}, Actual Maid: ${actualMaidName}`);
-        } else if (tagMatch) {
-            folderName = tagMatch[1].trim();
+        if (tagMatch) {
+            // maid 确实是旧式格式，提取作者
             actualMaidName = tagMatch[2].trim();
-            debugLog(`Tagged note detected. Tag: ${folderName}, Actual Maid: ${actualMaidName}`);
+            // 目录：显式 folder 优先，否则用旧式 maid 中的目录部分
+            folderName = trimmedFolderName || tagMatch[1].trim() || actualMaidName;
+            debugLog(`Legacy maid format parsed. Folder: ${folderName}, Actual Maid: ${actualMaidName}, explicit folder: ${!!trimmedFolderName}`);
         } else {
-            debugLog(`No tag detected. Folder: ${folderName}, Actual Maid: ${actualMaidName}`);
+            // maid 是普通署名
+            actualMaidName = trimmedMaidName;
+            folderName = trimmedFolderName || trimmedMaidName;
+            debugLog(`Plain maid. Folder: ${folderName}, Actual Maid: ${actualMaidName}`);
         }
 
         const folderResolution = await resolveDiaryFolderName(folderName, {
@@ -1053,7 +1057,7 @@ function generateDiff(oldText, newText, oldLabel, newLabel) {
 
         hunks.push(
             `@@ -${aRange} +${bRange} @@\n` +
-                hunkOps.map((o) => o.type + o.line).join('\n')
+            hunkOps.map((o) => o.type + o.line).join('\n')
         );
 
         idx = hunkEnd;
@@ -1135,8 +1139,7 @@ async function handleUpdateCommand(args) {
     }
 
     debugLog(
-        `Validated input for update. Target length: ${target.length}. Maid: ${
-            maid || 'Not specified'
+        `Validated input for update. Target length: ${target.length}. Maid: ${maid || 'Not specified'
         }. Folder: ${folder || 'Not specified'}`
     );
 

--- a/Plugin/DailyNoteManager/daily-note-manager.js
+++ b/Plugin/DailyNoteManager/daily-note-manager.js
@@ -295,16 +295,19 @@ async function _handleOrganizeInternal(args) {
 
         const trimmedMaidName = maid.trim();
         const trimmedFolderName = typeof folder === 'string' ? folder.trim() : '';
-        let folderName = trimmedFolderName || trimmedMaidName;
-        let actualMaidName = trimmedMaidName;
-        const tagMatch = trimmedMaidName.match(/^\[(.*?)\](.*)$/);
+        // 解析旧式 [文件夹]作者 格式——闭括号后必须有非空作者名才视为旧格式
+        const tagMatch = trimmedMaidName.match(/^\[([^\]]*)\](.+)$/);
+        let folderName;
+        let actualMaidName;
 
-        if (trimmedFolderName) {
-            debugLog(`Explicit folder provided for organize: folder=${folderName}, maid=${actualMaidName}`);
-        } else if (tagMatch) {
-            folderName = tagMatch[1].trim();
+        if (tagMatch) {
             actualMaidName = tagMatch[2].trim();
-            debugLog(`Tagged note: folder=${folderName}, maid=${actualMaidName}`);
+            folderName = trimmedFolderName || tagMatch[1].trim() || actualMaidName;
+            debugLog(`Legacy maid format parsed for organize. Folder: ${folderName}, Actual Maid: ${actualMaidName}, explicit folder: ${!!trimmedFolderName}`);
+        } else {
+            actualMaidName = trimmedMaidName;
+            folderName = trimmedFolderName || trimmedMaidName;
+            debugLog(`Plain maid for organize. Folder: ${folderName}, Actual Maid: ${actualMaidName}`);
         }
 
         const sanitizedFolderName = sanitizePathComponent(folderName);


### PR DESCRIPTION
## 问题

当调用者同时传入显式 `folder` 参数和旧式 `maid="[文件夹]人名"` 格式时，DailyNote 的 create 命令和 DailyNoteManager 的 organize 命令会将整个 `[文件夹]人名` 写入日记首行署名，而非只取 `人名`。

这违反了 manifest 声明的语义——"提供 folder 后，maid 只作为正文署名"。

## 根因

原 if/else-if/else 三分支结构将"目录决策"和"署名解包"绑定在同一条件路径中。当显式 folder 存在时，代码直接跳过了旧格式解包分支，导致 `actualMaidName` 保留了含方括号的完整原文。

## 修复

将 maid 的旧格式解包与目录来源决策解耦为两个独立步骤：

1. **先解包**：无论 folder 是否存在，只要 maid 匹配 `/^\[([^\]]*)\](.+)$/`（闭括号后必须有非空作者），就提取作者。
2. **再决策目录**：显式 folder 优先 → 旧格式中的目录部分 → 作者名兜底。

正则变更：`/^\[(.*?)\](.*)$/` → `/^\[([^\]]*)\](.+)$/`
- `[^\]]*` 禁止嵌套闭括号，更安全
- `(.+)` 要求作者非空，防止 `[目录名]` 无作者时误解包

## 影响范围

- `Plugin/DailyNote/dailynote.js`：`handleCreateCommand()` 内 maid/folder 解析块
- `Plugin/DailyNoteManager/daily-note-manager.js`：`_handleOrganizeInternal()` 内同等逻辑块

## 行为变化

| folder | maid | 旧行为（首行署名） | 新行为（首行署名） |
|--------|------|-------|-------|
| 有 | `[Y]Z` | `[Y]Z` | `Z` |
| 无 | `[Y]Z` | `Z`（不变） | `Z` |
| 有 | `Z` | `Z`（不变） | `Z` |

仅交叉态（第一行）行为改变，其他路径完全不变。

## 测试

12 项纯函数单元测试全部通过，覆盖：普通 maid、旧格式、交叉态、空作者拒绝、中间方括号不解包、空目录 fallback、嵌套方括号、纯空格 graceful handling 等边界情况。
