### PR TITLE
feat: add AnkiSearch plugin

### DIFF
--- a/Plugin/AnkiSearch/.gitignore
+++ b/Plugin/AnkiSearch/.gitignore
@@ -1,0 +1,5 @@
+config.env
+__pycache__/
+*.pyc
+*.zip
+test_output/

--- a/Plugin/AnkiSearch/README.md
+++ b/Plugin/AnkiSearch/README.md
@@ -1,0 +1,43 @@
+# AnkiSearch
+
+AnkiSearch 是一个同步 `stdio` 插件，通过本机 AnkiConnect 对 Anki 数据进行只读查询。它支持 Anki 查询语法、牌组统计和笔记类型字段探查，不会修改卡片或笔记。
+
+## 前提
+
+- Python 3.8 或更高版本。
+- 本机 Anki 桌面端已启动。
+- 已安装并启用 [AnkiConnect](https://ankiweb.net/shared/info/2055492159)。
+
+默认端点是 `http://127.0.0.1:8765`。AnkiConnect 不应暴露到公共网络；如有自定义地址，请确认它只接受受信任的本机请求。
+
+## 配置
+
+复制 `config.env.example` 为 `config.env`。所有配置均可选：
+
+```env
+ANKI_CONNECT_URL=http://127.0.0.1:8765
+ANKI_CONNECT_TIMEOUT_SECONDS=5
+ANKI_CONNECT_RETRIES=3
+```
+
+插件优先使用已存在的系统环境变量，随后读取本地 `config.env`。`config.env` 不应提交。
+
+## 命令
+
+| 命令 | 说明 |
+| --- | --- |
+| `anki_search_cards` | 以 Anki 查询语法搜索卡片，并返回最多 15 张的字段摘要。参数：`query`。 |
+| `anki_get_decks` | 返回牌组和学习统计。 |
+| `anki_get_models` | 返回笔记类型及其字段结构。 |
+
+示例：
+
+```text
+<<<[TOOL_REQUEST]>>>
+tool_name: AnkiSearch
+command: anki_search_cards
+query: deck:Default is:due
+<<<[END_TOOL_REQUEST]>>>
+```
+
+若返回连接错误，请确认 Anki 已打开、AnkiConnect 已启用，并检查端点与防火墙设置。

--- a/Plugin/AnkiSearch/config.env.example
+++ b/Plugin/AnkiSearch/config.env.example
@@ -1,0 +1,4 @@
+# Copy to config.env for local use. This plugin should normally connect only to local AnkiConnect.
+ANKI_CONNECT_URL=http://127.0.0.1:8765
+ANKI_CONNECT_TIMEOUT_SECONDS=5
+ANKI_CONNECT_RETRIES=3

--- a/Plugin/AnkiSearch/main.py
+++ b/Plugin/AnkiSearch/main.py
@@ -1,0 +1,165 @@
+﻿import sys
+import json
+import os
+import urllib.request
+import urllib.error
+import time
+
+# Force UTF-8 output for VCP compatibility
+sys.stdout.reconfigure(encoding='utf-8')
+
+PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_plugin_env():
+    config_path = os.path.join(PLUGIN_DIR, 'config.env')
+    if not os.path.exists(config_path):
+        return
+
+    try:
+        with open(config_path, 'r', encoding='utf-8') as config_file:
+            for raw_line in config_file:
+                line = raw_line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, value = line.split('=', 1)
+                os.environ.setdefault(key.strip(), value.strip())
+    except OSError:
+        pass
+
+
+def positive_int(value, fallback):
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return fallback
+
+
+load_plugin_env()
+ANKI_CONNECT_URL = os.environ.get('ANKI_CONNECT_URL', 'http://127.0.0.1:8765').rstrip('/')
+ANKI_CONNECT_TIMEOUT_SECONDS = positive_int(os.environ.get('ANKI_CONNECT_TIMEOUT_SECONDS'), 5)
+ANKI_CONNECT_RETRIES = positive_int(os.environ.get('ANKI_CONNECT_RETRIES'), 3)
+
+
+def request_anki(action, params=None, retries=ANKI_CONNECT_RETRIES):
+    payload = {
+        'action': action,
+        'version': 6,
+        'params': params or {}
+    }
+    data = json.dumps(payload).encode('utf-8')
+
+    last_error = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(ANKI_CONNECT_URL, data=data, method='POST')
+            with urllib.request.urlopen(req, timeout=ANKI_CONNECT_TIMEOUT_SECONDS) as response:
+                return json.loads(response.read().decode('utf-8'))
+        except urllib.error.URLError as e:
+            last_error = f"连接失败: {e.reason}。请确保 Anki 已打开并安装了 AnkiConnect (端口 8765)。"
+            time.sleep(1)
+        except Exception as e:
+            last_error = str(e)
+            time.sleep(1)
+
+    return {'error': last_error}
+
+def main():
+    try:
+        input_data = sys.stdin.read()
+        if not input_data:
+            return
+
+        try:
+            request = json.loads(input_data)
+        except json.JSONDecodeError:
+             return
+
+        command = request.get('command')
+        # Optimization: Fallback for flattened arguments
+        args = request.get('args', {})
+        if not args and request:
+             # If args is empty, try to use the request object itself (excluding command)
+             args = {k: v for k, v in request.items() if k != 'command'}
+
+        result = {}
+
+        if command == 'anki_search_cards':
+            query = args.get('query', '')
+            resp = request_anki('findCards', {'query': query})
+
+            if resp.get('error'):
+                result = {"status": "error", "error": resp['error']}
+            else:
+                card_ids = resp.get('result', [])
+                info_resp = request_anki('cardsInfo', {'cards': card_ids[:15]})
+
+                simplified_cards = []
+                for c in info_resp.get('result', []):
+                    fields_data = c.get('fields', {})
+                    safe_fields = {k: v.get('value', '')[:100] for k, v in fields_data.items()}
+
+                    simplified_cards.append({
+                        "cardId": c.get('cardId'),
+                        "deck": c.get('deckName', 'Unknown'),
+                        "model": c.get('modelName', 'Unknown'),
+                        "fields": safe_fields,
+                        "tags": c.get('tags', []),
+                        "interval": c.get('interval', 0),
+                        "due": c.get('due', 0)
+                    })
+
+                result = {
+                    "status": "success",
+                    "result": {
+                        "totalFound": len(card_ids),
+                        "cards": simplified_cards
+                    },
+                    "messageForAI": f"找到 {len(card_ids)} 张匹配查询 '{query}' 的卡片。"
+                }
+
+        elif command == 'anki_get_decks':
+            resp = request_anki('deckNamesAndIds')
+            if resp.get('error'):
+                 result = {"status": "error", "error": resp['error']}
+            else:
+                decks = resp.get('result', {})
+                stats_resp = request_anki('getDeckStats', {'decks': list(decks.keys())})
+
+                result = {
+                    "status": "success",
+                    "result": stats_resp.get('result', {}),
+                    "messageForAI": "成功获取牌组列表及学习统计。"
+                }
+
+        elif command == 'anki_get_models':
+            resp = request_anki('modelNames')
+            if resp.get('error'):
+                 result = {"status": "error", "error": resp['error']}
+            else:
+                model_names = resp.get('result', [])
+                models_info = []
+                # 获取每个 Model 的字段
+                for name in model_names[:10]: # 限制前10个避免超时
+                    f_resp = request_anki('modelFieldNames', {'modelName': name})
+                    models_info.append({
+                        "name": name,
+                        "fields": f_resp.get('result', [])
+                    })
+
+                result = {
+                    "status": "success",
+                    "result": models_info,
+                    "messageForAI": f"获取到 {len(model_names)} 个笔记类型。"
+                }
+
+        else:
+             result = {"status": "error", "error": f"未知指令: {command}"}
+
+        print(json.dumps(result, ensure_ascii=False))
+
+    except Exception as e:
+        print(json.dumps({"status": "error", "error": f"插件执行错误: {str(e)}"}, ensure_ascii=False))
+
+if __name__ == '__main__':
+    main()

--- a/Plugin/AnkiSearch/plugin-manifest.json
+++ b/Plugin/AnkiSearch/plugin-manifest.json
@@ -1,0 +1,59 @@
+{
+  "manifestVersion": "1.0.0",
+  "name": "AnkiSearch",
+  "displayName": "Anki 搜索与查询",
+  "version": "1.2.0",
+  "description": "VCP 体系下的独立 Anki 查询工具。支持使用 Anki 强大的查询语法搜索卡片，获取牌组统计数据，以及查询笔记类型（Model）。",
+  "author": "VCPAnki Team",
+  "pluginType": "synchronous",
+  "entryPoint": {
+    "type": "python",
+    "command": "python main.py"
+  },
+  "communication": {
+    "protocol": "stdio",
+    "timeout": 30000
+  },
+  "configSchema": {
+    "ANKI_CONNECT_URL": {
+      "type": "string",
+      "description": "Local AnkiConnect endpoint URL.",
+      "default": "http://127.0.0.1:8765"
+    },
+    "ANKI_CONNECT_TIMEOUT_SECONDS": {
+      "type": "integer",
+      "description": "AnkiConnect request timeout in seconds.",
+      "default": 5
+    },
+    "ANKI_CONNECT_RETRIES": {
+      "type": "integer",
+      "description": "Retry attempts after a connection failure.",
+      "default": 3
+    }
+  },
+  "capabilities": {
+    "invocationCommands": [
+      {
+        "command": "anki_search_cards",
+        "description": "使用 Anki 查询语法搜索卡片。例如：'deck:默认 is:due' 查找到期卡片。",
+        "args": [
+          {
+            "name": "query",
+            "type": "string",
+            "description": "Anki 查询语句 (e.g., 'deck:Default is:due')"
+          }
+        ]
+      },
+      {
+        "command": "anki_get_decks",
+        "description": "获取所有牌组列表及其学习统计信息（新卡、到期卡等）。",
+        "args": []
+      },
+      {
+        "command": "anki_get_models",
+        "description": "获取所有笔记类型（Model）及其字段结构。",
+        "args": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 插件简介

AnkiSearch 是一个本地 AnkiConnect 查询插件，可按关键词搜索笔记并返回笔记字段、标签与卡片信息；连接地址、超时和重试次数均可通过 config.env 配置。

## 包含内容

- README.md：安装、配置与查询命令说明。
- config.env.example：可安全复制的本地 AnkiConnect 配置模板。
- .gitignore：避免提交本地配置和 Python 缓存。

这是我用VCP 10个月来，一些自己用着比较顺手的自制插件，要是觉得有用可以加入，或者要是有什么功能可以归并到现有的插件中也可以