### PR TITLE
feat: add AnkiManage plugin

### DIFF
--- a/Plugin/AnkiManage/.gitignore
+++ b/Plugin/AnkiManage/.gitignore
@@ -1,0 +1,6 @@
+config.env
+__pycache__/
+*.pyc
+*.zip
+temp_request*.json
+test_output/

--- a/Plugin/AnkiManage/README.md
+++ b/Plugin/AnkiManage/README.md
@@ -1,0 +1,50 @@
+# AnkiManage
+
+AnkiManage 是一个同步 `stdio` 插件，通过本机 AnkiConnect 管理 Anki 笔记与卡片状态。它可添加笔记、更新字段、挂起/取消挂起卡片和调整复习日期。
+
+## 安全边界
+
+这些命令会修改你的本地 Anki 数据库。请先备份 Anki，并在每次写入前使用 `dryRun=true` 查看预期操作；确认牌组、笔记类型、字段和卡片 ID 后，再移除 `dryRun` 执行。新建笔记默认不允许重复，如确有需要可显式传 `allowDuplicate=true`。
+
+插件默认只连接 `http://127.0.0.1:8765`。不要把 AnkiConnect 暴露到公共网络，也不要在不受信任的环境中加载此插件。
+
+## 前提与配置
+
+- Python 3.8 或更高版本。
+- 本机 Anki 桌面端已启动。
+- 已安装并启用 [AnkiConnect](https://ankiweb.net/shared/info/2055492159)。
+
+复制 `config.env.example` 为 `config.env`，需要时调整本机端点、超时和重试次数：
+
+```env
+ANKI_CONNECT_URL=http://127.0.0.1:8765
+ANKI_CONNECT_TIMEOUT_SECONDS=10
+ANKI_CONNECT_RETRIES=3
+```
+
+系统环境变量优先于本地 `config.env`；不要提交本地配置。
+
+## 命令
+
+| 命令 | 说明 |
+| --- | --- |
+| `anki_add_note` | 添加笔记。参数：`deck`、`model`、`fields`（JSON 字符串）、可选 `tags`、`allowDuplicate`、`dryRun`。 |
+| `anki_update_note` | 更新笔记字段。参数：`note_id`、`fields`（JSON 字符串）、可选 `dryRun`。 |
+| `anki_suspend` | 挂起或取消挂起卡片。参数：`card_ids`（逗号分隔）、`suspend`、可选 `dryRun`。 |
+| `anki_reschedule` | 调整复习日期。参数：`card_ids`、`days`、可选 `dryRun`。 |
+
+安全预检示例：
+
+```text
+<<<[TOOL_REQUEST]>>>
+tool_name: AnkiManage
+command: anki_add_note
+deck: Default
+model: Basic
+fields: {"Front":"hello","Back":"你好"}
+tags: vcp example
+dryRun: true
+<<<[END_TOOL_REQUEST]>>>
+```
+
+`anki_update_note` 使用 Note ID；`anki_suspend` 和 `anki_reschedule` 使用 Card ID。字段内容必须是 JSON 对象，而不是 Python 字典或未转义的文本。

--- a/Plugin/AnkiManage/config.env.example
+++ b/Plugin/AnkiManage/config.env.example
@@ -1,0 +1,4 @@
+# Copy to config.env for local use. This plugin should normally connect only to local AnkiConnect.
+ANKI_CONNECT_URL=http://127.0.0.1:8765
+ANKI_CONNECT_TIMEOUT_SECONDS=10
+ANKI_CONNECT_RETRIES=3

--- a/Plugin/AnkiManage/main.py
+++ b/Plugin/AnkiManage/main.py
@@ -1,0 +1,202 @@
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+sys.stdout.reconfigure(encoding='utf-8')
+
+PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_plugin_env():
+    config_path = os.path.join(PLUGIN_DIR, 'config.env')
+    if not os.path.exists(config_path):
+        return
+
+    try:
+        with open(config_path, 'r', encoding='utf-8') as config_file:
+            for raw_line in config_file:
+                line = raw_line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, value = line.split('=', 1)
+                os.environ.setdefault(key.strip(), value.strip())
+    except OSError:
+        pass
+
+
+def positive_int(value, fallback):
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return fallback
+
+
+def parse_boolean(value, default=False):
+    if value is None:
+        return default
+    return str(value).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+def parse_card_ids(value):
+    card_ids = [int(item.strip()) for item in str(value or '').split(',') if item.strip()]
+    if not card_ids:
+        raise ValueError('card_ids must contain at least one card ID')
+    return card_ids
+
+
+def parse_fields(value):
+    fields = json.loads(value or '{}')
+    if not isinstance(fields, dict):
+        raise ValueError('fields must be a JSON object')
+    return fields
+
+
+def parse_tags(value):
+    if isinstance(value, list):
+        return [str(tag).strip() for tag in value if str(tag).strip()]
+    return [tag for tag in str(value or '').split() if tag]
+
+
+load_plugin_env()
+ANKI_CONNECT_URL = os.environ.get('ANKI_CONNECT_URL', 'http://127.0.0.1:8765').rstrip('/')
+ANKI_CONNECT_TIMEOUT_SECONDS = positive_int(os.environ.get('ANKI_CONNECT_TIMEOUT_SECONDS'), 10)
+ANKI_CONNECT_RETRIES = positive_int(os.environ.get('ANKI_CONNECT_RETRIES'), 3)
+
+
+def request_anki(action, params=None, retries=ANKI_CONNECT_RETRIES):
+    payload = {
+        'action': action,
+        'version': 6,
+        'params': params or {},
+    }
+    data = json.dumps(payload).encode('utf-8')
+
+    last_error = None
+    for _ in range(retries):
+        try:
+            request = urllib.request.Request(ANKI_CONNECT_URL, data=data, method='POST')
+            with urllib.request.urlopen(request, timeout=ANKI_CONNECT_TIMEOUT_SECONDS) as response:
+                return json.loads(response.read().decode('utf-8'))
+        except urllib.error.URLError as error:
+            last_error = f'Connection failed: {error.reason}. Ensure Anki and AnkiConnect are running locally.'
+            time.sleep(1)
+        except Exception as error:
+            last_error = str(error)
+            time.sleep(1)
+
+    return {'error': last_error}
+
+
+def success(result, message):
+    return {'status': 'success', 'result': result, 'messageForAI': message}
+
+
+def main():
+    try:
+        input_data = sys.stdin.read()
+        if not input_data:
+            return
+
+        request = json.loads(input_data)
+        command = request.get('command')
+        args = request.get('args', {})
+        if not args:
+            args = {key: value for key, value in request.items() if key != 'command'}
+
+        dry_run = parse_boolean(args.get('dryRun', args.get('dry_run')), False)
+
+        if command == 'anki_add_note':
+            fields = parse_fields(args.get('fields'))
+            deck_name = str(args.get('deck', 'Default')).strip() or 'Default'
+            model_name = str(args.get('model', 'Basic')).strip() or 'Basic'
+            note = {
+                'deckName': deck_name,
+                'modelName': model_name,
+                'fields': fields,
+                'tags': parse_tags(args.get('tags')),
+                'options': {'allowDuplicate': parse_boolean(args.get('allowDuplicate'), False)},
+            }
+
+            if dry_run:
+                result = success({'dryRun': True, 'wouldAdd': note}, 'Preflight complete; no Anki note was created.')
+            else:
+                response = request_anki('addNote', {'note': note})
+                if response.get('error') and 'deck' in response['error'].lower():
+                    request_anki('createDeck', {'deck': deck_name})
+                    response = request_anki('addNote', {'note': note})
+
+                if response.get('error'):
+                    result = {'status': 'error', 'error': f"Failed to add note: {response['error']}"}
+                else:
+                    result = success(response.get('result'), f"Note added successfully. ID: {response.get('result')}")
+
+        elif command == 'anki_update_note':
+            note_id = int(args.get('note_id'))
+            if note_id <= 0:
+                raise ValueError('note_id must be positive')
+            fields = parse_fields(args.get('fields'))
+            planned = {'id': note_id, 'fields': fields}
+
+            if dry_run:
+                result = success({'dryRun': True, 'wouldUpdate': planned}, 'Preflight complete; no Anki note was changed.')
+            else:
+                response = request_anki('updateNoteFields', {'note': planned})
+                if response.get('error'):
+                    result = {'status': 'error', 'error': response['error']}
+                else:
+                    result = success('Updated', 'Note fields updated successfully.')
+
+        elif command == 'anki_suspend':
+            card_ids = parse_card_ids(args.get('card_ids'))
+            suspend = parse_boolean(args.get('suspend'), True)
+            action = 'suspend' if suspend else 'unsuspend'
+
+            if dry_run:
+                result = success(
+                    {'dryRun': True, 'wouldRun': action, 'cardIds': card_ids},
+                    'Preflight complete; no card state was changed.',
+                )
+            else:
+                response = request_anki(action, {'cards': card_ids})
+                if response.get('error'):
+                    result = {'status': 'error', 'error': response['error']}
+                else:
+                    result = success(response.get('result'), f"Cards {'suspended' if suspend else 'unsuspended'} successfully.")
+
+        elif command == 'anki_reschedule':
+            card_ids = parse_card_ids(args.get('card_ids'))
+            days = int(args.get('days', 0))
+
+            if dry_run:
+                result = success(
+                    {'dryRun': True, 'wouldReschedule': card_ids, 'days': days},
+                    'Preflight complete; no review schedule was changed.',
+                )
+            else:
+                response = request_anki('setDue', {'cards': card_ids, 'days': days})
+                if response.get('error'):
+                    response = request_anki('rescheduleCards', {'cards': card_ids, 'minDays': days, 'maxDays': days})
+                if response.get('error'):
+                    response = request_anki('setDueDate', {'cards': card_ids, 'days': days})
+
+                if response.get('error'):
+                    result = {'status': 'error', 'error': response['error']}
+                else:
+                    result = success(True, f'Cards rescheduled for {days} day(s) from today.')
+
+        else:
+            result = {'status': 'error', 'error': f'Unknown command: {command}'}
+
+        print(json.dumps(result, ensure_ascii=False))
+    except json.JSONDecodeError as error:
+        print(json.dumps({'status': 'error', 'error': f'Invalid JSON input: {error}'}, ensure_ascii=False))
+    except Exception as error:
+        print(json.dumps({'status': 'error', 'error': f'Plugin execution error: {error}'}, ensure_ascii=False))
+
+
+if __name__ == '__main__':
+    main()

--- a/Plugin/AnkiManage/plugin-manifest.json
+++ b/Plugin/AnkiManage/plugin-manifest.json
@@ -1,0 +1,132 @@
+{
+  "manifestVersion": "1.0.0",
+  "name": "AnkiManage",
+  "displayName": "Anki 管理与操作",
+  "version": "1.2.0",
+  "description": "VCP 体系下的独立 Anki 管理工具。支持添加笔记、更新字段、挂起卡片及重新调度。",
+  "author": "VCPAnki Team",
+  "pluginType": "synchronous",
+  "entryPoint": {
+    "type": "python",
+    "command": "python main.py"
+  },
+  "communication": {
+    "protocol": "stdio",
+    "timeout": 30000
+  },
+  "configSchema": {
+    "ANKI_CONNECT_URL": {
+      "type": "string",
+      "description": "Local AnkiConnect endpoint URL.",
+      "default": "http://127.0.0.1:8765"
+    },
+    "ANKI_CONNECT_TIMEOUT_SECONDS": {
+      "type": "integer",
+      "description": "AnkiConnect request timeout in seconds.",
+      "default": 10
+    },
+    "ANKI_CONNECT_RETRIES": {
+      "type": "integer",
+      "description": "Retry attempts after a connection failure.",
+      "default": 3
+    }
+  },
+  "capabilities": {
+    "invocationCommands": [
+      {
+        "command": "anki_add_note",
+        "description": "向 Anki 添加一条新笔记。支持指定牌组、模板、字段及标签。",
+        "args": [
+          {
+            "name": "deck",
+            "type": "string",
+            "description": "牌组名称"
+          },
+          {
+            "name": "model",
+            "type": "string",
+            "description": "笔记类型 (Model Name)"
+          },
+          {
+            "name": "fields",
+            "type": "string",
+            "description": "字段内容的 JSON 字符串"
+          },
+          {
+            "name": "tags",
+            "type": "string",
+            "description": "空格分隔的标签"
+          },
+          {
+            "name": "dryRun",
+            "type": "boolean",
+            "description": "为 true 时仅返回写入预览，不修改 Anki。"
+          }
+        ]
+      },
+      {
+        "command": "anki_update_note",
+        "description": "更新现有笔记的字段内容。",
+        "args": [
+          {
+            "name": "note_id",
+            "type": "number",
+            "description": "笔记 ID"
+          },
+          {
+            "name": "fields",
+            "type": "string",
+            "description": "需要更新的字段内容的 JSON 字符串"
+          },
+          {
+            "name": "dryRun",
+            "type": "boolean",
+            "description": "为 true 时仅返回写入预览，不修改 Anki。"
+          }
+        ]
+      },
+      {
+        "command": "anki_suspend",
+        "description": "挂起或取消挂起卡片。",
+        "args": [
+          {
+            "name": "card_ids",
+            "type": "string",
+            "description": "逗号分隔的 Card ID 列表"
+          },
+          {
+            "name": "suspend",
+            "type": "string",
+            "description": "true 挂起, false 取消挂起"
+          },
+          {
+            "name": "dryRun",
+            "type": "boolean",
+            "description": "为 true 时仅返回操作预览，不修改 Anki。"
+          }
+        ]
+      },
+      {
+        "command": "anki_reschedule",
+        "description": "重新调度卡片的复习日期。",
+        "args": [
+          {
+            "name": "card_ids",
+            "type": "string",
+            "description": "逗号分隔的 Card ID 列表"
+          },
+          {
+            "name": "days",
+            "type": "number",
+            "description": "今天起算的新间隔天数"
+          },
+          {
+            "name": "dryRun",
+            "type": "boolean",
+            "description": "为 true 时仅返回操作预览，不修改 Anki。"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 插件简介

AnkiManage 是一个本地 AnkiConnect 管理插件，支持添加及更新笔记、挂起/恢复卡片和调整复习日期；所有写操作均支持 dryRun=true 预检，新建笔记默认禁止重复。

## 包含内容

- README.md：前置条件、安全边界、配置与命令说明。
- config.env.example：可安全复制的本地 AnkiConnect 配置模板。
- .gitignore：避免提交本地配置和 Python 缓存。

这是我用VCP 10个月来，一些自己用着比较顺手的自制插件，要是觉得有用可以加入，或者要是有什么功能可以归并到现有的插件中也可以