### PR TITLE
feat(TomatoNovel): add configurable novel downloader plugin

### DIFF
--- a/Plugin/TomatoNovel/.gitignore
+++ b/Plugin/TomatoNovel/.gitignore
@@ -1,0 +1,6 @@
+config.env
+__pycache__/
+*.epub
+*.log
+logs/
+downloads/

--- a/Plugin/TomatoNovel/README.md
+++ b/Plugin/TomatoNovel/README.md
@@ -1,0 +1,49 @@
+# TomatoNovel
+
+TomatoNovel 是一个同步 `stdio` 插件，用于通过本地 TomatoNovelDownloader 服务搜索番茄小说、下载 EPUB，并提取简介与目录。下载器本身由用户单独安装和配置；插件不会携带下载器二进制文件。
+
+## 能力
+
+- `search`: 按关键词搜索书籍。
+- `download_intro`: 下载最小章节范围并返回简介、作者信息和目录摘要。
+- `download`: 下载整本 EPUB，并处理下载器生成的输出文件。
+
+## 安装与配置
+
+1. 安装可用的 `TomatoNovelDownloader.exe`，并确认它支持 `--server` 参数。
+2. 复制 `config.env.example` 为同目录的 `config.env`。
+3. 设置 `TOMATO_DOWNLOADER_PATH` 为本机下载器的绝对路径。可选地设置工作目录、输出目录、服务端口和代理。
+4. 在 VCPToolBox 中加载此目录的 `plugin-manifest.json`。
+
+`config.env` 只存在于本机，不能提交到 Git。插件不再包含任何开发者本机路径或固定代理；未配置下载器时会给出明确错误。
+
+## 调用示例
+
+```json
+{"tool_name":"TomatoNovel","action":"search","query":"科幻小说"}
+```
+
+```json
+{"tool_name":"TomatoNovel","action":"download_intro","book_id":"7580018670118652952"}
+```
+
+```json
+{"tool_name":"TomatoNovel","action":"download","book_id":"7580018670118652952"}
+```
+
+命令行冒烟测试：
+
+```powershell
+'{"tool_name":"TomatoNovel","action":"search","query":"科幻小说"}' | node TomatoNovel.js
+```
+
+## 运行依赖
+
+- Node.js 18 或更高版本
+- Python 3（用于 `download_intro` 的 EPUB 摘要提取）
+- 本机可运行的 TomatoNovelDownloader
+- 插件目录可解析 `dotenv`（VCPToolBox 根目录通常已提供）
+
+## 说明
+
+请确认你对请求的小说内容拥有相应的访问和使用权，并遵守目标站点的服务条款。下载器的网络请求、登录状态和代理由用户自行负责。

