### PR TITLE
feat(NeteaseMusic): add music assistant plugin

### DIFF
--- a/Plugin/NeteaseMusic/.gitignore
+++ b/Plugin/NeteaseMusic/.gitignore
@@ -1,0 +1,9 @@
+config.env
+*cookies*.txt
+node_modules/
+downloads/
+output/
+*.mp3
+*.flac
+*.wav
+scratch/

--- a/Plugin/NeteaseMusic/README.md
+++ b/Plugin/NeteaseMusic/README.md
@@ -1,0 +1,52 @@
+# NeteaseMusic
+
+NeteaseMusic 是一个同步 `stdio` 插件，基于 NeteaseCloudMusicApi 为 VCPToolBox 提供网易云音乐搜索、歌单、歌词、播放链接、个人记录、下载和可选的音频分析能力。
+
+## 能力概览
+
+- 公共查询：`search`、`playlist`、`playlist_all_songs`、`song_detail`、`song_info`、`share_song`、`cover`、`song_url`、`lyric`、`top_playlist`。
+- 登录数据：`my_playlists`、`user_playlist`、`recent_songs`、`top_songs`、`daily_recommend`、`today_listens`、`login_status`。
+- 账号写操作：`like_song`、`unlike_song`、`add_to_playlist`、`remove_from_playlist`。支持 `dryRun=true` 预检。
+- 本地能力：`download` 下载音频；`analyze` 使用 VCPToolBox 主配置中的多模态模型分析音频。
+
+所有调用都使用 `action`，歌曲可以用 `id`、`ids`、`songId`、歌曲 URL、分享短链或完整分享文案定位。
+
+## 配置
+
+复制 `config.env.example` 为 `config.env`。公共查询无需 Cookie；个人数据、推荐、写操作和高音质下载通常需要有效的 `NETEASE_COOKIE`。也可以将 Netscape Cookie 导出为插件目录下的 `music.163.com_cookies.txt`，该文件只保存在本机。
+
+```env
+NETEASE_COOKIE=
+```
+
+不要把 Cookie、下载音频、`node_modules` 或测试输出提交到 Git。音频分析还需要 VCPToolBox 根配置提供可用的多模态模型和 API 地址；下载压缩路径需要本机安装 `ffmpeg`。
+
+## 调用示例
+
+```text
+<<<[TOOL_REQUEST]>>>
+tool_name: NeteaseMusic
+action: search
+keywords: 夜に駆ける
+limit: 5
+<<<[END_TOOL_REQUEST]>>>
+```
+
+```text
+<<<[TOOL_REQUEST]>>>
+tool_name: NeteaseMusic
+action: song_info
+shareText: 分享歌曲《NEVER》: https://163cn.tv/example
+<<<[END_TOOL_REQUEST]>>>
+```
+
+账号写操作建议先使用 `dryRun=true`，确认目标歌曲和歌单后再执行真实变更。请遵守网易云音乐及内容版权方的服务条款。
+
+## 安装与测试
+
+```powershell
+npm install
+'{"action":"login_status"}' | node index.js
+```
+
+需要登录态的测试请在本机 `config.env` 配置 Cookie；测试输出和下载文件不得进入 PR。

--- a/Plugin/NeteaseMusic/config.env.example
+++ b/Plugin/NeteaseMusic/config.env.example
@@ -1,0 +1,4 @@
+# Optional login cookie. Public search and metadata actions work without it.
+# Prefer a local Netscape export named music.163.com_cookies.txt when possible.
+# Never commit the real config.env or cookie file.
+NETEASE_COOKIE=

