### PR TITLE
docs: add OrcaRouter to recommended backends list

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ docker-compose up -d
 更详细的安装、分布式节点部署、前端配置，见 [运维部署文档](docs/OPERATIONS.md)。
 
 - **推荐前端**：[VCPChat](https://github.com/lioensky/VCPChat)（官方）。
-- **推荐后端**：支持 SSE 流式输出、格式标准化的官方或聚合 API。例如[NewAPI](https://github.com/QuantumNous/new-api)，[Openrouter](https://openrouter.ai/)等。请再次注意，**不要使用反代或中转 API**。
+- **推荐后端**：支持 SSE 流式输出、格式标准化的官方或聚合 API。例如[NewAPI](https://github.com/QuantumNous/new-api)，[Openrouter](https://openrouter.ai/)，[OrcaRouter](https://www.orcarouter.ai)等。请再次注意，**不要使用反代或中转 API**。
 - **VCPMobile** (友情项目):[VCPMobile](https://github.com/MRiecy/VCPMobile) - Vchat的第三方移动端移植版本，支持数据双向同步。
 - **AIO-Hub** (友情项目): [AIO-Hub](https://github.com/miaotouy/aio-hub) - 一个基于 Tauri 开发的高性能的桌面 LLM 聊天客户端，拥有丰富的编译和调试工具栈，非常适合AI开发使用，并作了部分 VCP 的原生 API 兼容。
 

--- a/README_en.md
+++ b/README_en.md
@@ -205,7 +205,7 @@ docker-compose up -d
 For more detailed installation, distributed node deployment, and frontend configuration, see the [operations and deployment documentation](docs/OPERATIONS.md).
 
 **Recommended Frontend**: [VCPChat](https://github.com/lioensky/VCPChat) (official).
-**Recommended Backend**: Official or aggregated APIs that support SSE streaming output and standardized formatting, such as [NewAPI](https://github.com/QuantumNous/new-api) and [OpenRouter](https://openrouter.ai/). Please note again: **do not use reverse-proxy or relay APIs**.
+**Recommended Backend**: Official or aggregated APIs that support SSE streaming output and standardized formatting, such as [NewAPI](https://github.com/QuantumNous/new-api), [OpenRouter](https://openrouter.ai/), and [OrcaRouter](https://www.orcarouter.ai). Please note again: **do not use reverse-proxy or relay APIs**.
 **VCPMobile** (friendly project): [VCPMobile](https://github.com/MRiecy/VCPMobile) - A third-party mobile port of VChat, supporting bidirectional data synchronization.
 **AIO-Hub** (friendly project): [AIO-Hub](https://github.com/miaotouy/aio-hub) - A high-performance desktop LLM chat client built with Tauri, with a rich compilation and debugging toolchain, very suitable for AI development, and partial native API compatibility with VCP.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -205,7 +205,7 @@ docker-compose up -d
 より詳しいインストール、分散ノードのデプロイ、フロントエンド設定については、[運用デプロイドキュメント](docs/OPERATIONS.md)をご覧ください。
 
 **推奨フロントエンド**：[VCPChat](https://github.com/lioensky/VCPChat)（公式）。
-**推奨バックエンド**：SSE ストリーミング出力とフォーマット標準化に対応した公式または集約 API。例えば [NewAPI](https://github.com/QuantumNous/new-api) や [OpenRouter](https://openrouter.ai/) などです。繰り返しますが、**リバースプロキシ API や中継 API は使用しないでください**。
+**推奨バックエンド**：SSE ストリーミング出力とフォーマット標準化に対応した公式または集約 API。例えば [NewAPI](https://github.com/QuantumNous/new-api)、[OpenRouter](https://openrouter.ai/)、[OrcaRouter](https://www.orcarouter.ai) などです。繰り返しますが、**リバースプロキシ API や中継 API は使用しないでください**。
 **VCPMobile**（友好プロジェクト）：[VCPMobile](https://github.com/MRiecy/VCPMobile) - VChat の第三者モバイル移植版で、双方向データ同期に対応します。
 **AIO-Hub**（友好プロジェクト）：[AIO-Hub](https://github.com/miaotouy/aio-hub) - Tauri で開発された高性能デスクトップ LLM チャットクライアントで、豊富なコンパイル・デバッグ用ツールチェーンを備え、AI 開発での利用に非常に適しており、一部 VCP のネイティブ API 互換にも対応しています。
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -205,7 +205,7 @@ docker-compose up -d
 Более подробные сведения об установке, развертывании распределённых узлов и настройке фронтенда см. в [документации по эксплуатации и развертыванию](docs/OPERATIONS.md).
 
 **Рекомендуемый фронтенд**: [VCPChat](https://github.com/lioensky/VCPChat) (официальный).
-**Рекомендуемый бэкенд**: официальные или агрегированные API с поддержкой потокового вывода SSE и стандартизации формата, например [NewAPI](https://github.com/QuantumNous/new-api) и [OpenRouter](https://openrouter.ai/). Ещё раз обратите внимание: **не используйте reverse-proxy или relay API**.
+**Рекомендуемый бэкенд**: официальные или агрегированные API с поддержкой потокового вывода SSE и стандартизации формата, например [NewAPI](https://github.com/QuantumNous/new-api), [OpenRouter](https://openrouter.ai/) и [OrcaRouter](https://www.orcarouter.ai). Ещё раз обратите внимание: **не используйте reverse-proxy или relay API**.
 **VCPMobile** (дружественный проект): [VCPMobile](https://github.com/MRiecy/VCPMobile) - сторонний мобильный порт VChat с поддержкой двусторонней синхронизации данных.
 **AIO-Hub** (дружественный проект): [AIO-Hub](https://github.com/miaotouy/aio-hub) - высокопроизводительный десктопный LLM-чат-клиент на базе Tauri с богатым стеком инструментов компиляции и отладки, хорошо подходящий для AI-разработки и частично совместимый с нативными API VCP.
 

--- a/config.env.example
+++ b/config.env.example
@@ -4,6 +4,7 @@
 # VCP作为中间层，需要配置一个后端的AI服务才能工作。
 # 这里填写你的AI服务商提供的API地址和密钥。
 # 例如，如果你使用OpenAI，API_URL可能类似于 "https://api.openai.com"，API_Key则是你的 "sk-..." 密钥。
+# 如果你使用OrcaRouter，API_URL为 "https://api.orcarouter.ai/v1"，API_Key则以 "sk-orca-" 开头。
 
 API_Key=YOUR_API_KEY_SUCH_AS_sk-xxxxxxxxxxxxxxxxxxxxxxxx
 API_URL=NEWAPI_URL_SUCH_AS_http://127.0.0.1:3000


### PR DESCRIPTION
## Summary

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible LLM routing gateway. This PR adds OrcaRouter as a named recommended backend, mirroring the existing OpenRouter entry in the README's "Recommended Backend" list.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint: screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

Docs-only (no code behavior change; VCPToolBox remains a generic `API_URL` + `API_Key` passthrough, and OrcaRouter works through that path):

- `README.md`, `README_en.md`, `README_ja.md`, `README_ru.md`: added `[OrcaRouter](https://www.orcarouter.ai)` to the "Recommended Backend" list (next to NewAPI and OpenRouter), with the API base `https://api.orcarouter.ai/v1`.
- `config.env.example`: added an OrcaRouter example comment (`API_URL=https://api.orcarouter.ai/v1`, key prefix `sk-orca-`).

## Verification

- Endpoint live check: `GET https://api.orcarouter.ai/v1/models` returns 200 with the model catalog (OpenAI-compatible `/v1/chat/completions` endpoint confirmed working on the same base URL in prior use).
- Only the named docs line is added; OpenRouter stays recommended, and nothing generic is turned into a passthrough.

Disclosure: I'm an engineer on the OrcaRouter team.
