### PR TITLE
feat(YTFetch): add Gemini YouTube analysis plugin

### DIFF
--- a/Plugin/YTFetch/.gitignore
+++ b/Plugin/YTFetch/.gitignore
@@ -1,0 +1,4 @@
+config.env
+__pycache__/
+*.pyc
+*.log

--- a/Plugin/YTFetch/README.md
+++ b/Plugin/YTFetch/README.md
@@ -1,0 +1,37 @@
+# YTFetch
+
+YTFetch 是一个同步 `stdio` 插件，通过 Gemini API 直接读取公开 YouTube URL 并返回视频、音频和时间线分析。它不在本地下载或上传视频文件；URL 会发送给 Google Gemini 服务处理。
+
+## 参数
+
+- `url`（必需）：YouTube watch 或 `youtu.be` URL。
+- `prompt`（可选）：分析要求；默认返回简体中文结构化摘要。
+- `model`（可选）：非 Pro Gemini 模型，默认 `gemini-2.5-flash-lite`。
+- `fallbackModels`（可选）：逗号分隔的回退模型。
+- `maxOutputTokens`（可选）：默认 `40000`。
+- `thinkingBudget`（可选）：传 `0` 可关闭支持该选项的模型的思考预算。
+- `raw`（可选）：返回结构化结果而不是 Markdown。
+- `command=list_models`：列出支持 `generateContent` 的非 Pro 模型。
+
+## 配置
+
+复制 `config.env.example` 为 `config.env`，并设置 `GEMINI_API_KEY`。也支持 `GEMINI_API_KEYS` 轮换多个密钥，以及 `GEMINI_API_BASE_URL` 和 `YTFETCH_MODEL` 覆盖默认值。真实密钥只保存在本机 `config.env` 或系统环境变量中，绝不提交。
+
+```text
+<<<[TOOL_REQUEST]>>>
+tool_name: YTFetch
+url: https://www.youtube.com/watch?v=BClcpTpEyn4
+prompt: 使用简体中文总结视频主题、画面、音频和关键时间线。
+model: gemini-2.5-flash-lite
+maxOutputTokens: 40000
+<<<[END_TOOL_REQUEST]>>>
+```
+
+## 安装与测试
+
+```powershell
+python -m pip install -r requirements.txt
+'{"url":"https://www.youtube.com/watch?v=BClcpTpEyn4"}' | python YTFetch.py
+```
+
+需要联网、有效 Gemini API 密钥和可由 Gemini 访问的公开 YouTube URL。请确认视频内容、URL 和分析结果符合平台条款与隐私要求。

