### PR TITLE
fix(TavilySearch): override SDK default days param to prevent conflict with start_date/end_date

### DIFF
--- a/Plugin/TavilySearch/TavilySearch.js
+++ b/Plugin/TavilySearch/TavilySearch.js
@@ -138,6 +138,9 @@ async function main() {
                     searchOptions.end_date = endDate.trim();
                 }
                 searchOptions.time_range = null; // 显式覆盖任何默认或传入的 time_range 值
+                // 防御 @tavily/core 0.5.2 SDK 内部 _search() 函数硬编码 days:3 默认值的问题
+                // SDK 合并参数时 defaultOptions.days=3 不会被 undefined 覆盖，需显式传入
+                searchOptions.days = undefined;
             } else if (time_range) {
                 // 仅在没有日期范围时才使用 time_range 参数
                 const validTimeRanges = ['day', 'week', 'month', 'year', 'd', 'w', 'm', 'y'];

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@dqbd/tiktoken": "^1.0.22",
     "@mozilla/readability": "^0.6.0",
     "@node-rs/jieba": "^2.0.1",
-    "@tavily/core": "^0.5.2",
+    "@tavily/core": "^0.7.6",
     "axios": "^1.6.0",
     "basic-auth": "^2.0.1",
     "better-sqlite3": "^12.4.1",


### PR DESCRIPTION
## 问题
当调用 TavilySearch 同时传入 `topic:"news"` + `start_date`/`end_date` 时，
Tavily API 返回 400 错误：`"When days is set, start_date or end_date cannot be set"`
根因：

@tavily/core@0.5.2
 内部 
_search()
 函数硬编码 
days: 3
 作为默认值。
SDK 合并参数时，如果调用者未显式传入 days，默认值 3 会保留在请求体中，
与 start_date/end_date 产生互斥冲突。


修复：
TavilySearch.js：在日期参数处理块后显式传入 
searchOptions.days = undefined
，
利用 JS spread 覆盖 SDK 默认值 + JSON.stringify 跳过 undefined 字段的特性

package.json：升级 
@tavily/core
 从 
^0.5.2
 到 
^0.7.6
（新版已将 days 默认值改为 undefined）


验证：
topic:"news" + start_date + end_date
 组合搜索成功返回结果

SDK 0.5.2 + 补丁 ✅

SDK 0.7.6 + 补丁 ✅（双重保险）

注：调研了一番，SDK 升级兼容性评估（0.5.2 → 0.7.6）
维度 | 0.5.2 现状 | 0.7.6 变化 | VCP兼容？
-- | -- | -- | --
初始化 | tavily({ apiKey }) | 相同，无变化 | ✅
search() 签名 | (query, options) | 相同 | ✅
参数命名 | camelCase 传入，SDK 内部转 snake_case | 相同机制 | ✅
VCP传参方式 | 直接传 snake_case（如 search_depth） | SDK现在用 camelCase 接口，snake_case 进入 kwargs 透传 | ⚠️ 关键
响应格式 | results[].title/url/content | 相同，新增 publishedDate, favicon | ✅
days 默认值 | 3（硬编码） | 预期已改为 undefined | ✅ 根本解
新参数 | — | startDate, endDate, autoParameters, exactMatch 等 | ✅ 向后兼容

但我并没有完整测试升级后的所有命令。