### PR TITLE
修改 TavilySearch 多 query 批量搜索的分隔符，与 AnySearch 统一

### DIFF
--- a/Plugin/TavilySearch/TavilySearch.js
+++ b/Plugin/TavilySearch/TavilySearch.js
@@ -146,11 +146,11 @@ async function main() {
                 }
             }
 
-            // 检测是否包含 || 分隔的多个查询
-            const subQueries = query.split('||').map(q => q.trim()).filter(q => q.length > 0);
+            // 检测是否包含 | 分隔的多个查询
+            const subQueries = query.split('|').map(q => q.trim()).filter(q => q.length > 0);
 
             if (subQueries.length === 0) {
-                throw new Error("No valid search query after splitting by '||'");
+                throw new Error("No valid search query after splitting by '|'");
             }
 
             if (subQueries.length > 1) {

--- a/Plugin/TavilySearch/plugin-manifest.json
+++ b/Plugin/TavilySearch/plugin-manifest.json
@@ -3,7 +3,7 @@
   "name": "TavilySearch",
   "displayName": "Tavily 搜索插件",
   "version": "0.1.0",
-  "description": "使用 Tavily API 进行高级网络搜索。AI可以指定搜索查询、主题、最大结果数，并可选择包含原始内容、图片链接及描述，以及设定搜索时间范围。支持使用 || 分隔多个关键词进行并发搜索，所有结果同时返回。",
+  "description": "使用 Tavily API 进行高级网络搜索。AI可以指定搜索查询、主题、最大结果数，并可选择包含原始内容、图片链接及描述，以及设定搜索时间范围。支持使用 | 分隔多个关键词进行并发搜索，所有结果同时返回。",
   "author": "Roo",
   "pluginType": "synchronous",
   "entryPoint": {
@@ -21,7 +21,7 @@
     "invocationCommands": [
       {
         "commandIdentifier": "TavilySearch",
-        "description": "调用此工具使用 Tavily API 进行高级网络搜索。默认启用高级搜索模式并返回图片链接。重要提示：请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。请在您的回复中，使用以下精确格式来请求搜索，确保所有参数值都用「始」和「末」准确包裹：\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」TavilySearch「末」,\nquery:「始」(必需) 搜索的关键词或问题，支持使用 || 分隔多个关键词进行并发搜索「末」,\nsearch_depth:「始」(可选, 默认为 'basic') 搜索深度。'ultra-fast': 不太准但最快, 'fast':快速搜索, 'basic':兼顾速度与准确度, 'advanced':牺牲速度进行高精度查找。「末」,\ntopic:「始」(可选, 默认为 'general') 搜索的主题，只允许['general', 'news', 'finance']。「末」,\nmax_results:「始」(可选, 默认为 10) 返回的最大结果数量，范围 0-20。「末」,\ninclude_raw_content:「始」(可选) 如果需要获取网页原始内容，请将此值设为 'markdown' 或 'text'。「末」,\ncountry:「始」(可选) 仅在topic为 'general' 时可用，搜索结果的国家来源，使用小写英文名例如 'china' (中国)。「末」,\ntime_range:「始」(可选) 指定周期(day, week, month, year)搜索最近的结果。注意：此参数与 start_date/end_date 互斥，如果设置了 start_date 或 end_date，则 time_range 参数会被忽略。「末」,\nstart_date:「始」(可选) 搜索开始日期，格式为 YYYY-MM-DD。「末」,\nend_date:「始」(可选) 搜索结束日期，格式为 YYYY-MM-DD。「末」\n<<<[END_TOOL_REQUEST]>>>\n\n重要提示给AI：\n当此工具执行完毕后，您将收到包含搜索结果的JSON对象。请基于这些结果回答用户的问题或完成相关任务。\n请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。",
+        "description": "调用此工具使用 Tavily API 进行高级网络搜索。默认启用高级搜索模式并返回图片链接。重要提示：请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。请在您的回复中，使用以下精确格式来请求搜索，确保所有参数值都用「始」和「末」准确包裹：\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」TavilySearch「末」,\nquery:「始」(必需) 搜索的关键词或问题，支持使用 | 分隔多个关键词进行并发搜索「末」,\nsearch_depth:「始」(可选, 默认为 'basic') 搜索深度。'ultra-fast': 不太准但最快, 'fast':快速搜索, 'basic':兼顾速度与准确度, 'advanced':牺牲速度进行高精度查找。「末」,\ntopic:「始」(可选, 默认为 'general') 搜索的主题，只允许['general', 'news', 'finance']。「末」,\nmax_results:「始」(可选, 默认为 10) 返回的最大结果数量，范围 0-20。「末」,\ninclude_raw_content:「始」(可选) 如果需要获取网页原始内容，请将此值设为 'markdown' 或 'text'。「末」,\ncountry:「始」(可选) 仅在topic为 'general' 时可用，搜索结果的国家来源，使用小写英文名例如 'china' (中国)。「末」,\ntime_range:「始」(可选) 指定周期(day, week, month, year)搜索最近的结果。注意：此参数与 start_date/end_date 互斥，如果设置了 start_date 或 end_date，则 time_range 参数会被忽略。「末」,\nstart_date:「始」(可选) 搜索开始日期，格式为 YYYY-MM-DD。「末」,\nend_date:「始」(可选) 搜索结束日期，格式为 YYYY-MM-DD。「末」\n<<<[END_TOOL_REQUEST]>>>\n\n重要提示给AI：\n当此工具执行完毕后，您将收到包含搜索结果的JSON对象。请基于这些结果回答用户的问题或完成相关任务。\n请优先使用中文词作为检索词，并带上即时信息（如当前年份、月份等）进行检索，以获得更准确的结果。",
         "example": "```text\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」TavilySearch「末」,\nquery:「始」最近一周的AI技术进展「末」,\nsearch_depth:「始」advanced「末」,\ntopic:「始」technology「末」,\nmax_results:「始」5「末」,\time_range:「始」d「末」\n<<<[END_TOOL_REQUEST]>>>\n```"
       }
     ]


### PR DESCRIPTION
TavilySearch 多 query 批量搜索的分隔符由 || 改为 | ，