### PR TITLE
fix: upgrade axios to 1.12.0, 0.30.2 (CVE-2025-58754)

### DIFF
--- a/Plugin/ComfyUIGen/package-lock.json
+++ b/Plugin/ComfyUIGen/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.0",
+        "axios": "^1.12.0",
         "uuid": "^9.0.0"
       }
     },
@@ -20,9 +20,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/Plugin/ComfyUIGen/package.json
+++ b/Plugin/ComfyUIGen/package.json
@@ -4,10 +4,15 @@
   "description": "ComfyUI image generation plugin for VCP",
   "main": "ComfyUIGen.js",
   "dependencies": {
-    "axios": "^1.6.0",
+    "axios": "^1.12.0",
     "uuid": "^9.0.0"
   },
-  "keywords": ["comfyui", "image-generation", "ai", "vcp-plugin"],
+  "keywords": [
+    "comfyui",
+    "image-generation",
+    "ai",
+    "vcp-plugin"
+  ],
   "author": "Kilo Code",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
Upgrade axios from 1.11.0 to 1.12.0, 0.30.2 to fix CVE-2025-58754.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2025-58754 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2025-58754` |
| **File** | `Plugin/ComfyUIGen/package-lock.json` (dependency: `axios`) |
| **Assessment** | Likely exploitable |

**Description**: axios: Axios DoS via lack of data size check

## Evidence

**Scanner confirmation**: trivy rule `CVE-2025-58754` flagged this pattern.

## Changes
- `Plugin/ComfyUIGen/package.json`
- `Plugin/ComfyUIGen/package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