--- a/Plugin/TomatoNovel/TomatoNovel.js
+++ b/Plugin/TomatoNovel/TomatoNovel.js
@@ -1,0 +1,374 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { spawn, exec } = require('child_process');
+const http = require('http');
+
+// 读取同级目录的 config.env
+require('dotenv').config({ path: path.resolve(__dirname, 'config.env') });
+
+const configuredPort = Number.parseInt(process.env.TOMATO_DOWNLOADER_PORT || '18423', 10);
+const PORT = Number.isInteger(configuredPort) && configuredPort > 0 && configuredPort <= 65535
+    ? configuredPort
+    : 18423;
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+const DEFAULT_EXE_PATH = '';
+
+// 帮助实现简易 HTTP 请求的 Promise 包装（使用 Node.js 原生 http）
+function httpRequest(method, urlPath, bodyData = null) {
+    return new Promise((resolve, reject) => {
+        const options = {
+            hostname: '127.0.0.1',
+            port: PORT,
+            path: urlPath,
+            method: method,
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        };
+
+        const req = http.request(options, (res) => {
+            let data = '';
+            res.setEncoding('utf8');
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => {
+                if (res.statusCode >= 200 && res.statusCode < 300) {
+                    try {
+                        resolve(JSON.parse(data));
+                    } catch (e) {
+                        resolve(data);
+                    }
+                } else {
+                    reject(new Error(`HTTP Status ${res.statusCode}: ${data}`));
+                }
+            });
+        });
+
+        req.on('error', (e) => { reject(e); });
+
+        if (bodyData) {
+            req.write(JSON.stringify(bodyData));
+        }
+        req.end();
+    });
+}
+
+// 检查服务是否在线，若不在线则自动拉起
+async function ensureServerOnline() {
+    try {
+        // 尝试发送一个极速的 ping 请求 (timeout 1.5s)
+        await Promise.race([
+            httpRequest('GET', '/api/jobs'),
+            new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 1500))
+        ]);
+        return; // 在线，直接返回
+    } catch (err) {
+        // 不在线，开始执行拉起逻辑
+        const exePath = process.env.TOMATO_DOWNLOADER_PATH || DEFAULT_EXE_PATH;
+        const cwd = process.env.TOMATO_DOWNLOADER_CWD || (exePath ? path.dirname(exePath) : process.cwd());
+
+        if (!fs.existsSync(exePath)) {
+            throw new Error('未配置或找不到 TomatoNovelDownloader.exe，请设置 TOMATO_DOWNLOADER_PATH。');
+        }
+
+        const childEnv = { ...process.env };
+        const proxy = process.env.TOMATO_HTTP_PROXY;
+        if (proxy) {
+            childEnv.HTTP_PROXY = proxy;
+            childEnv.HTTPS_PROXY = proxy;
+        }
+
+        // 以分离模式（detached）在后台拉起下载器
+        const serverProcess = spawn(exePath, ['--server'], {
+            cwd: cwd,
+            detached: true,
+            stdio: 'ignore',
+            windowsHide: true,
+            env: {
+                ...childEnv
+            }
+        });
+
+        serverProcess.on('error', (spawnErr) => {
+            console.error(`[TomatoNovel] 拉起后台进程失败: ${spawnErr.message}`);
+        });
+
+        serverProcess.unref();
+
+        // 自旋探测端口就绪状态，最多重试 15 次 (约 6.0 秒)
+        for (let i = 0; i < 15; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 400));
+            try {
+                await Promise.race([
+                    httpRequest('GET', '/api/jobs'),
+                    new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 800))
+                ]);
+                return; // 通了，说明服务完全就绪！
+            } catch (pingErr) {
+                // 忽略，等待下一次轮询自旋
+            }
+        }
+        throw new Error(`后台下载服务已拉起，但自旋探测未能通 ${PORT} 端口，可能初始化失败。`);
+    }
+}
+
+// 从 stdin 读取参数
+function readInput() {
+    return new Promise((resolve) => {
+        const stdin = process.stdin;
+        let data = '';
+        stdin.setEncoding('utf8');
+        stdin.on('data', (chunk) => { data += chunk; });
+        stdin.on('end', () => { resolve(data); });
+        if (stdin.isTTY) { resolve('{}'); }
+    });
+}
+
+async function handleSearch(query) {
+    const data = await httpRequest('GET', `/api/search?q=${encodeURIComponent(query)}`);
+    const books = data.items || [];
+
+    if (books.length === 0) {
+        return {
+            status: 'success',
+            result: `未能在番茄小说上搜索到与 "${query}" 相关的书籍。`
+        };
+    }
+
+    // 格式化为非常漂亮的 Markdown 表格
+    let md = [];
+    md.push(`### 🔍 针对 "${query}" 的番茄小说搜索结果 (共 ${books.length} 本)`);
+    md.push("| 序号 | 书名 | 作者 | 类别/标签 | 在读人数 | 书籍 ID |");
+    md.push("|:---:|:---|:---|:---|:---|:---|");
+
+    books.forEach((book, idx) => {
+        const title = book.title || (book.raw && book.raw.book_name) || "未知";
+        const author = book.author || (book.raw && book.raw.author) || "未知";
+        const category = book.raw ? book.raw.pure_category_tags || book.raw.category || "无" : "无";
+        const score = book.raw ? book.raw.score || "无评分" : "无评分";
+        const readers = book.raw ? book.raw.read_cnt_text || "未知" : "未知";
+        const book_id = book.book_id;
+        md.push(`| ${idx + 1} | **${title}** | ${author} | \`${category}\` | ${readers} (评分: ${score}) | \`${book_id}\` |`);
+    });
+
+    return {
+        status: 'success',
+        result: md.join('\n')
+    };
+}
+
+async function handleDownload(bookId, rangeStart = null, rangeEnd = null, isIntroOnly = false) {
+    // 1. 创建下载 Job
+    const jobReq = { book_id: bookId };
+    if (rangeStart !== null && rangeEnd !== null) {
+        jobReq.range_start = rangeStart;
+        jobReq.range_end = rangeEnd;
+    }
+
+    let jobResp;
+    try {
+        jobResp = await httpRequest('POST', '/api/jobs', jobReq);
+    } catch (postErr) {
+        if (postErr.message && postErr.message.includes('429')) {
+            // 遇到了 429 并发限制，开始自动清理挂起在 Rust 内存里的旧任务占用的通道
+            try {
+                const activeJobs = await httpRequest('GET', '/api/jobs');
+                const items = activeJobs.items || [];
+                for (const item of items) {
+                    const activeJobId = item.id;
+                    // 发送 cancel 请求以强行移除和停止旧的无主活跃任务
+                    await httpRequest('POST', `/api/jobs/${activeJobId}/cancel`, {});
+                }
+                // 等待 1.0 秒给后端释放通道
+                await new Promise((resolve) => setTimeout(resolve, 1000));
+                // 重新尝试提交创建任务
+                jobResp = await httpRequest('POST', '/api/jobs', jobReq);
+            } catch (retryErr) {
+                throw new Error(`并发下载通道被占用 (HTTP 429)，且自动清理重试失败: ${retryErr.message}`);
+            }
+        } else {
+            throw postErr;
+        }
+    }
+    const jobId = jobResp.id;
+
+    // 2. 轮询等待任务结束，并自动提交名字/格式选择
+    let jobDone = false;
+    let jobResult = null;
+    const maxRetries = 400; // 调大轮询以防全本下载时间长
+
+    for (let check = 0; check < maxRetries; check++) {
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+
+        const jobsData = await httpRequest('GET', '/api/jobs');
+        const items = jobsData.items || [];
+
+        let currentJob = items.find(item => item.id === jobId);
+        if (!currentJob) {
+            // 不在活跃任务中，去 history 查
+            const historyData = await httpRequest('GET', '/api/history');
+            const historyItems = historyData.items || [];
+            currentJob = historyItems.find(item => item.id === jobId);
+
+            if (!currentJob) {
+                // 如果历史里也没有，可能被清理了，或者是完成了
+                jobDone = true;
+                break;
+            }
+        }
+
+        const status = currentJob.status || {};
+        const stateStr = currentJob.state || "";
+
+        // 自动选择书名
+        if (currentJob.book_name_options && currentJob.book_name_options.length > 0) {
+            const choice = currentJob.book_name_options[0];
+            await httpRequest('POST', `/api/jobs/${jobId}/book_name`, { value: choice });
+        }
+
+        // 自动选择格式
+        if (currentJob.format_options && currentJob.format_options.length > 0) {
+            const choice = currentJob.format_options[0];
+            await httpRequest('POST', `/api/jobs/${jobId}/format`, { value: choice });
+        }
+
+        // 成功或失败判定
+        if (stateStr === 'done' || stateStr.includes('Done') || stateStr.includes('Success')) {
+            jobDone = true;
+            jobResult = { status: 'success', currentJob };
+            break;
+        } else if (stateStr === 'failed' || stateStr.includes('Failed')) {
+            jobDone = true;
+            jobResult = { status: 'error', error: currentJob.message || "下载任务失败" };
+            break;
+        }
+    }
+
+    if (!jobDone) {
+        throw new Error("下载任务轮询超时，仍在后台运行中。");
+    }
+
+    if (jobResult.status === 'error') {
+        return {
+            status: 'error',
+            error: jobResult.error
+        };
+    }
+
+    // 3. 定位生成的 EPUB 文件物理路径
+    const bookTitle = jobResult.currentJob.title || "未知小说";
+    const exePath = process.env.TOMATO_DOWNLOADER_PATH || DEFAULT_EXE_PATH;
+    const downloadDir = process.env.TOMATO_DOWNLOAD_DIR || (exePath ? path.dirname(exePath) : process.cwd());
+
+    // 番茄下载器默认会把小说打包保存在下载目录的 "<书名>.epub"
+    let epubPath = path.join(downloadDir, `${bookTitle}.epub`);
+
+    if (!fs.existsSync(epubPath)) {
+        const fallbackPath = path.join(downloadDir, `${bookId}.epub`);
+        if (fs.existsSync(fallbackPath)) {
+            try {
+                fs.renameSync(fallbackPath, epubPath);
+                console.error(`[TomatoNovel] Web fallback detected, renamed ${bookId}.epub to ${bookTitle}.epub`);
+            } catch (renameErr) {
+                epubPath = fallbackPath; // 重命名失败则直接使用 bookId.epub 路径
+            }
+        }
+    }
+
+    if (!fs.existsSync(epubPath)) {
+        return {
+            status: 'error',
+            error: `下载已标记完成，但是在输出目录下未能定位到 EPUB 文件: ${epubPath}`
+        };
+    }
+
+    // 4. 处理 "仅下载首页和目录" 的大纲模式
+    if (isIntroOnly) {
+        return new Promise((resolve) => {
+            const scriptPath = path.join(__dirname, 'extract_intro.py');
+            exec(`python "${scriptPath}" "${epubPath}"`, (err, stdout, stderr) => {
+                // 读取完大纲后，因为只是临时的大纲包，自动清理这个只下了 1 章的临时 epub 文件以节省磁盘空间！
+                try {
+                    fs.unlinkSync(epubPath);
+                } catch (e) {}
+
+                if (err) {
+                    resolve({
+                        status: 'error',
+                        error: `提取大纲失败: ${stderr || err.message}`
+                    });
+                } else {
+                    resolve({
+                        status: 'success',
+                        result: `### 📖 《${bookTitle}》 首页与大纲信息已成功提取！\n\n` + stdout.trim()
+                    });
+                }
+            });
+        });
+    }
+
+    // 5. 全本精准下载模式
+    return {
+        status: 'success',
+        result: `### 🎉 小说全本下载成功！\n\n` +
+                `- **书名**：《${bookTitle}》\n` +
+                `- **作者**：${jobResult.currentJob.author || "未知"}\n` +
+                `- **章节总数**：${jobResult.currentJob.progress ? jobResult.currentJob.progress.chapter_total : "未知"} 章\n` +
+                `- **存储路径**：\`${epubPath}\` (标准 EPUB 格式，字体脱混淆已完全解密)\n\n` +
+                `您已可以直接在对应路径找到该文件进行阅读。`
+    };
+}
+
+async function main() {
+    let output;
+    try {
+        // 1. 读取标准输入
+        const input = await readInput();
+        const request = JSON.parse(input);
+
+        // 自动解析或提取子命令 action
+        // 支持统合后的 action 参数，同时兼容旧的 tool_name 别名
+        let action = request.action;
+        const toolName = request.tool_name || "";
+
+        if (!action) {
+            if (toolName === "TomatoNovelSearch") action = "search";
+            else if (toolName === "TomatoNovelDownload") action = "download";
+            else if (toolName === "TomatoNovelDownloadIntro") action = "download_intro";
+        }
+
+        // 2. 保证底层 Rust 服务在后台运行
+        await ensureServerOnline();
+
+        // 3. 路由具体业务 Action
+        if (action === "search") {
+            const query = request.query;
+            if (!query) throw new Error("缺少搜索关键词 'query' 参数。");
+            output = await handleSearch(query);
+        } else if (action === "download") {
+            const bookId = request.book_id;
+            if (!bookId) throw new Error("缺少书籍 ID 'book_id' 参数。");
+            // 全本精准下载
+            output = await handleDownload(bookId, null, null, false);
+        } else if (action === "download_intro") {
+            const bookId = request.book_id;
+            if (!bookId) throw new Error("缺少书籍 ID 'book_id' 参数。");
+            // 仅下载大纲（指定 range 1-1 并开启 isIntroOnly）
+            output = await handleDownload(bookId, 1, 1, true);
+        } else {
+            throw new Error(`未支持的 Action: ${action || toolName}`);
+        }
+
+    } catch (e) {
+        output = { status: 'error', error: e.message };
+    } finally {
+        // 输出 JSON 结果给 VCP 插件调度系统
+        console.log(JSON.stringify(output, null, 2));
+        if (output.status === 'error') {
+            process.exit(1);
+        }
+    }
+}
+
+main();

