### PR TITLE
补一个分布式节点工具的取消功能

### DIFF
--- a/WebSocketServer.js
+++ b/WebSocketServer.js
@@ -256,6 +256,7 @@ function initialize(httpServer, config) {
                     distributedServers.set(serverId, {
                         ws,
                         tools: [],
+                        capabilities: {},
                         ips: {},
                         connectedAt: formatDateTimeForConfiguredTimezone(),
                         lastSeenAt: formatDateTimeForConfiguredTimezone()
@@ -497,6 +498,7 @@ function initialize(httpServer, config) {
                 if (pluginManager) {
                     pluginManager.unregisterAllDistributedTools(ws.serverId);
                 }
+                rejectPendingToolRequestsForServer(ws.serverId);
                 distributedServers.delete(ws.serverId);
                 distributedServerIPs.delete(ws.serverId); // 新增：移除IP信息
                 writeLog(`Distributed Server ${ws.serverId} disconnected. Its tools and IP info have been unregistered.`);
@@ -695,6 +697,9 @@ async function handleDistributedServerMessage(serverId, message) {
                 if (message.data.serverName) {
                     serverEntry.serverName = message.data.serverName;
                 }
+                serverEntry.capabilities = message.data.capabilities && typeof message.data.capabilities === 'object'
+                    ? { ...message.data.capabilities }
+                    : {};
                 serverEntry.lastSeenAt = formatDateTimeForConfiguredTimezone();
                 distributedServers.set(serverId, serverEntry);
                 writeLog(`Registered ${externalTools.length} external tools from server ${serverId}${serverEntry.serverName ? ` (${serverEntry.serverName})` : ''}.`);
@@ -802,23 +807,62 @@ async function handleDistributedServerMessage(serverId, message) {
                 console.error(`[WebSocketServer] Failed to sync distributed music playlist from ${serverId}:`, error);
             }
             break;
-        case 'tool_result':
+        case 'tool_result': {
             const pending = pendingToolRequests.get(message.data.requestId);
-            if (pending) {
-                clearTimeout(pending.timeout);
-                if (message.data.status === 'success') {
-                    pending.resolve(message.data.result);
-                } else {
-                    pending.reject(new Error(message.data.error || 'Distributed tool execution failed.'));
-                }
-                pendingToolRequests.delete(message.data.requestId);
+            if (!pending) break;
+
+            // requestId 虽然随机生成，仍不能作为跨节点信任边界；只接受目标
+            // serverId 返回的结果，其他节点的同 ID 消息不得完成该 Promise。
+            if (pending.serverId !== serverId) {
+                console.warn(`[WebSocketServer] Ignoring tool_result for ${message.data.requestId} from non-target server ${serverId}; expected ${pending.serverId}.`);
+                break;
             }
+
+            clearTimeout(pending.timeout);
+            if (message.data.status === 'success') {
+                pending.resolve(message.data.result);
+            } else {
+                pending.reject(new Error(message.data.error || 'Distributed tool execution failed.'));
+            }
+            pendingToolRequests.delete(message.data.requestId);
             break;
+        }
         case 'plugin_callback_forward':
             await handleDistributedPluginCallback(serverId, message);
             break;
         default:
             writeLog(`Unknown message type '${message.type}' from server ${serverId}.`);
+    }
+}
+
+function sendCancelToolIfSupported(pending) {
+    const ws = pending.server?.ws;
+    const supportsCancelTool = pending.server?.capabilities?.cancelTool === true;
+    if (!supportsCancelTool || !ws || ws.readyState !== WebSocket.OPEN || pending.cancelSent) {
+        return false;
+    }
+
+    try {
+        ws.send(JSON.stringify({
+            type: 'cancel_tool',
+            data: { requestId: pending.requestId }
+        }));
+        pending.cancelSent = true;
+        writeLog(`Sent cancel_tool for timed-out request ${pending.requestId} to server ${pending.serverId}.`);
+        return true;
+    } catch (error) {
+        console.warn(`[WebSocketServer] Failed to send cancel_tool for ${pending.requestId}:`, error.message);
+        return false;
+    }
+}
+
+function rejectPendingToolRequestsForServer(serverId) {
+    for (const [requestId, pending] of pendingToolRequests.entries()) {
+        if (pending.serverId !== serverId) continue;
+
+        clearTimeout(pending.timeout);
+        pendingToolRequests.delete(requestId);
+        pending.reject(new Error(`Distributed server ${serverId} disconnected while executing request ${requestId}.`));
     }
 }
 
@@ -828,12 +872,14 @@ async function executeDistributedTool(serverIdOrName, toolName, toolArgs, timeou
     const defaultTimeout = plugin?.communication?.timeout || 60000;
     const effectiveTimeout = timeout ?? defaultTimeout;
 
+    let targetServerId = serverIdOrName;
     let server = distributedServers.get(serverIdOrName); // 优先尝试通过 ID 查找
 
     // 如果通过 ID 找不到，则遍历并尝试通过 name 查找
     if (!server) {
-        for (const srv of distributedServers.values()) {
+        for (const [candidateServerId, srv] of distributedServers.entries()) {
             if (srv.serverName === serverIdOrName) {
+                targetServerId = candidateServerId;
                 server = srv;
                 break;
             }
@@ -855,15 +901,31 @@ async function executeDistributedTool(serverIdOrName, toolName, toolArgs, timeou
     };
 
     return new Promise((resolve, reject) => {
-        const timeoutId = setTimeout(() => {
+        const pending = {
+            requestId,
+            serverId: targetServerId,
+            server,
+            resolve,
+            reject,
+            timeout: null,
+            cancelSent: false
+        };
+        pending.timeout = setTimeout(() => {
             pendingToolRequests.delete(requestId);
+            sendCancelToolIfSupported(pending);
             reject(new Error(`Request to distributed tool ${toolName} on server ${serverIdOrName} timed out after ${effectiveTimeout / 1000}s.`));
         }, effectiveTimeout);
 
-        pendingToolRequests.set(requestId, { resolve, reject, timeout: timeoutId });
+        pendingToolRequests.set(requestId, pending);
 
-        server.ws.send(JSON.stringify(payload));
-        writeLog(`Sent tool execution request ${requestId} for ${toolName} to server ${serverIdOrName}.`);
+        try {
+            server.ws.send(JSON.stringify(payload));
+            writeLog(`Sent tool execution request ${requestId} for ${toolName} to server ${serverIdOrName}.`);
+        } catch (error) {
+            clearTimeout(pending.timeout);
+            pendingToolRequests.delete(requestId);
+            reject(error);
+        }
     });
 }
 
@@ -890,6 +952,7 @@ function getDistributedServerSnapshot() {
             localIPs,
             publicIP: ipInfo.publicIP ?? serverInfo.ips?.publicIP ?? null,
             tools: Array.isArray(serverInfo.tools) ? [...serverInfo.tools] : [],
+            capabilities: { ...(serverInfo.capabilities || {}) },
             connected: serverInfo.ws?.readyState === WebSocket.OPEN,
             connectedAt: serverInfo.connectedAt || null,
             lastSeenAt: serverInfo.lastSeenAt || null
@@ -964,5 +1027,12 @@ module.exports = {
     shutdown,
     // 暴露给 PluginManager,在审核响应到达时清除对应缓存
     cancelVcpLogApprovalCache: (requestId) => vcpLogReplayManager.cancelApprovalCache(requestId),
-    getVcpLogReplayStats: () => vcpLogReplayManager.getStats()
+    getVcpLogReplayStats: () => vcpLogReplayManager.getStats(),
+    // Narrow test hooks for deterministic lifecycle tests; not used by production callers.
+    __testing: {
+        distributedServers,
+        pendingToolRequests,
+        sendCancelToolIfSupported,
+        rejectPendingToolRequestsForServer
+    }
 };

--- a/docs/DISTRIBUTED_ARCHITECTURE.md
+++ b/docs/DISTRIBUTED_ARCHITECTURE.md
@@ -861,3 +861,18 @@ module.exports = {
 **文档版本**: 1.0  
 **最后更新**: 2026-02-13  
 **相关文件**: `WebSocketServer.js`, `FileFetcherServer.js`, `Plugin.js`
+
+## 分布式工具取消与节点生命周期
+
+`executeDistributedTool()` 的 pending 项绑定目标 `serverId`。服务端只接受该节点返回的 `tool_result`；其他节点即使意外复用了同一个 `requestId` 也不会完成请求。目标节点断开时，服务端立即清理并 reject 该节点的所有 pending，并且不向已经关闭的 socket 发送取消帧。
+
+节点在 `register_tools.data.capabilities.cancelTool === true` 时声明支持取消。服务端 timeout 只在目标 socket 仍为 `OPEN` 且节点已声明该能力时 best-effort 发送一次：
+
+```json
+{
+  "type": "cancel_tool",
+  "data": { "requestId": "..." }
+}
+```
+
+旧节点未声明能力时不会收到该帧，但节点侧的本地 deadline 仍然独立生效。服务端断线清理与节点本地 AbortController 都是必要的生命周期边界，不能依赖对方在连接关闭后继续接收消息。

--- a/tests/distributedToolCancellation.test.js
+++ b/tests/distributedToolCancellation.test.js
@@ -1,0 +1,101 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const webSocketServer = require('../WebSocketServer');
+
+const {
+    distributedServers,
+    pendingToolRequests,
+    rejectPendingToolRequestsForServer
+} = webSocketServer.__testing;
+
+function createFakeServer({ cancelTool = true } = {}) {
+    const messages = [];
+    const ws = {
+        readyState: 1,
+        send(payload) {
+            messages.push(JSON.parse(payload));
+        }
+    };
+    return {
+        server: { ws, capabilities: { cancelTool }, tools: [] },
+        messages
+    };
+}
+
+function resetState() {
+    for (const pending of pendingToolRequests.values()) {
+        clearTimeout(pending.timeout);
+    }
+    pendingToolRequests.clear();
+    distributedServers.clear();
+}
+
+test.beforeEach(() => {
+    resetState();
+    webSocketServer.setPluginManager({
+        getPlugin() {
+            return { communication: { timeout: 20 } };
+        }
+    });
+});
+
+test.afterEach(resetState);
+
+test('timeout sends one cancel_tool only when the target declares support', async () => {
+    const { server, messages } = createFakeServer({ cancelTool: true });
+    distributedServers.set('server-a', server);
+
+    await assert.rejects(
+        webSocketServer.executeDistributedTool('server-a', 'demo-tool', {}, 10),
+        /timed out/
+    );
+
+    assert.equal(messages.filter(message => message.type === 'execute_tool').length, 1);
+    assert.equal(messages.filter(message => message.type === 'cancel_tool').length, 1);
+    assert.equal(pendingToolRequests.size, 0);
+});
+
+test('disconnect rejects target pending requests without sending to a closed socket', async () => {
+    const { server, messages } = createFakeServer({ cancelTool: true });
+    distributedServers.set('server-a', server);
+
+    const execution = webSocketServer.executeDistributedTool(
+        'server-a',
+        'demo-tool',
+        {},
+        5_000
+    );
+    rejectPendingToolRequestsForServer('server-a');
+
+    await assert.rejects(execution, /disconnected/);
+    assert.equal(messages.filter(message => message.type === 'cancel_tool').length, 0);
+    assert.equal(pendingToolRequests.size, 0);
+});
+
+test('tool_result from a non-target server cannot complete another node request', async () => {
+    const target = createFakeServer({ cancelTool: true });
+    const other = createFakeServer({ cancelTool: true });
+    distributedServers.set('server-a', target.server);
+    distributedServers.set('server-b', other.server);
+
+    const execution = webSocketServer.executeDistributedTool(
+        'server-a',
+        'demo-tool',
+        {},
+        5_000
+    );
+    const requestId = target.messages[0].data.requestId;
+
+    await webSocketServer.handleDistributedServerMessage('server-b', {
+        type: 'tool_result',
+        data: { requestId, status: 'success', result: 'wrong-node' }
+    });
+    assert.equal(pendingToolRequests.has(requestId), true);
+
+    await webSocketServer.handleDistributedServerMessage('server-a', {
+        type: 'tool_result',
+        data: { requestId, status: 'success', result: 'target-node' }
+    });
+    await assert.doesNotReject(execution);
+    assert.equal(await execution, 'target-node');
+});


### PR DESCRIPTION
改动内容包括：
节点通过 capabilities.cancelTool 声明是否支持取消
分布式工具超时时，向目标节点最多发送一次 cancel_tool
节点断开时立即 reject 该节点的 pending 请求
防止其他节点伪造或误用相同 requestId 完成请求
增加取消、断线清理、跨节点结果校验测试
补充分布式架构文档