--- a/Plugin/YTFetch/YTFetch.py
+++ b/Plugin/YTFetch/YTFetch.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import logging
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+from dotenv import load_dotenv
+
+
+PLUGIN_DIR = Path(__file__).parent
+PROJECT_ROOT = PLUGIN_DIR.parent.parent
+
+logging.getLogger("dotenv.main").setLevel(logging.CRITICAL)
+load_dotenv(PROJECT_ROOT / "config.env", verbose=False)
+load_dotenv(PLUGIN_DIR / "config.env", verbose=False)
+
+API_BASE_URL = os.getenv("GEMINI_API_BASE_URL", "https://generativelanguage.googleapis.com").rstrip("/")
+DEFAULT_MODEL = os.getenv("YTFETCH_MODEL", "gemini-2.5-flash-lite")
+DEFAULT_FALLBACK_MODELS = [
+    DEFAULT_MODEL,
+    "gemini-3.1-flash-lite-preview",
+    "gemini-2.5-flash",
+    "gemini-flash-lite-latest",
+]
+
+DEFAULT_PROMPT = """Read this YouTube video deeply. Use Simplified Chinese only.
+Do not use English headings unless they are proper nouns from the video.
+Include:
+1. The core topic
+2. Main visible scenes and people/objects
+3. Main audible content, dialogue, narration, or music
+4. Key timeline or steps
+5. The most useful facts for an Agent to reuse later
+"""
+
+
+class YTFetchError(Exception):
+    def __init__(self, message: str, code: str = "YTFETCH_ERROR", status_code: int | None = None):
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+
+
+def emit(payload: dict[str, Any], exit_code: int = 0) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    sys.stdout.flush()
+    raise SystemExit(exit_code)
+
+
+MODEL_ALIASES = {
+    "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+}
+
+
+def get_api_keys() -> list[str]:
+    values: list[str] = []
+    multi_key = os.getenv("GEMINI_API_KEYS") or os.getenv("YTFETCH_API_KEYS") or ""
+    if multi_key.strip():
+        values.extend(re.split(r"[,;\n]+", multi_key))
+    values.extend(
+        [
+            os.getenv("GEMINI_API_KEY"),
+            os.getenv("AI_STUDIO_API_KEY"),
+            os.getenv("GOOGLE_API_KEY"),
+            os.getenv("GeminiImageKey"),
+        ]
+    )
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        key = (value or "").strip()
+        if key and key not in seen:
+            seen.add(key)
+            result.append(key)
+    if not result:
+        raise YTFetchError("Missing GEMINI_API_KEY / AI_STUDIO_API_KEY / GOOGLE_API_KEY", "NO_API_KEY")
+    return result
+
+
+def normalize_model(model: str | None) -> str:
+    value = (model or DEFAULT_MODEL).strip()
+    value = value.removeprefix("models/")
+    return MODEL_ALIASES.get(value, value)
+
+
+def is_youtube_url(url: str) -> bool:
+    return bool(re.match(r"^https?://(www\.)?(youtube\.com/watch\?v=|youtu\.be/)", url.strip(), re.I))
+
+
+def canonicalize_youtube_url(url: str) -> str:
+    text = url.strip()
+    watch = re.search(r"[?&]v=([A-Za-z0-9_-]+)", text)
+    if watch:
+        return f"https://www.youtube.com/watch?v={watch.group(1)}"
+    short = re.search(r"youtu\.be/([A-Za-z0-9_-]+)", text, re.I)
+    if short:
+        return f"https://www.youtube.com/watch?v={short.group(1)}"
+    return text
+
+
+def parse_int(value: Any, default: int) -> int:
+    try:
+        if value in (None, ""):
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_float(value: Any, default: float) -> float:
+    try:
+        if value in (None, ""):
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "y"}
+
+
+def handle_response(resp: requests.Response) -> dict[str, Any]:
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise YTFetchError(f"Gemini API returned non-JSON response: {resp.text[:500]}", "BAD_RESPONSE", resp.status_code) from exc
+    if resp.status_code >= 400:
+        error = data.get("error", {})
+        message = error.get("message") or resp.text[:1000]
+        raise YTFetchError(message, error.get("status", "HTTP_ERROR"), resp.status_code)
+    return data
+
+
+def list_models(api_key: str) -> list[dict[str, Any]]:
+    resp = requests.get(f"{API_BASE_URL}/v1beta/models", params={"key": api_key}, timeout=30)
+    data = handle_response(resp)
+    models = []
+    for item in data.get("models", []):
+        methods = item.get("supportedGenerationMethods", [])
+        name = item.get("name", "")
+        display_name = item.get("displayName", "")
+        if "generateContent" not in methods:
+            continue
+        if "pro" in name.lower() or "pro" in display_name.lower():
+            continue
+        models.append(
+            {
+                "name": name,
+                "displayName": display_name,
+                "inputTokenLimit": item.get("inputTokenLimit"),
+                "outputTokenLimit": item.get("outputTokenLimit"),
+                "thinking": item.get("thinking", False),
+            }
+        )
+    return models
+
+
+def extract_text(data: dict[str, Any]) -> str:
+    texts: list[str] = []
+    for cand in data.get("candidates", []):
+        for part in cand.get("content", {}).get("parts", []):
+            if "text" in part:
+                texts.append(part["text"])
+    return "\n".join(t.strip() for t in texts if t and t.strip()).strip()
+
+
+def usage_summary(data: dict[str, Any]) -> dict[str, Any]:
+    usage = data.get("usageMetadata", {})
+    return {
+        "promptTokenCount": usage.get("promptTokenCount"),
+        "candidatesTokenCount": usage.get("candidatesTokenCount"),
+        "thoughtsTokenCount": usage.get("thoughtsTokenCount"),
+        "totalTokenCount": usage.get("totalTokenCount"),
+        "promptTokensDetails": usage.get("promptTokensDetails"),
+    }
+
+
+def build_payload(req: dict[str, Any], url: str) -> dict[str, Any]:
+    prompt = req.get("prompt") or req.get("question") or DEFAULT_PROMPT
+    max_tokens = parse_int(req.get("maxOutputTokens") or req.get("max_tokens"), 40000)
+    temperature = parse_float(req.get("temperature"), 0.2)
+    mime_type = req.get("mime_type") or req.get("mimeType") or "video/mp4"
+
+    generation_config: dict[str, Any] = {
+        "temperature": temperature,
+        "maxOutputTokens": max_tokens,
+    }
+
+    thinking_budget = req.get("thinkingBudget")
+    if thinking_budget is None:
+        thinking_budget = req.get("thinking_budget")
+    if thinking_budget is not None:
+        generation_config["thinkingConfig"] = {"thinkingBudget": parse_int(thinking_budget, 0)}
+
+    return {
+        "systemInstruction": {
+            "parts": [
+                {
+                    "text": "You are a YouTube video analysis tool. Unless the user explicitly requests another language, answer only in Simplified Chinese. Do not use English section headings."
+                }
+            ]
+        },
+        "contents": [
+            {
+                "role": "user",
+                "parts": [
+                    {"text": str(prompt)},
+                    {"file_data": {"file_uri": url, "mime_type": str(mime_type)}},
+                ],
+            }
+        ],
+        "generationConfig": generation_config,
+    }
+
+
+def generate_once(api_key: str, model: str, payload: dict[str, Any], timeout_sec: int) -> dict[str, Any]:
+    endpoint = f"{API_BASE_URL}/v1beta/models/{normalize_model(model)}:generateContent"
+    resp = requests.post(
+        endpoint,
+        params={"key": api_key},
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        json=payload,
+        timeout=timeout_sec,
+    )
+    return handle_response(resp)
+
+
+def model_candidates(req: dict[str, Any]) -> list[str]:
+    raw = req.get("models") or req.get("fallbackModels") or req.get("fallback_models")
+    if isinstance(raw, list):
+        values = raw
+    elif isinstance(raw, str) and raw.strip():
+        values = [x.strip() for x in raw.split(",")]
+    else:
+        values = DEFAULT_FALLBACK_MODELS
+
+    primary = req.get("model")
+    if primary:
+        values = [str(primary), *values]
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        model = normalize_model(str(value))
+        if not model or "pro" in model.lower() or model in seen:
+            continue
+        seen.add(model)
+        result.append(model)
+    return result or [DEFAULT_MODEL]
+
+
+def fetch_youtube(req: dict[str, Any]) -> dict[str, Any]:
+    api_keys = get_api_keys()
+    url = str(req.get("url") or req.get("URL") or req.get("link") or "").strip()
+    if not url:
+        raise YTFetchError("Missing required parameter: url", "MISSING_URL")
+    if not is_youtube_url(url):
+        raise YTFetchError(f"Unsupported YouTube URL: {url}", "BAD_URL")
+
+    original_url = url
+    url = canonicalize_youtube_url(url)
+    payload = build_payload(req, url)
+    timeout_sec = parse_int(req.get("timeoutSec") or req.get("timeout_sec"), 240)
+    retries = parse_int(req.get("retries"), 1)
+    errors: list[dict[str, Any]] = []
+
+    for key_index, api_key in enumerate(api_keys):
+        for model in model_candidates(req):
+            for attempt in range(retries + 1):
+                started = time.time()
+                try:
+                    data = generate_once(api_key, model, payload, timeout_sec)
+                    text = extract_text(data)
+                    if not text:
+                        finish = data.get("candidates", [{}])[0].get("finishReason")
+                        raise YTFetchError(f"Gemini returned empty text. finishReason={finish}", "EMPTY_TEXT")
+                    return {
+                        "model": normalize_model(model),
+                        "keyIndex": key_index,
+                        "url": original_url,
+                        "canonicalUrl": url,
+                        "durationMs": int((time.time() - started) * 1000),
+                        "text": text,
+                        "attemptedErrors": errors,
+                        "usage": usage_summary(data),
+                        "finishReason": data.get("candidates", [{}])[0].get("finishReason"),
+                        "responseId": data.get("responseId"),
+                        "modelVersion": data.get("modelVersion"),
+                    }
+                except YTFetchError as exc:
+                    errors.append(
+                        {
+                            "keyIndex": key_index,
+                            "model": normalize_model(model),
+                            "attempt": attempt + 1,
+                            "code": exc.code,
+                            "statusCode": exc.status_code,
+                            "message": str(exc)[:1200],
+                        }
+                    )
+                    retryable = exc.status_code in {429, 500, 502, 503, 504}
+                    if exc.status_code in {400, 404} or not retryable:
+                        break
+                    if attempt < retries:
+                        time.sleep(min(2 + attempt * 2, 8))
+                    else:
+                        break
+
+    raise YTFetchError("All Gemini model attempts failed: " + json.dumps(errors, ensure_ascii=False), "ALL_MODELS_FAILED")
+
+
+def format_markdown(result: dict[str, Any]) -> str:
+    usage = result.get("usage") or {}
+    lines = [
+        "## YouTube Fetch Result",
+        "",
+        f"- URL: {result.get('url')}",
+        f"- Model: {result.get('modelVersion') or result.get('model')}",
+        f"- Finish: {result.get('finishReason')}",
+        f"- Tokens: prompt={usage.get('promptTokenCount')}, output={usage.get('candidatesTokenCount')}, thoughts={usage.get('thoughtsTokenCount')}, total={usage.get('totalTokenCount')}",
+        "",
+        result.get("text", ""),
+    ]
+    return "\n".join(lines).strip()
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            raise YTFetchError("Empty stdin", "NO_INPUT")
+        req = json.loads(raw)
+        command = str(req.get("command") or req.get("cmd") or "fetch").strip().lower()
+
+        if command in {"models", "list_models", "list-models"}:
+            models = list_models(get_api_keys()[0])
+            emit({"status": "success", "result": {"models": models}})
+
+        result = fetch_youtube(req)
+        output = result if parse_bool(req.get("raw"), False) else format_markdown(result)
+        emit({"status": "success", "result": output, "data": result})
+    except json.JSONDecodeError as exc:
+        emit({"status": "error", "code": "BAD_JSON", "error": str(exc)}, 1)
+    except YTFetchError as exc:
+        emit({"status": "error", "code": exc.code, "statusCode": exc.status_code, "error": str(exc)}, 1)
+    except Exception as exc:
+        emit({"status": "error", "code": "FATAL", "error": str(exc)}, 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Plugin/YTFetch/config.env.example
+++ b/Plugin/YTFetch/config.env.example
@@ -1,0 +1,8 @@
+# Copy to config.env for local use. Never commit config.env or API keys.
+
+# Google AI Studio key. GEMINI_API_KEYS can be used instead for rotation.
+GEMINI_API_KEY=
+# GEMINI_API_KEYS=key-one,key-two
+
+GEMINI_API_BASE_URL=https://generativelanguage.googleapis.com
+YTFETCH_MODEL=gemini-2.5-flash-lite

--- a/Plugin/YTFetch/plugin-manifest.json
+++ b/Plugin/YTFetch/plugin-manifest.json
@@ -1,0 +1,42 @@
+{
+  "manifestVersion": "1.0.0",
+  "name": "YTFetch",
+  "displayName": "YouTube Gemini Fetch",
+  "version": "0.1.0",
+  "description": "Use Gemini API to directly read public YouTube URLs and return multimodal video/audio analysis without downloading the video locally.",
+  "author": "VCP Community",
+  "pluginType": "synchronous",
+  "entryPoint": {
+    "type": "python",
+    "command": "python YTFetch.py"
+  },
+  "communication": {
+    "protocol": "stdio",
+    "timeout": 300000
+  },
+  "configSchema": {
+    "GEMINI_API_KEY": {
+      "type": "string",
+      "description": "Google AI Studio API key."
+    },
+    "GEMINI_API_BASE_URL": {
+      "type": "string",
+      "description": "Gemini API base URL.",
+      "default": "https://generativelanguage.googleapis.com"
+    },
+    "YTFETCH_MODEL": {
+      "type": "string",
+      "description": "Default non-Pro Gemini model.",
+      "default": "gemini-2.5-flash-lite"
+    }
+  },
+  "capabilities": {
+    "invocationCommands": [
+      {
+        "commandIdentifier": "YTFetch",
+        "description": "Fetch and analyze a public YouTube video through Gemini direct YouTube URL input. Parameters: url(required), prompt(optional), model(optional, default gemini-2.5-flash-lite), fallbackModels(optional comma-separated), maxOutputTokens(optional, default 40000), thinkingBudget(optional), raw(optional boolean). command=list_models lists available non-Pro generateContent models.",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:<YTFetch>\nurl:<https://www.youtube.com/watch?v=BClcpTpEyn4>\nprompt:<Use Simplified Chinese. Summarize the video content, visuals, audio, and key timeline.>\nmodel:<gemini-2.5-flash-lite>\nmaxOutputTokens:<40000>\n<<<[END_TOOL_REQUEST]>>>"
+      }
+    ]
+  }
+}

--- a/Plugin/YTFetch/requirements.txt
+++ b/Plugin/YTFetch/requirements.txt
@@ -1,0 +1,2 @@
+requests
+python-dotenv


### PR DESCRIPTION
## 简介
YTFetch 是一个同步 stdio 插件，通过 Gemini API 直接读取公开 YouTube URL，并返回视频、音频和时间线分析；它不在本地下载视频。

## README
- 参数、数据流向与安全说明：`Plugin/YTFetch/README.md`
- 示例配置：`Plugin/YTFetch/config.env.example`
- 依赖：`Plugin/YTFetch/requirements.txt`

## 安全与兼容性
- 未提交 Gemini API 密钥、真实 config.env、缓存或 Python 运行产物。
- README 明确说明 URL 会发送给 Gemini 服务处理，并要求使用公开 URL、有效密钥和符合平台条款的内容。
- 已通过 Python 语法检查和 manifest JSON 校验。

这是我用VCP 10个月来，一些自己用着比较顺手的自制插件，要是觉得有用可以加入，或者要是有什么功能可以归并到现有的插件中也可以