--- a/Plugin/TomatoNovel/config.env.example
+++ b/Plugin/TomatoNovel/config.env.example
@@ -1,0 +1,17 @@
+# Copy this file to config.env and adjust paths for your installation.
+# Do not commit config.env.
+
+# Required: absolute path to TomatoNovelDownloader.exe.
+TOMATO_DOWNLOADER_PATH=
+
+# Optional working directory. Defaults to the executable directory.
+TOMATO_DOWNLOADER_CWD=
+
+# Optional output directory. Defaults to the executable directory.
+TOMATO_DOWNLOAD_DIR=
+
+# Optional local downloader HTTP port.
+TOMATO_DOWNLOADER_PORT=18423
+
+# Optional proxy for the downloader process only.
+# TOMATO_HTTP_PROXY=http://127.0.0.1:7897

--- a/Plugin/TomatoNovel/extract_intro.py
+++ b/Plugin/TomatoNovel/extract_intro.py
@@ -1,0 +1,83 @@
+import zipfile
+import re
+import sys
+import io
+
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+
+def extract_epub_intro(epub_path):
+    try:
+        with zipfile.ZipFile(epub_path, 'r') as z:
+            namelist = z.namelist()
+
+            # 1. 提取简介
+            intro_content = "暂无详细简介"
+            intro_files = [f for f in namelist if "aux_" in f]
+            if intro_files:
+                try:
+                    with z.open(intro_files[0]) as f:
+                        html = f.read().decode('utf-8')
+                        # 去除标签与样式
+                        text = re.sub(r'<[^>]+>', '', html).strip()
+                        lines = [l.strip() for l in text.split('\n') if l.strip()]
+                        # 过滤掉重复的“简介”标题
+                        clean_lines = []
+                        for line in lines:
+                            if line == "简介" and len(clean_lines) < 2:
+                                continue
+                            clean_lines.append(line)
+                        intro_content = "\n".join(clean_lines)
+                except Exception:
+                    pass
+
+            # 2. 提取目录
+            chapters = []
+            chapter_files = sorted([f for f in namelist if "chapter_" in f])
+            total_chapters = len(chapter_files)
+
+            def get_title(filepath):
+                try:
+                    with z.open(filepath) as f:
+                        html = f.read().decode('utf-8')
+                        title_match = re.search(r'<title>(.*?)</title>', html, re.IGNORECASE)
+                        if title_match:
+                            return title_match.group(1).strip()
+                        text = re.sub(r'<[^>]+>', '', html).strip()
+                        lines = [l.strip() for l in text.split('\n') if l.strip()]
+                        return lines[0] if lines else "未知章节"
+                except Exception:
+                    return "章节读取失败"
+
+            if total_chapters == 0:
+                chapters.append("(未检测到章节)")
+            elif total_chapters <= 30:
+                for f in chapter_files:
+                    chapters.append(get_title(f))
+            else:
+                for f in chapter_files[:15]:
+                    chapters.append(get_title(f))
+                chapters.append(f"... (中间省略 {total_chapters - 20} 章) ...")
+                for f in chapter_files[-5:]:
+                    chapters.append(get_title(f))
+
+            # 3. 组织为精美的 Markdown
+            md = []
+            md.append(f"## 📖 小说大纲简介\n\n{intro_content}\n")
+            md.append(f"## 🗂️ 小说目录大纲 (共 {total_chapters} 章)\n")
+            for title in chapters:
+                if "中间省略" in title:
+                    md.append(f"\n{title}\n")
+                else:
+                    md.append(f"- {title}")
+            return "\n".join(md)
+
+    except Exception as e:
+        return f"Error reading EPUB: {e}"
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python extract_intro.py <path_to_epub>")
+        sys.exit(1)
+    epub_path = sys.argv[1]
+    report = extract_epub_intro(epub_path)
+    print(report)