--- a/Plugin/NeteaseMusic/index.js
+++ b/Plugin/NeteaseMusic/index.js
@@ -1,0 +1,1303 @@
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const https = require('https');
+const { execFile } = require('child_process');
+const api = require('NeteaseCloudMusicApi');
+
+function downloadFile(url, targetPath) {
+    return new Promise((resolve, reject) => {
+        let parsed;
+        try {
+            parsed = new URL(url);
+        } catch (error) {
+            return reject(new Error(`Invalid download URL: ${url}`));
+        }
+
+        const client = parsed.protocol === 'http:' ? http : https;
+        const req = client.get(parsed, {
+            headers: {
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            }
+        }, res => {
+            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                const redirectUrl = new URL(res.headers.location, parsed.origin).toString();
+                return downloadFile(redirectUrl, targetPath).then(resolve).catch(reject);
+            }
+
+            if (res.statusCode !== 200) {
+                return reject(new Error(`Failed to download: HTTP ${res.statusCode}`));
+            }
+
+            const fileStream = fs.createWriteStream(targetPath);
+            res.pipe(fileStream);
+
+            fileStream.on('finish', () => {
+                fileStream.close();
+                resolve(targetPath);
+            });
+
+            fileStream.on('error', err => {
+                fs.unlink(targetPath, () => {});
+                reject(err);
+            });
+        });
+
+        req.on('error', reject);
+    });
+}
+
+function compressAudio(inputPath, outputPath, durationSeconds = 60) {
+    return new Promise((resolve, reject) => {
+        const ffmpegPath = 'D:\\327AI-VCP\\VCPToolBox\\Plugin\\VideoAnalyzer\\yt-dlp\\ffmpeg.exe';
+        const args = [
+            '-y',
+            '-i', inputPath,
+            '-t', String(durationSeconds),
+            '-ac', '1',
+            '-b:a', '48k',
+            outputPath
+        ];
+        execFile(ffmpegPath, args, (error, stdout, stderr) => {
+            if (error) {
+                return reject(error);
+            }
+            resolve(outputPath);
+        });
+    });
+}
+
+function loadMainConfig() {
+    const mainConfig = {
+        API_Key: process.env.API_Key,
+        API_URL: process.env.API_URL,
+        MultiModalModel: process.env.MultiModalModel,
+        MultiModalModelChain: process.env.MultiModalModelChain
+    };
+
+    if (!mainConfig.API_Key || !mainConfig.API_URL) {
+        try {
+            const configPath = path.join(__dirname, '..', '..', 'config.env');
+            if (fs.existsSync(configPath)) {
+                const content = fs.readFileSync(configPath, 'utf8');
+                content.split(/\r?\n/).forEach(line => {
+                    const trimmed = line.trim();
+                    if (!trimmed || trimmed.startsWith('#')) return;
+                    const index = trimmed.indexOf('=');
+                    if (index > 0) {
+                        const key = trimmed.substring(0, index).trim();
+                        const val = trimmed.substring(index + 1).trim();
+                        const cleanVal = val.replace(/^["']|["']$/g, '');
+                        if (['API_Key', 'API_URL', 'MultiModalModel', 'MultiModalModelChain'].includes(key)) {
+                            mainConfig[key] = cleanVal;
+                        }
+                    }
+                });
+            }
+        } catch (e) {
+            log('warn', `Failed to parse main config.env: ${e.message}`);
+        }
+    }
+
+    if (!mainConfig.MultiModalModel) {
+        mainConfig.MultiModalModel = 'gemini-2.5-flash-lite';
+    }
+
+    return mainConfig;
+}
+
+const httpsAgent = new https.Agent({
+    keepAlive: true,
+    maxSockets: 50,
+    keepAliveMsecs: 10000
+});
+
+function log(level, message, data = null) {
+    const logObj = { timestamp: new Date().toISOString(), level, message, data };
+    console.error(JSON.stringify(logObj));
+}
+
+function clampNumber(value, fallback, max) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+    return Math.min(parsed, max);
+}
+
+function normalizeBoolean(value, fallback = false) {
+    if (value === undefined || value === null || value === '') return fallback;
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') return value !== 0;
+    const normalized = String(value).trim().toLowerCase();
+    if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) return true;
+    if (['false', '0', 'no', 'n', 'off'].includes(normalized)) return false;
+    return fallback;
+}
+
+function pickArg(args, names) {
+    for (const name of names) {
+        if (args[name] !== undefined && args[name] !== null && args[name] !== '') {
+            return args[name];
+        }
+    }
+    return undefined;
+}
+
+function normalizePicUrl(url) {
+    if (!url) return null;
+    return String(url).replace(/^http:\/\//i, 'https://');
+}
+
+function formatLocalDate(date = new Date()) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function toSongIdList(value) {
+    if (value === undefined || value === null || value === '') return [];
+    if (Array.isArray(value)) {
+        return value.flatMap(toSongIdList);
+    }
+    const text = String(value);
+    if (/^\s*\d+(?:\s*,\s*\d+)*\s*$/.test(text)) {
+        return text.split(',').map(item => item.trim()).filter(Boolean);
+    }
+    return [];
+}
+
+function extractUrls(text) {
+    if (!text) return [];
+    const matches = String(text).match(/https?:\/\/[^\s<>"'，。；、）)]+/gi);
+    return matches ? matches.map(url => url.replace(/[)\]）】。,.，]+$/g, '')) : [];
+}
+
+function extractSongIdsFromText(text) {
+    if (!text) return [];
+    const ids = new Set();
+    const raw = String(text);
+    const candidates = [raw];
+    try {
+        candidates.push(decodeURIComponent(raw));
+    } catch (_) {
+        // Some shared text is not valid URI-encoded content.
+    }
+
+    for (const candidate of candidates) {
+        for (const pattern of [
+            /music\.163\.com\/(?:#\/)?(?:m\/)?song\?[^#\s]*?\bid=(\d{5,})/gi,
+            /\/song\/(\d{5,})/gi,
+            /\bsongId["'=:\s]+(\d{5,})/gi,
+            /\btrackId["'=:\s]+(\d{5,})/gi
+        ]) {
+            let match;
+            while ((match = pattern.exec(candidate)) !== null) {
+                ids.add(match[1]);
+            }
+        }
+    }
+
+    return [...ids];
+}
+
+function resolveHttpUrl(url, maxRedirects = 6) {
+    return new Promise((resolve, reject) => {
+        let parsed;
+        try {
+            parsed = new URL(url);
+        } catch (error) {
+            reject(new Error(`Invalid URL: ${url}`));
+            return;
+        }
+
+        const client = parsed.protocol === 'http:' ? http : https;
+        const req = client.request(parsed, {
+            method: 'GET',
+            timeout: 12000,
+            headers: {
+                'User-Agent': 'Mozilla/5.0 VCPToolBox NeteaseMusic/1.0',
+                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+            }
+        }, res => {
+            const location = res.headers.location;
+            if (res.statusCode >= 300 && res.statusCode < 400 && location) {
+                res.resume();
+                if (maxRedirects <= 0) {
+                    reject(new Error(`Too many redirects while resolving ${url}`));
+                    return;
+                }
+                const nextUrl = new URL(location, parsed).toString();
+                resolve(resolveHttpUrl(nextUrl, maxRedirects - 1));
+                return;
+            }
+
+            let body = '';
+            res.setEncoding('utf8');
+            res.on('data', chunk => {
+                if (body.length < 30000) body += chunk;
+            });
+            res.on('end', () => {
+                resolve({ finalUrl: parsed.toString(), statusCode: res.statusCode, body });
+            });
+        });
+
+        req.on('timeout', () => req.destroy(new Error(`Timed out resolving ${url}`)));
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+async function callApi(method, params, timeoutMs = 90000) {
+    let timer;
+    const apiParams = {
+        ...params,
+        httpAgent: httpsAgent,
+        httpsAgent: httpsAgent
+    };
+
+    try {
+        return await Promise.race([
+            method(apiParams),
+            new Promise((_, reject) => {
+                timer = setTimeout(() => reject(new Error(`API call timed out after ${timeoutMs}ms`)), timeoutMs);
+            })
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}
+
+function loadCookie(config) {
+    let cookie = config.NETEASE_COOKIE || process.env.NETEASE_COOKIE || '';
+    if (cookie) return cookie;
+
+    const cookieFiles = ['music.163.com_cookies.txt', 'cookies.txt'];
+    for (const file of cookieFiles) {
+        const filePath = path.join(__dirname, file);
+        if (!fs.existsSync(filePath)) continue;
+
+        try {
+            const content = fs.readFileSync(filePath, 'utf8').trim();
+            if (!content) continue;
+
+            if (content.includes('=') && !content.includes('\t')) {
+                log('info', `Loaded raw cookie from ${file}`);
+                return content.replace(/\r?\n/g, '; ');
+            }
+
+            const cookies = [];
+            content.split(/\r?\n/).forEach(line => {
+                const trimmed = line.trim();
+                if (!trimmed || trimmed.startsWith('#')) return;
+                const parts = trimmed.split('\t');
+                if (parts.length >= 7) {
+                    cookies.push(`${parts[5]}=${parts[6]}`);
+                }
+            });
+
+            if (cookies.length > 0) {
+                log('info', `Loaded Netscape cookie from ${file}`);
+                return cookies.join('; ');
+            }
+        } catch (error) {
+            log('warn', `Failed to read cookie file ${file}: ${error.message}`);
+        }
+    }
+
+    return '';
+}
+
+function simplifyArtist(artist) {
+    if (!artist) return null;
+    return {
+        id: artist.id,
+        name: artist.name,
+        alias: artist.alias || artist.alia || []
+    };
+}
+
+function simplifyAlbum(album) {
+    if (!album) return null;
+    const coverUrl = normalizePicUrl(album.picUrl || album.coverUrl || album.blurPicUrl);
+    return {
+        id: album.id,
+        name: album.name,
+        picUrl: coverUrl,
+        coverUrl,
+        size: album.size
+    };
+}
+
+function simplifySong(song, extra = {}) {
+    if (!song) return null;
+    const artists = (song.ar || song.artists || []).map(simplifyArtist).filter(Boolean);
+    const artistNames = artists.map(artist => artist.name).filter(Boolean);
+    const album = simplifyAlbum(song.al || song.album);
+    const coverUrl = normalizePicUrl(song.coverUrl || song.picUrl || (album && album.coverUrl));
+    const id = song.id || song.songId;
+
+    const simplified = {
+        id,
+        name: song.name,
+        artists,
+        artistNames,
+        artistText: artistNames.join('/'),
+        album,
+        albumName: album ? album.name : null,
+        coverUrl,
+        webUrl: id ? `https://music.163.com/#/song?id=${id}` : null,
+        duration: song.dt || song.duration,
+        durationMs: song.dt || song.duration,
+        fee: song.fee,
+        publishTime: song.publishTime || song.publish_time,
+        tns: song.tns || song.transNames || [],
+        alia: song.alia || song.alias || []
+    };
+
+    if (extra.reason !== undefined) simplified.reason = extra.reason;
+    if (extra.liked !== undefined) simplified.liked = extra.liked;
+    if (extra.inPlaylists !== undefined) simplified.inPlaylists = extra.inPlaylists;
+    if (extra.playTime !== undefined) simplified.playTime = extra.playTime;
+    if (extra.score !== undefined) simplified.score = extra.score;
+    if (extra.playCount !== undefined) simplified.playCount = extra.playCount;
+    return simplified;
+}
+
+function compactSong(song, extra = {}, options = {}) {
+    const simplified = simplifySong(song, extra);
+    if (!simplified) return null;
+    const compact = {
+        id: simplified.id,
+        name: simplified.name,
+        artistText: simplified.artistText,
+        artistNames: simplified.artistNames,
+        albumName: simplified.albumName,
+        coverUrl: simplified.coverUrl,
+        durationMs: simplified.durationMs
+    };
+    if (options.includeWebUrl === true) compact.webUrl = simplified.webUrl;
+    if (simplified.tns && simplified.tns.length) compact.tns = simplified.tns;
+    if (simplified.alia && simplified.alia.length) compact.alia = simplified.alia;
+    if (extra.reason !== undefined) compact.reason = extra.reason;
+    if (extra.liked !== undefined) compact.liked = extra.liked;
+    if (extra.inPlaylists !== undefined) compact.inPlaylists = extra.inPlaylists;
+    if (extra.playTime !== undefined) compact.playTime = extra.playTime;
+    if (extra.score !== undefined) compact.score = extra.score;
+    if (extra.playCount !== undefined) compact.playCount = extra.playCount;
+    return compact;
+}
+
+function simplifyPlaylist(playlist) {
+    if (!playlist) return null;
+    return {
+        id: playlist.id,
+        name: playlist.name,
+        coverImgUrl: normalizePicUrl(playlist.coverImgUrl),
+        trackCount: playlist.trackCount,
+        playCount: playlist.playCount,
+        userId: playlist.userId || (playlist.creator ? playlist.creator.userId : null),
+        description: playlist.description ? playlist.description.substring(0, 200) + (playlist.description.length > 200 ? '...' : '') : '',
+        tags: playlist.tags
+    };
+}
+
+function simplifyUser(user) {
+    if (!user) return null;
+    return {
+        userId: user.userId,
+        nickname: user.nickname,
+        avatarUrl: normalizePicUrl(user.avatarUrl),
+        signature: user.signature,
+        vipType: user.vipType
+    };
+}
+
+function simplifySearchResult(result) {
+    if (!result) return {};
+    const simplified = {};
+    if (result.songs) {
+        simplified.songs = result.songs.map(song => simplifySong(song));
+        simplified.songCount = result.songCount;
+    }
+    if (result.playlists) {
+        simplified.playlists = result.playlists.map(simplifyPlaylist);
+        simplified.playlistCount = result.playlistCount;
+    }
+    if (result.artists) {
+        simplified.artists = result.artists.map(simplifyArtist);
+        simplified.artistCount = result.artistCount;
+    }
+    if (result.userprofiles) {
+        simplified.users = result.userprofiles.map(simplifyUser);
+        simplified.userprofileCount = result.userprofileCount;
+    }
+    return simplified;
+}
+
+async function getUserId(args, cookie) {
+    if (args.uid) return args.uid;
+    if (!cookie) throw new Error('Need cookie or uid for this action');
+    const statusRes = await callApi(api.login_status, { cookie });
+    const uid = statusRes.body.data && statusRes.body.data.profile && statusRes.body.data.profile.userId;
+    if (!uid) throw new Error('Could not determine userId');
+    return uid;
+}
+
+async function getLikedSet(args, cookie) {
+    const uid = await getUserId(args, cookie);
+    const likeRes = await callApi(api.likelist, { uid, cookie });
+    return {
+        uid,
+        ids: new Set((likeRes.body.ids || []).map(id => String(id)))
+    };
+}
+
+async function mapWithConcurrency(items, concurrency, mapper) {
+    const results = new Array(items.length);
+    let cursor = 0;
+    const workerCount = Math.max(1, Math.min(concurrency, items.length));
+    const workers = Array.from({ length: workerCount }, async () => {
+        while (cursor < items.length) {
+            const index = cursor++;
+            results[index] = await mapper(items[index], index);
+        }
+    });
+    await Promise.all(workers);
+    return results;
+}
+
+async function getPlaylistMembershipMap(args, cookie, targetIds) {
+    const uid = await getUserId(args, cookie);
+    const wanted = new Set(targetIds.map(id => String(id)));
+    if (wanted.size === 0) {
+        return { uid, scannedPlaylists: 0, failedPlaylists: 0, bySongId: new Map() };
+    }
+
+    const playlistLimit = clampNumber(args.playlistScanLimit, 80, 300);
+    const playlistRes = await callApi(api.user_playlist, {
+        uid,
+        limit: playlistLimit,
+        offset: 0,
+        cookie
+    });
+    const playlists = (playlistRes.body.playlist || []).map(simplifyPlaylist).filter(Boolean).slice(0, playlistLimit);
+    const bySongId = new Map();
+    let failedPlaylists = 0;
+
+    await mapWithConcurrency(playlists, 4, async playlist => {
+        try {
+            const detailRes = await callApi(api.playlist_detail, {
+                id: playlist.id,
+                cookie
+            }, clampNumber(args.playlistScanTimeoutMs, 90000, 300000));
+            const trackIds = ((detailRes.body.playlist && detailRes.body.playlist.trackIds) || []).map(track => String(track.id));
+            for (const trackId of trackIds) {
+                if (!wanted.has(trackId)) continue;
+                if (!bySongId.has(trackId)) bySongId.set(trackId, []);
+                bySongId.get(trackId).push({
+                    id: playlist.id,
+                    name: playlist.name,
+                    trackCount: playlist.trackCount
+                });
+            }
+        } catch (error) {
+            failedPlaylists += 1;
+            log('warn', `Failed to scan playlist ${playlist.id}: ${error.message}`);
+        }
+    });
+
+    return {
+        uid,
+        scannedPlaylists: playlists.length,
+        failedPlaylists,
+        bySongId
+    };
+}
+
+async function enrichListeningEntries(entries, args, cookie) {
+    const compact = normalizeBoolean(args.compact, true) && args.format !== 'full';
+    const includeWebUrl = normalizeBoolean(args.includeWebUrl, false);
+    const includeLikeState = normalizeBoolean(args.includeLikeState, true);
+    // Playlist membership requires scanning user playlists and can exceed the synchronous plugin timeout.
+    // Keep it opt-in for listening-record actions so recent_songs/top_songs remain responsive by default.
+    const includePlaylistState = normalizeBoolean(args.includePlaylistState, false);
+    const ids = entries
+        .map(entry => entry.song && (entry.song.id || entry.song.songId))
+        .filter(id => id !== undefined && id !== null)
+        .map(id => String(id));
+
+    let uid = null;
+    let likedSet = null;
+    let playlistMembership = null;
+
+    if (cookie && includeLikeState) {
+        try {
+            const liked = await getLikedSet(args, cookie);
+            uid = liked.uid;
+            likedSet = liked.ids;
+        } catch (error) {
+            log('warn', `Failed to load liked songs for listening records: ${error.message}`);
+        }
+    }
+
+    if (cookie && includePlaylistState) {
+        try {
+            playlistMembership = await getPlaylistMembershipMap(args, cookie, ids);
+            uid = uid || playlistMembership.uid;
+        } catch (error) {
+            log('warn', `Failed to load playlist membership for listening records: ${error.message}`);
+        }
+    }
+
+    const songs = entries.map(entry => {
+        const songId = entry.song && (entry.song.id || entry.song.songId);
+        const extra = { ...entry.extra };
+        if (likedSet && songId !== undefined && songId !== null) {
+            extra.liked = likedSet.has(String(songId));
+        }
+        if (playlistMembership && songId !== undefined && songId !== null) {
+            extra.inPlaylists = playlistMembership.bySongId.get(String(songId)) || [];
+        }
+        return compact
+            ? compactSong(entry.song, extra, { includeWebUrl })
+            : simplifySong(entry.song, extra);
+    }).filter(Boolean);
+
+    return {
+        uid,
+        compact,
+        includeWebUrl,
+        includeLikeState,
+        includePlaylistState,
+        playlistMembership: playlistMembership ? {
+            scannedPlaylists: playlistMembership.scannedPlaylists,
+            failedPlaylists: playlistMembership.failedPlaylists
+        } : null,
+        songs
+    };
+}
+
+async function resolveSongIds(args, options = {}) {
+    const allowMultiple = options.allowMultiple !== false;
+    const idLikeValue = pickArg(args, ['ids', 'songIds', 'song_ids', 'trackIds', 'track_ids', 'id', 'songId', 'song_id', 'trackId', 'track_id']);
+    const direct = toSongIdList(idLikeValue);
+    if (direct.length > 0) {
+        const ids = allowMultiple ? direct : [direct[0]];
+        return { ids, id: ids[0], source: 'direct' };
+    }
+
+    const textParts = [
+        idLikeValue,
+        pickArg(args, ['url', 'shareUrl', 'share_url', 'link']),
+        pickArg(args, ['shareText', 'share_text', 'text', 'input', 'content', 'message'])
+    ].filter(Boolean).map(String);
+
+    for (const part of textParts) {
+        const ids = extractSongIdsFromText(part);
+        if (ids.length > 0) {
+            const finalIds = allowMultiple ? ids : [ids[0]];
+            return { ids: finalIds, id: finalIds[0], source: 'text' };
+        }
+    }
+
+    const urls = textParts.flatMap(extractUrls);
+    for (const url of urls) {
+        const directIds = extractSongIdsFromText(url);
+        if (directIds.length > 0) {
+            const ids = allowMultiple ? directIds : [directIds[0]];
+            return { ids, id: ids[0], source: 'url', sourceUrl: url, resolvedUrl: url };
+        }
+
+        const resolved = await resolveHttpUrl(url);
+        const resolvedIds = [
+            ...extractSongIdsFromText(resolved.finalUrl),
+            ...extractSongIdsFromText(resolved.body)
+        ];
+        if (resolvedIds.length > 0) {
+            const ids = allowMultiple ? [...new Set(resolvedIds)] : [resolvedIds[0]];
+            return { ids, id: ids[0], source: 'resolved_url', sourceUrl: url, resolvedUrl: resolved.finalUrl };
+        }
+    }
+
+    throw new Error('Need a song id, song URL, or NetEase share text containing a resolvable song link');
+}
+
+function buildReasonMap(data) {
+    const map = new Map();
+    for (const item of data.recommendReasons || []) {
+        if (item && item.songId) map.set(String(item.songId), item.reason || null);
+    }
+    return map;
+}
+
+async function getSongDetails(ids, cookie) {
+    const songRes = await callApi(api.song_detail, {
+        ids: Array.isArray(ids) ? ids.join(',') : ids,
+        cookie
+    });
+    return songRes.body.songs || [];
+}
+
+async function buildSongInfo(args, cookie) {
+    const resolved = await resolveSongIds(args, { allowMultiple: false });
+    const songs = await getSongDetails([resolved.id], cookie);
+    if (!songs.length) throw new Error(`No song detail returned for ${resolved.id}`);
+
+    const song = simplifySong(songs[0]);
+    const includeLyrics = normalizeBoolean(args.includeLyrics, true);
+    const result = {
+        source: resolved,
+        song,
+        cover: {
+            url: song.coverUrl
+        },
+        artists: song.artists,
+        artistText: song.artistText
+    };
+
+    if (includeLyrics) {
+        const lyricRes = await callApi(api.lyric, { id: resolved.id, cookie });
+        result.lyrics = {
+            lrc: lyricRes.body.lrc ? lyricRes.body.lrc.lyric : '',
+            tlyric: lyricRes.body.tlyric ? lyricRes.body.tlyric.lyric : '',
+            romalrc: lyricRes.body.romalrc ? lyricRes.body.romalrc.lyric : ''
+        };
+    }
+
+    if (normalizeBoolean(args.multimodal, false) && song.coverUrl) {
+        result.content = [
+            {
+                type: 'text',
+                text: `${song.name} - ${song.artistText}\n${song.webUrl}`
+            },
+            {
+                type: 'image_url',
+                image_url: { url: song.coverUrl }
+            }
+        ];
+    }
+
+    return result;
+}
+
+async function main() {
+    const stdin = process.stdin;
+    let inputData = '';
+
+    stdin.setEncoding('utf8');
+    stdin.on('data', chunk => {
+        inputData += chunk;
+    });
+
+    stdin.on('end', async () => {
+        try {
+            if (!inputData.trim()) {
+                throw new Error('No input data received');
+            }
+
+            const input = JSON.parse(inputData);
+            const action = input.action || (input.args && input.args.action);
+            if (!action) throw new Error('Missing action');
+
+            const config = input.config || {};
+            const cookie = loadCookie(config);
+            const args = { ...input.args, ...input };
+            delete args.config;
+            delete args.tool_name;
+            delete args.action;
+
+            let result = null;
+            let summary = '';
+            let rawResult = null;
+
+            log('info', `Executing action: ${action}`, args);
+
+            switch (action) {
+                case 'search': {
+                    const searchRes = await callApi(api.cloudsearch, {
+                        keywords: args.keywords,
+                        type: args.type || 1,
+                        limit: Math.min(args.limit || 30, 100),
+                        offset: args.offset || 0,
+                        cookie
+                    });
+                    rawResult = searchRes.body.result;
+                    result = simplifySearchResult(rawResult);
+                    summary = `Found ${rawResult.songCount || rawResult.playlistCount || rawResult.artistCount || 0} results for "${args.keywords}"`;
+                    break;
+                }
+
+                case 'playlist': {
+                    const plRes = await callApi(api.playlist_detail, {
+                        id: args.id,
+                        cookie
+                    });
+                    const playlist = plRes.body.playlist;
+                    const tracks = (playlist.tracks || []).map(song => simplifySong(song));
+                    result = {
+                        ...simplifyPlaylist(playlist),
+                        tracks,
+                        trackIds: (playlist.trackIds || []).map(track => track.id)
+                    };
+                    summary = `Playlist: ${playlist.name} (${playlist.trackCount} tracks)`;
+                    break;
+                }
+
+                case 'playlist_all_songs': {
+                    const allTracksRes = await callApi(api.playlist_track_all, {
+                        id: args.id,
+                        limit: args.limit || 10000,
+                        offset: args.offset || 0,
+                        cookie
+                    });
+                    rawResult = allTracksRes.body.songs || [];
+                    result = rawResult.map(song => simplifySong(song));
+                    summary = `Retrieved ${result.length} tracks from playlist ${args.id}`;
+                    break;
+                }
+
+                case 'song_detail': {
+                    const resolved = await resolveSongIds(args);
+                    const songs = await getSongDetails(resolved.ids, cookie);
+                    result = songs.map(song => simplifySong(song));
+                    summary = `Details for ${result.length} song(s)`;
+                    break;
+                }
+
+                case 'song_info':
+                case 'share_song': {
+                    result = await buildSongInfo(args, cookie);
+                    summary = `Song info: ${result.song.name} - ${result.song.artistText}`;
+                    break;
+                }
+
+                case 'cover': {
+                    result = await buildSongInfo({ ...args, includeLyrics: false, multimodal: true }, cookie);
+                    summary = `Cover for ${result.song.name}`;
+                    break;
+                }
+
+                case 'song_url': {
+                    const resolved = await resolveSongIds(args);
+                    const urlRes = await callApi(api.song_url, {
+                        id: resolved.ids.join(','),
+                        level: args.level || 'standard',
+                        cookie
+                    });
+                    result = (urlRes.body.data || []).map(item => ({
+                        id: item.id,
+                        url: item.url,
+                        size: item.size,
+                        type: item.type,
+                        br: item.br
+                    }));
+                    summary = `Got URL for song(s)`;
+                    break;
+                }
+
+                case 'lyric': {
+                    const resolved = await resolveSongIds(args, { allowMultiple: false });
+                    const lyricRes = await callApi(api.lyric, {
+                        id: resolved.id,
+                        cookie
+                    });
+                    result = {
+                        id: resolved.id,
+                        source: resolved,
+                        lrc: lyricRes.body.lrc ? lyricRes.body.lrc.lyric : '',
+                        tlyric: lyricRes.body.tlyric ? lyricRes.body.tlyric.lyric : '',
+                        romalrc: lyricRes.body.romalrc ? lyricRes.body.romalrc.lyric : ''
+                    };
+                    summary = `Got lyrics for ${resolved.id}`;
+                    break;
+                }
+
+                case 'user_playlist':
+                case 'my_playlists': {
+                    const uid = await getUserId(args, cookie);
+                    const uPlRes = await callApi(api.user_playlist, {
+                        uid,
+                        limit: args.limit || 30,
+                        offset: args.offset || 0,
+                        cookie
+                    });
+                    result = (uPlRes.body.playlist || []).map(simplifyPlaylist);
+                    summary = `User playlists for ${uid}`;
+                    break;
+                }
+
+                case 'recent_songs': {
+                    const limit = Math.min(args.limit || 50, 100);
+                    const recentRes = await callApi(api.record_recent_song, {
+                        limit,
+                        cookie
+                    });
+                    const list = (recentRes.body.data && recentRes.body.data.list) || [];
+                    const limitedList = list.slice(0, limit);
+                    const enriched = await enrichListeningEntries(limitedList.map(item => ({
+                        song: item.data,
+                        extra: {
+                            playTime: item.playTime
+                        }
+                    })), args, cookie);
+                    result = {
+                        total: list.length,
+                        returned: enriched.songs.length,
+                        ...enriched
+                    };
+                    summary = `Got ${enriched.songs.length} recently played songs with listening context`;
+                    break;
+                }
+
+                case 'top_songs': {
+                    const uid = await getUserId(args, cookie);
+                    const topRes = await callApi(api.user_record, {
+                        uid,
+                        type: args.type !== undefined ? args.type : 1,
+                        cookie
+                    });
+                    const source = Number(args.type) === 0 ? topRes.body.allData : topRes.body.weekData;
+                    const limitedSource = (source || []).slice(0, clampNumber(args.limit, 50, 100));
+                    const enriched = await enrichListeningEntries(limitedSource.map(item => ({
+                        song: item.song,
+                        extra: {
+                            score: item.score,
+                            playCount: item.playCount
+                        }
+                    })), { ...args, uid }, cookie);
+                    result = {
+                        type: Number(args.type) === 0 ? 'all' : 'week',
+                        total: (source || []).length,
+                        returned: enriched.songs.length,
+                        ...enriched
+                    };
+                    summary = `Got ${enriched.songs.length} top played songs with listening context`;
+                    break;
+                }
+
+                case 'daily_recommend': {
+                    const dailyRes = await callApi(api.recommend_songs, { cookie });
+                    const data = dailyRes.body.data || {};
+                    const dailySongs = data.dailySongs || [];
+                    const limit = clampNumber(args.limit, 20, 100);
+                    const compact = normalizeBoolean(args.compact, true) && args.format !== 'full';
+                    const includeLikeState = normalizeBoolean(args.includeLikeState, true);
+                    const reasonMap = buildReasonMap(data);
+                    let likedSet = null;
+                    let uid = null;
+
+                    if (includeLikeState && cookie) {
+                        try {
+                            const liked = await getLikedSet(args, cookie);
+                            likedSet = liked.ids;
+                            uid = liked.uid;
+                        } catch (error) {
+                            log('warn', `Failed to load liked songs for daily_recommend: ${error.message}`);
+                        }
+                    }
+
+                    const songs = dailySongs.slice(0, limit).map(song => {
+                        const extra = {
+                            reason: reasonMap.get(String(song.id)) || null
+                        };
+                        if (likedSet) extra.liked = likedSet.has(String(song.id));
+                        return compact ? compactSong(song, extra) : simplifySong(song, extra);
+                    });
+
+                    result = {
+                        date: formatLocalDate(),
+                        total: dailySongs.length,
+                        returned: songs.length,
+                        compact,
+                        uid,
+                        songs,
+                        operationActions: {
+                            like: "action='like_song', id/songId/url/shareText",
+                            unlike: "action='unlike_song', id/songId/url/shareText",
+                            addToPlaylist: "action='add_to_playlist', pid/playlistId, id/songId/url/shareText"
+                        }
+                    };
+                    summary = `Got ${songs.length}/${dailySongs.length} daily recommended songs`;
+                    break;
+                }
+
+                case 'today_listens': {
+                    const todayRes = await callApi(api.listen_data_today_song, { cookie });
+                    const data = todayRes.body.data || {};
+                    const list = data.songDTOs || data.list || data.songList || [];
+                    const limitedList = list.slice(0, clampNumber(args.limit, 50, 100));
+                    const enriched = await enrichListeningEntries(limitedList.map(item => {
+                        const song = item.song || item.songDTO || item;
+                        return {
+                            song,
+                            extra: {
+                                playTime: item.playTime,
+                                score: item.score,
+                                playCount: item.playCount
+                            }
+                        };
+                    }), args, cookie);
+                    result = {
+                        total: list.length,
+                        returned: enriched.songs.length,
+                        ...enriched
+                    };
+                    summary = `Got ${enriched.songs.length} today's listen records with listening context`;
+                    break;
+                }
+
+                case 'like_song':
+                case 'unlike_song': {
+                    if (!cookie) throw new Error('Need NETEASE_COOKIE for like/unlike actions');
+                    const resolved = await resolveSongIds(args, { allowMultiple: false });
+                    const like = action === 'like_song' ? normalizeBoolean(args.like, true) : false;
+                    const dryRun = normalizeBoolean(args.dryRun, false);
+                    const song = simplifySong((await getSongDetails([resolved.id], cookie))[0]);
+
+                    if (dryRun) {
+                        result = {
+                            dryRun: true,
+                            operation: like ? 'like_song' : 'unlike_song',
+                            id: resolved.id,
+                            song,
+                            source: resolved,
+                            message: 'No account changes were made'
+                        };
+                    } else {
+                        const likeRes = await callApi(api.like, {
+                            id: resolved.id,
+                            like,
+                            cookie
+                        });
+                        result = {
+                            operation: like ? 'like_song' : 'unlike_song',
+                            id: resolved.id,
+                            song,
+                            response: likeRes.body
+                        };
+                    }
+                    summary = `${dryRun ? 'Dry-run ' : ''}${like ? 'like' : 'unlike'} song ${resolved.id}`;
+                    break;
+                }
+
+                case 'add_to_playlist':
+                case 'remove_from_playlist': {
+                    if (!cookie) throw new Error('Need NETEASE_COOKIE for playlist mutation actions');
+                    const pid = pickArg(args, ['pid', 'playlistId', 'playlist_id']);
+                    if (!pid) throw new Error('Need pid or playlistId');
+
+                    const songArgs = {
+                        ...args,
+                        ids: pickArg(args, ['songIds', 'song_ids', 'trackIds', 'track_ids', 'songId', 'song_id', 'trackId', 'track_id', 'ids', 'id'])
+                    };
+                    const resolved = await resolveSongIds(songArgs);
+                    const dryRun = normalizeBoolean(args.dryRun, false);
+                    const op = action === 'remove_from_playlist' ? 'del' : 'add';
+                    const songs = (await getSongDetails(resolved.ids, cookie)).map(song => simplifySong(song));
+
+                    if (dryRun) {
+                        result = {
+                            dryRun: true,
+                            operation: action,
+                            pid,
+                            ids: resolved.ids,
+                            songs,
+                            source: resolved,
+                            message: 'No account changes were made'
+                        };
+                    } else {
+                        const mutationRes = await callApi(api.playlist_tracks, {
+                            op,
+                            pid,
+                            tracks: resolved.ids.join(','),
+                            cookie
+                        });
+                        result = {
+                            operation: action,
+                            pid,
+                            ids: resolved.ids,
+                            songs,
+                            response: mutationRes.body
+                        };
+                    }
+                    summary = `${dryRun ? 'Dry-run ' : ''}${op === 'add' ? 'add' : 'remove'} ${resolved.ids.length} song(s) ${op === 'add' ? 'to' : 'from'} playlist ${pid}`;
+                    break;
+                }
+
+                case 'top_playlist': {
+                    const topPlRes = await callApi(api.top_playlist, {
+                        cat: args.cat || '全部',
+                        limit: args.limit || 30,
+                    offset: args.offset || 0,
+                        cookie
+                    });
+                    result = (topPlRes.body.playlists || []).map(simplifyPlaylist);
+                    summary = `Top playlists retrieved`;
+                    break;
+                }
+
+                case 'login_status': {
+                    const statusRes = await callApi(api.login_status, { cookie });
+                    result = {
+                        code: statusRes.body.data.code,
+                        profile: simplifyUser(statusRes.body.data.profile)
+                    };
+                    summary = `Login status check`;
+                    break;
+                }
+
+                case 'download': {
+                    const resolved = await resolveSongIds(args, { allowMultiple: false });
+                    const level = args.level || 'standard';
+
+                    const songs = await getSongDetails([resolved.id], cookie);
+                    if (!songs.length) throw new Error(`No song detail returned for ${resolved.id}`);
+                    const song = simplifySong(songs[0]);
+
+                    const urlRes = await callApi(api.song_url, {
+                        id: resolved.id,
+                        level: level,
+                        cookie
+                    });
+                    const urlData = urlRes.body.data && urlRes.body.data[0];
+                    if (!urlData || !urlData.url) {
+                        throw new Error(`Could not get download URL for song ${resolved.id} (VIP/Copyright restriction)`);
+                    }
+
+                    const songUrl = urlData.url;
+                    const ext = urlData.type ? urlData.type.toLowerCase() : 'mp3';
+
+                    let outputDir = args.outputDir || args.savePath || path.join(__dirname, 'downloads');
+                    outputDir = path.resolve(outputDir);
+                    if (!fs.existsSync(outputDir)) {
+                        fs.mkdirSync(outputDir, { recursive: true });
+                    }
+
+                    const safeName = `${song.name} - ${song.artistText}`.replace(/[\\/:*?"<>|]/g, '_');
+                    const targetPath = path.join(outputDir, `${safeName}.${ext}`);
+
+                    log('info', `Downloading song from ${songUrl} to ${targetPath}`);
+                    await downloadFile(songUrl, targetPath);
+
+                    result = {
+                        songId: resolved.id,
+                        name: song.name,
+                        artistText: song.artistText,
+                        albumName: song.albumName,
+                        coverUrl: song.coverUrl,
+                        url: songUrl,
+                        savePath: targetPath,
+                        fileSize: urlData.size,
+                        bitrate: urlData.br,
+                        format: ext
+                    };
+                    summary = `Successfully downloaded "${song.name} - ${song.artistText}" to ${targetPath}`;
+                    break;
+                }
+
+                case 'analyze': {
+                    let audioPath = args.audioPath || args.filePath;
+                    let songInfo = null;
+
+                    if (!audioPath) {
+                        const resolved = await resolveSongIds(args, { allowMultiple: false });
+                        const level = args.level || 'standard';
+
+                        const songs = await getSongDetails([resolved.id], cookie);
+                        if (!songs.length) throw new Error(`No song detail returned for ${resolved.id}`);
+                        const song = simplifySong(songs[0]);
+
+                        const urlRes = await callApi(api.song_url, {
+                            id: resolved.id,
+                            level: level,
+                            cookie
+                        });
+                        const urlData = urlRes.body.data && urlRes.body.data[0];
+                        if (!urlData || !urlData.url) {
+                            throw new Error(`Could not get URL for song ${resolved.id} to analyze`);
+                        }
+
+                        const songUrl = urlData.url;
+                        const ext = urlData.type ? urlData.type.toLowerCase() : 'mp3';
+
+                        const outputDir = path.join(__dirname, 'downloads');
+                        if (!fs.existsSync(outputDir)) {
+                            fs.mkdirSync(outputDir, { recursive: true });
+                        }
+                        const safeName = `${song.name} - ${song.artistText}`.replace(/[\\/:*?"<>|]/g, '_');
+                        audioPath = path.join(outputDir, `${safeName}.${ext}`);
+
+                        log('info', `Downloading song for analysis to ${audioPath}`);
+                        await downloadFile(songUrl, audioPath);
+                        songInfo = song;
+                    } else {
+                        audioPath = path.resolve(audioPath);
+                        if (!fs.existsSync(audioPath)) {
+                            throw new Error(`Target audio file not found: ${audioPath}`);
+                        }
+                        const basename = path.basename(audioPath, path.extname(audioPath));
+                        const parts = basename.split(' - ');
+                        songInfo = {
+                            name: parts[0] || basename,
+                            artistText: parts[1] || 'Unknown Artist'
+                        };
+                    }
+
+                    const mainConfig = loadMainConfig();
+                    if (!mainConfig.API_Key || !mainConfig.API_URL) {
+                        throw new Error('API_Key or API_URL not found in config.env');
+                    }
+
+                    const stat = fs.statSync(audioPath);
+                    let processedAudioPath = audioPath;
+                    let isTempProcessedFile = false;
+
+                    const ffmpegPath = 'D:\\327AI-VCP\\VCPToolBox\\Plugin\\VideoAnalyzer\\yt-dlp\\ffmpeg.exe';
+                    if (stat.size > 2 * 1024 * 1024 && fs.existsSync(ffmpegPath)) {
+                        const tempDir = path.join(__dirname, 'temp');
+                        if (!fs.existsSync(tempDir)) {
+                            fs.mkdirSync(tempDir, { recursive: true });
+                        }
+                        const processedName = `temp_${Date.now()}_compact.mp3`;
+                        const outputPath = path.join(tempDir, processedName);
+
+                        log('info', `Audio file size ${stat.size} bytes > 2MB. Compressing 60s sample to ${outputPath}...`);
+                        try {
+                            await compressAudio(audioPath, outputPath, 60);
+                            processedAudioPath = outputPath;
+                            isTempProcessedFile = true;
+                            log('info', `Compressed successfully. New size: ${fs.statSync(outputPath).size} bytes`);
+                        } catch (e) {
+                            log('warn', `Failed to compress audio with ffmpeg: ${e.message}. Will try uploading original file.`);
+                        }
+                    }
+
+                    log('info', `Reading audio file: ${processedAudioPath}`);
+                    const audioBuffer = fs.readFileSync(processedAudioPath);
+                    const base64Audio = audioBuffer.toString('base64');
+                    const ext = path.extname(processedAudioPath).toLowerCase();
+                    const mimeType = ext === '.flac' ? 'audio/flac' : (ext === '.wav' ? 'audio/wav' : 'audio/mpeg');
+
+                    const analyzePrompt = `你是一个专业的音乐分析引擎（Music Analysis Engine）。请你对所给的音乐音频进行深度、“体毛级”的全面剖析。
+请重点从以下几个维度进行分析，并输出结构化的 Markdown 报告：
+1. **整体曲风与流派 (Genre & Style)**: 识别音乐的风格（如流行、摇融、电子、古风、交响等），以及它的融合元素与整体氛围。
+2. **节奏与律动 (Tempo & Rhythm)**: 分析节拍律动、BPM 大致范围、节奏的强弱对比，以及打击乐器/节奏声部的编排特点。
+3. **旋律、和声与器乐 (Melody, Harmony & Instrumentation)**: 音乐中使用了哪些主要乐器？它们的音色特点是什么？旋律线与和声走向有什么特点？
+4. **歌曲结构与转折点 (Structure & Transitions)**: 音乐是如何层层递进的？列出它的各个转折点（如前奏、主歌、副歌/高潮、桥段、间奏、尾奏）以及在这些转折点处配器、情绪、节奏上的具体变化。
+5. **亮点与特色 (Highlights & Characteristics)**: 这首音乐有什么抓耳的特色（Hook）、新颖的转调、人声编排或特殊的混音效果？
+6. **情感与听觉画卷 (Emotion & Narrative)**: 音乐传达了怎样的情绪？在听觉上勾勒出了怎样的画面？`;
+
+                    let fetchImpl;
+                    if (typeof fetch === 'function') {
+                        fetchImpl = fetch;
+                    } else {
+                        try {
+                            fetchImpl = require('node-fetch');
+                        } catch (e) {
+                            const { default: nodeFetch } = await import('node-fetch');
+                            fetchImpl = nodeFetch;
+                        }
+                    }
+
+                    const modelsToTry = [];
+                    if (mainConfig.MultiModalModel) {
+                        modelsToTry.push(mainConfig.MultiModalModel);
+                    }
+                    if (mainConfig.MultiModalModelChain) {
+                        const chainModels = mainConfig.MultiModalModelChain.split(',').map(m => m.trim()).filter(Boolean);
+                        for (const m of chainModels) {
+                            if (!modelsToTry.includes(m)) {
+                                modelsToTry.push(m);
+                            }
+                        }
+                    }
+                    if (modelsToTry.length === 0) {
+                        modelsToTry.push('gemini-2.5-flash-lite');
+                    }
+
+                    let analysis = null;
+                    let lastError = null;
+                    let usedModel = null;
+
+                    for (const currentModel of modelsToTry) {
+                        log('info', `Attempting music analysis with model: ${currentModel} via API: ${mainConfig.API_URL}`);
+                        try {
+                            const payload = {
+                                model: currentModel,
+                                messages: [{
+                                    role: 'user',
+                                    content: [
+                                        { type: 'text', text: analyzePrompt },
+                                        { type: 'image_url', image_url: { url: `data:${mimeType};base64,${base64Audio}` } }
+                                    ]
+                                }],
+                                max_tokens: 4000
+                            };
+
+                            const response = await fetchImpl(`${mainConfig.API_URL}/v1/chat/completions`, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'Authorization': `Bearer ${mainConfig.API_Key}`
+                                },
+                                body: JSON.stringify(payload),
+                                timeout: 600000
+                            });
+
+                            if (!response.ok) {
+                                const errorText = await response.text();
+                                throw new Error(`HTTP ${response.status} - ${errorText}`);
+                            }
+
+                            const apiResult = await response.json();
+                            const content = apiResult?.choices?.[0]?.message?.content;
+                            if (content) {
+                                analysis = content;
+                                usedModel = currentModel;
+                                break;
+                            } else {
+                                throw new Error('API returned empty message content');
+                            }
+                        } catch (e) {
+                            lastError = e;
+                            log('warn', `Failed analysis with model ${currentModel}: ${e.message}. Trying next model...`);
+                        }
+                    }
+
+                    if (!analysis) {
+                        throw new Error(`All models in chain failed. Last error: ${lastError ? lastError.message : 'Unknown error'}`);
+                    }
+
+                    if (isTempProcessedFile && fs.existsSync(processedAudioPath)) {
+                        try {
+                            fs.unlinkSync(processedAudioPath);
+                            log('info', `Cleaned up temporary compressed file: ${processedAudioPath}`);
+                        } catch (e) {
+                            log('warn', `Failed to clean up temporary file: ${e.message}`);
+                        }
+                    }
+
+                    result = {
+                        song: songInfo,
+                        audioPath: audioPath,
+                        analysis: analysis
+                    };
+                    summary = `Completed music analysis for "${songInfo.name} - ${songInfo.artistText}" using model ${usedModel}`;
+                    break;
+                }
+
+                default:
+                    throw new Error(`Unknown action: ${action}`);
+            }
+
+            process.stdout.write(JSON.stringify({ status: 'success', result, summary }, null, 2));
+            process.exit(0);
+        } catch (error) {
+            log('error', `Execution failed: ${error.message}`);
+            process.stdout.write(JSON.stringify({ status: 'error', error: error.message }, null, 2));
+            process.exit(0);
+        }
+    });
+}
+
+main();

--- a/Plugin/NeteaseMusic/package-lock.json
+++ b/Plugin/NeteaseMusic/package-lock.json
@@ -1,0 +1,2111 @@
+{
+  "name": "neteasemusic",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "neteasemusic",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "NeteaseCloudMusicApi": "^4.28.0"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmmirror.com/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmmirror.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmmirror.com/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmmirror.com/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/basic-ftp/-/basic-ftp-5.1.0.tgz",
+      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmmirror.com/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmmirror.com/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmmirror.com/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmmirror.com/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmmirror.com/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmmirror.com/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmmirror.com/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmmirror.com/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-fileupload": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmmirror.com/express-fileupload/-/express-fileupload-1.5.2.tgz",
+      "integrity": "sha512-wxUJn2vTHvj/kZCVmc5/bJO15C7aSMyHeuXYY3geKpeKibaAoQGcEv5+sM6nHS2T7VF+QHS4hTWPiY2mKofEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmmirror.com/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmmirror.com/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmmirror.com/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmmirror.com/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmmirror.com/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-uri/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmmirror.com/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/music-metadata": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmmirror.com/music-metadata/-/music-metadata-7.14.0.tgz",
+      "integrity": "sha512-xrm3w7SV0Wk+OythZcSbaI8mcr/KHd0knJieu8bVpaPfMv/Agz5EooCAPz3OR5hbYMiUG6dgAPKZKnMzV+3amA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "content-type": "^1.0.5",
+        "debug": "^4.3.4",
+        "file-type": "^16.5.4",
+        "media-typer": "^1.1.0",
+        "strtok3": "^6.3.0",
+        "token-types": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/music-metadata/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/music-metadata/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/NeteaseCloudMusicApi": {
+      "version": "4.28.0",
+      "resolved": "https://registry.npmmirror.com/NeteaseCloudMusicApi/-/NeteaseCloudMusicApi-4.28.0.tgz",
+      "integrity": "sha512-cdYfANR+yEGMNFurs3WX8vNg8T8ZkqkGb8eQv2zTz/sXDY27Elu8S+nL9K4RXU4mDG8e5PF8HcJ3+EWaMSlc6A==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.2.2",
+        "crypto-js": "^4.2.0",
+        "express": "^4.17.1",
+        "express-fileupload": "^1.1.9",
+        "md5": "^2.3.0",
+        "music-metadata": "^7.5.3",
+        "node-forge": "^1.3.1",
+        "pac-proxy-agent": "^7.0.0",
+        "qrcode": "^1.4.4",
+        "safe-decode-uri-component": "^1.2.1",
+        "tunnel": "^0.0.6",
+        "xml2js": "^0.6.2",
+        "yargs": "^17.1.1"
+      },
+      "bin": {
+        "NeteaseCloudMusicApi": "app.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmmirror.com/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmmirror.com/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmmirror.com/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmmirror.com/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmmirror.com/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmmirror.com/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmmirror.com/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-decode-uri-component": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/safe-decode-uri-component/-/safe-decode-uri-component-1.2.1.tgz",
+      "integrity": "sha512-j0PKk0v8qPOD0goqRAvoI7GKy+HwLHXEpXaQlA1IqJ65jjiILRK1InlfNdIKUUUYuLtERADaJumgYKNfyQBO+w==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmmirror.com/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmmirror.com/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmmirror.com/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmmirror.com/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmmirror.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmmirror.com/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmmirror.com/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmmirror.com/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmmirror.com/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmmirror.com/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmmirror.com/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmmirror.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmmirror.com/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/Plugin/NeteaseMusic/package.json
+++ b/Plugin/NeteaseMusic/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "neteasemusic",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "NeteaseCloudMusicApi": "^4.28.0"
+  }
+}

--- a/Plugin/NeteaseMusic/plugin-manifest.json
+++ b/Plugin/NeteaseMusic/plugin-manifest.json
@@ -1,0 +1,32 @@
+{
+  "manifestVersion": "1.0.0",
+  "name": "NeteaseMusic",
+  "displayName": "网易云音乐助手",
+  "version": "1.2.0",
+  "description": "网易云音乐 VCP 同步插件，支持搜索、歌单、歌曲详情、歌词、分享短链解析、每日推荐、红心、歌单操作、个人数据查询、下载与多模态音乐分析。",
+  "author": "VCP Team",
+  "pluginType": "synchronous",
+  "entryPoint": {
+    "type": "nodejs",
+    "command": "node index.js"
+  },
+  "communication": {
+    "protocol": "stdio",
+    "timeout": 300000
+  },
+  "configSchema": {
+    "NETEASE_COOKIE": {
+      "type": "string",
+      "description": "网易云音乐登录 Cookie。个人数据、每日推荐、红心和歌单写操作需要有效 Cookie。"
+    }
+  },
+  "capabilities": {
+    "invocationCommands": [
+      {
+        "commandIdentifier": "NeteaseMusic",
+        "description": "【网易云音乐助手】参数为 action 加对应参数。支持 search, playlist, playlist_all_songs, song_detail, song_info, share_song, cover, song_url, lyric, my_playlists, user_playlist, recent_songs, top_songs, daily_recommend, today_listens, like_song, unlike_song, add_to_playlist, remove_from_playlist, top_playlist, login_status, download, analyze。歌曲类动作可传 id/ids/songId/url/shareUrl/shareText，支持 https://163cn.tv/... 这类短链和整段分享文案。daily_recommend 默认返回紧凑歌曲信息，包含 coverUrl、artistText、推荐理由与可用时的红心状态。recent_songs/top_songs/today_listens 默认返回听歌记录画像，包含 artistText、liked、playTime/playCount/score；如需扫描歌曲属于哪些歌单，请显式传 includePlaylistState=true。账号写操作支持 dryRun=true 安全预检。download 支持下载音乐文件，analyze 支持使用多模态大模型体毛级分析音乐音频节奏曲风等特征。",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」NeteaseMusic「末」\naction:「始」song_info「末」\nshareText:「始」分享Neuro-sama/Evil Neuro的单曲《NEVER (feat. Evil Neuro)》: https://163cn.tv/7mipOKo「末」\n<<<[END_TOOL_REQUEST]>>>"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 简介
NeteaseMusic 是一个同步 stdio 插件，提供网易云音乐搜索、歌单、歌词、播放链接、个人记录、下载和可选音频分析能力。

## README
- 功能、Cookie 安全与调用示例：`Plugin/NeteaseMusic/README.md`
- 示例配置：`Plugin/NeteaseMusic/config.env.example`
- 依赖安装：`Plugin/NeteaseMusic/package.json`

## 安全与兼容性
- 未提交网易云 Cookie、音频、node_modules、scratch 和测试输出。
- 账号写操作文档要求先使用 `dryRun=true` 预检；Cookie 仅通过本机配置或 Cookie 文件提供。
- 已通过 Node.js 语法检查和 package/manifest JSON 校验。

这是我用VCP 10个月来，一些自己用着比较顺手的自制插件，要是觉得有用可以加入，或者要是有什么功能可以归并到现有的插件中也可以