--- a/Plugin/TomatoNovel/plugin-manifest.json
+++ b/Plugin/TomatoNovel/plugin-manifest.json
@@ -1,0 +1,48 @@
+{
+  "manifestVersion": "1.0.0",
+  "name": "TomatoNovel",
+  "version": "1.0.0",
+  "displayName": "番茄小说增强器",
+  "description": "提供多功能搜书、全本精准下载、以及极速下载大纲目录等功能。",
+  "author": "Antigravity",
+  "pluginType": "synchronous",
+  "entryPoint": {
+    "type": "nodejs",
+    "command": "node TomatoNovel.js"
+  },
+  "communication": {
+    "protocol": "stdio",
+    "timeout": 720000
+  },
+  "configSchema": {
+    "TOMATO_DOWNLOADER_PATH": {
+      "type": "string",
+      "description": "TomatoNovelDownloader.exe 的绝对路径。"
+    },
+    "TOMATO_DOWNLOADER_CWD": {
+      "type": "string",
+      "description": "下载器工作目录；留空时使用可执行文件所在目录。"
+    },
+    "TOMATO_DOWNLOAD_DIR": {
+      "type": "string",
+      "description": "下载器输出目录；留空时使用可执行文件所在目录。"
+    },
+    "TOMATO_DOWNLOADER_PORT": {
+      "type": "integer",
+      "description": "下载器本地 HTTP 服务端口，默认 18423。"
+    },
+    "TOMATO_HTTP_PROXY": {
+      "type": "string",
+      "description": "可选 HTTP/HTTPS 代理地址。"
+    }
+  },
+  "capabilities": {
+    "invocationCommands": [
+      {
+        "commandIdentifier": "TomatoNovel",
+        "description": "调用此工具管理番茄小说，支持搜书、下载全本、下载简介和大纲目录。\n参数:\n- action (字符串, 必需): 细分功能类型。可选：'search' (搜书), 'download' (精准全本下载), 'download_intro' (仅下载大纲)。\n- query (字符串, 条件必需): 搜书时必需，表示搜索关键词（主角/分类/Tags/设定等）。\n- book_id (字符串, 条件必需): 下载或提取大纲时必需，表示书籍的唯一 ID。\n调用格式:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」TomatoNovel「末」,\naction:「始」search「末」,\nquery:「始」穿成哈利邻居 程序员转生「末」\n<<<[END_TOOL_REQUEST]>>>",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」TomatoNovel「末」,\naction:「始」download_intro「末」,\nbook_id:「始」7580018670118652952「末」\n<<<[END_TOOL_REQUEST]>>>"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 简介
TomatoNovel 是一个同步 stdio 插件，通过用户本机安装的 TomatoNovelDownloader 服务搜索番茄小说、下载 EPUB，并提取简介与目录摘要。插件不携带下载器二进制文件，也不包含开发者本机路径或代理配置。

## README
- 配置与调用方式：`Plugin/TomatoNovel/README.md`
- 示例配置：`Plugin/TomatoNovel/config.env.example`
- 运行入口：`Plugin/TomatoNovel/TomatoNovel.js`

## 安全与兼容性
- 真实 `config.env` 未提交，下载器路径、工作目录、输出目录、端口和代理均由环境变量显式配置。
- 已排除 EPUB、日志和本地运行产物。
- 已通过 Node.js 语法检查和 Python 摘要提取器语法检查。

这是我用VCP 10个月来，一些自己用着比较顺手的自制插件，要是觉得有用可以加入，或者要是有什么功能可以归并到现有的插件中也可以