### PR TITLE
Refresh MiniMax music helper models, cover mode and regional endpoints

### DIFF
--- a/Plugin/SkillBridge/SKILL/frontend-dev/references/minimax-cli-reference.md
+++ b/Plugin/SkillBridge/SKILL/frontend-dev/references/minimax-cli-reference.md
@@ -105,9 +105,10 @@ See [minimax-image-guide.md](minimax-image-guide.md) for ratio dimensions and de
 python scripts/minimax_music.py --prompt "Indie folk, melancholic" --lyrics "[verse]\nStreetlights flicker" -o song.mp3
 python scripts/minimax_music.py --prompt "Upbeat pop, energetic" --auto-lyrics -o pop.mp3
 python scripts/minimax_music.py --prompt "Jazz piano, smooth, relaxing" --instrumental -o jazz.mp3
+python scripts/minimax_music.py --model music-cover --prompt "Lo-fi bedroom pop rework" --audio-url https://example.com/reference.mp3 -o cover.mp3
 ```
 
-**Model:** `music-2.5+` (default). Sync: returns audio hex or URL.
+**Model:** `music-3.0` (default). Sync: returns audio hex or URL.
 
 | Flag | Default | Options |
 |------|---------|---------|
@@ -115,12 +116,20 @@ python scripts/minimax_music.py --prompt "Jazz piano, smooth, relaxing" --instru
 | `--prompt` | (empty) | Music description: style, mood, scenario (max 2000 chars) |
 | `--lyrics` | (empty) | Song lyrics with structure tags (max 3500 chars) |
 | `--lyrics-file` | (empty) | Read lyrics from file |
-| `--model` | `music-2.5+` | music-2.5+ / music-2.5 |
-| `--instrumental` | false | Generate instrumental only (no vocals, music-2.5+ only) |
-| `--auto-lyrics` | false | Auto-generate lyrics from prompt |
+| `--model` | `music-3.0` | music-3.0 / music-2.6 / music-cover / music-3.0-free / music-2.6-free / music-cover-free |
+| `--region` | (env, else global_en) | global_en (`https://api.minimax.io/v1`) / cn_zh (`https://api.minimaxi.com/v1`) |
+| `--instrumental` | false | Generate instrumental only (no vocals, text-to-music models only) |
+| `--auto-lyrics` | false | Auto-generate lyrics from prompt (text-to-music models only) |
+| `--audio-url` | (empty) | Reference track URL (cover models only) |
+| `--audio-file` | (empty) | Local reference track sent as base64 (cover models only) |
+| `--cover-feature-id` | (empty) | Preprocessed reference id, requires `--lyrics` (cover models only) |
 | `--format` | mp3 | mp3 / wav / pcm |
 | `--sample-rate` | 44100 | 16000 / 24000 / 32000 / 44100 |
 | `--bitrate` | 256000 | 32000 / 64000 / 128000 / 256000 |
+
+**Regional endpoints:** resolution order is `--region`, then `MINIMAX_API_BASE`, then `MINIMAX_REGION`, then `global_en`.
+
+**Cover models:** supply exactly one of `--audio-url`, `--audio-file` or `--cover-feature-id`, plus a `--prompt` describing the target style.
 
 **Lyrics structure tags:** `[Intro]`, `[Verse]`, `[Pre Chorus]`, `[Chorus]`, `[Interlude]`, `[Bridge]`, `[Outro]`, `[Post Chorus]`, `[Transition]`, `[Break]`, `[Hook]`, `[Build Up]`, `[Inst]`, `[Solo]`
 

--- a/Plugin/SkillBridge/SKILL/frontend-dev/references/minimax-music-guide.md
+++ b/Plugin/SkillBridge/SKILL/frontend-dev/references/minimax-music-guide.md
@@ -17,6 +17,32 @@ python scripts/minimax_music.py --prompt "Soulful blues, rainy night" --lyrics-f
 
 # Custom audio settings
 python scripts/minimax_music.py --prompt "Lo-fi beats" --instrumental -o lofi.wav --format wav --sample-rate 44100 --bitrate 256000
+
+# Cover a reference track (URL or local file)
+python scripts/minimax_music.py --model music-cover --prompt "Lo-fi bedroom pop rework, soft female vocals" --audio-url https://example.com/reference.mp3 -o cover.mp3
+python scripts/minimax_music.py --model music-cover --prompt "Acoustic ballad rework" --audio-file reference.wav -o cover.mp3
+
+# Pick a regional endpoint
+python scripts/minimax_music.py --prompt "Ambient pads" --instrumental -o pad.mp3 --region cn_zh
+```
+
+## Regional Endpoints
+
+The music API is served from two regional hosts with the same request shape. Resolution order:
+
+1. `--region` flag (or `region=` argument)
+2. `MINIMAX_API_BASE` environment variable (full base URL override, e.g. a gateway)
+3. `MINIMAX_REGION` environment variable
+4. default `global_en`
+
+| Region | Base URL |
+|--------|----------|
+| `global_en` | `https://api.minimax.io/v1` |
+| `cn_zh` | `https://api.minimaxi.com/v1` |
+
+```bash
+export MINIMAX_REGION=cn_zh
+python scripts/minimax_music.py --prompt "City pop" --auto-lyrics -o citypop.mp3
 ```
 
 ## Programmatic Usage
@@ -41,6 +67,16 @@ result = generate_music(
     lyrics_optimizer=True,
 )
 
+# Cover a reference track
+result = generate_music(
+    model="music-cover",
+    prompt="Lo-fi bedroom pop rework, soft female vocals",
+    audio_url="https://example.com/reference.mp3",
+)
+
+# Target a regional endpoint
+result = generate_music(prompt="Ambient pads", is_instrumental=True, region="cn_zh")
+
 # Access metadata
 print(f"Duration: {result['duration']}ms")
 print(f"Sample rate: {result['sample_rate']}")
@@ -51,8 +87,15 @@ print(f"Size: {result['size']} bytes")
 
 | Model | Features |
 |-------|----------|
-| `music-2.5+` | Recommended. Supports instrumental mode, complete song structures, hi-fi audio |
-| `music-2.5` | Standard model. No instrumental mode |
+| `music-3.0` | Recommended. Latest text-to-music model. Supports instrumental mode and auto-written lyrics |
+| `music-2.6` | Previous-generation text-to-music model. Supports instrumental mode and auto-written lyrics |
+| `music-cover` | Cover generation from a reference track. Needs a style `prompt` plus one reference |
+| `music-3.0-free` | Free tier of `music-3.0`, much lower rate limit |
+| `music-2.6-free` | Free tier of `music-2.6`, much lower rate limit |
+| `music-cover-free` | Free tier of `music-cover`, much lower rate limit |
+
+`--instrumental` and `--auto-lyrics` apply to the text-to-music models only; the reference flags
+(`--audio-url`, `--audio-file`, `--cover-feature-id`) apply to the cover models only.
 
 ## Prompt Writing
 
@@ -163,7 +206,7 @@ Under the neon lights...
 ```bash
 python scripts/minimax_music.py --prompt "Ambient electronic, space theme" --instrumental -o ambient.mp3
 ```
-- Requires `music-2.5+` model
+- Requires a text-to-music model (`music-3.0` / `music-2.6`, or their `-free` variants)
 - Only `prompt` needed, no lyrics
 
 ### 2. With Custom Lyrics
@@ -178,6 +221,24 @@ python scripts/minimax_music.py --prompt "Rock anthem about freedom" --auto-lyri
 ```
 - System generates lyrics from prompt
 - Good for quick generation when lyrics aren't critical
+
+### 4. Cover From a Reference Track
+```bash
+# Reference by URL
+python scripts/minimax_music.py --model music-cover --prompt "Lo-fi bedroom pop rework" --audio-url https://example.com/reference.mp3 -o cover.mp3
+
+# Reference from a local file (sent as base64)
+python scripts/minimax_music.py --model music-cover --prompt "Acoustic ballad rework" --audio-file reference.wav -o cover.mp3
+
+# Two-step workflow: reuse a preprocessed reference and supply edited lyrics
+python scripts/minimax_music.py --model music-cover --prompt "Acoustic ballad rework" --cover-feature-id "<id>" --lyrics "[verse]\nNew words here" -o cover.mp3
+```
+- `--prompt` describes the target style and is required
+- Supply exactly one reference: `--audio-url`, `--audio-file` or `--cover-feature-id`
+- Reference track: 6 seconds to 6 minutes, up to 50 MB, common audio formats
+- `--cover-feature-id` comes from the cover preprocess step, is valid for 24 hours, and requires `--lyrics`
+- Without lyrics the cover models derive them from the reference track
+- `--instrumental` and `--auto-lyrics` are not available on the cover models
 
 ## Limits
 

--- a/Plugin/SkillBridge/SKILL/frontend-dev/scripts/minimax_music.py
+++ b/Plugin/SkillBridge/SKILL/frontend-dev/scripts/minimax_music.py
@@ -8,10 +8,14 @@ Usage:
   python minimax_music.py --prompt "Indie folk, melancholic" --lyrics "[verse]\nStreetlights flicker" -o song.mp3
   python minimax_music.py --prompt "Upbeat pop, energetic" --auto-lyrics -o pop.mp3
   python minimax_music.py --prompt "Jazz piano, smooth, relaxing" --instrumental -o jazz.mp3
+  python minimax_music.py --model music-cover --prompt "Lo-fi bedroom pop rework" --audio-url https://host/ref.mp3 -o cover.mp3
 
 Env: MINIMAX_API_KEY (required)
+     MINIMAX_REGION (optional: global_en | cn_zh, default global_en)
+     MINIMAX_API_BASE (optional: full base URL override, e.g. a gateway)
 """
 
+import base64
 import os
 import sys
 import json
@@ -19,15 +23,66 @@ import argparse
 import requests
 
 API_KEY = os.getenv("MINIMAX_API_KEY")
-API_BASE = os.getenv("MINIMAX_API_BASE", "https://api.minimax.io/v1")
+
+# The music API is served from two regional hosts with identical request shapes.
+# Pick one by region name instead of pasting a host into every call site.
+REGION_BASES = {
+    "global_en": "https://api.minimax.io/v1",
+    "cn_zh": "https://api.minimaxi.com/v1",
+}
+DEFAULT_REGION = "global_en"
+
+# Text-to-music models take prompt/lyrics; cover models rework a reference track.
+COVER_MODELS = ("music-cover", "music-cover-free")
+MUSIC_MODELS = (
+    "music-3.0",
+    "music-2.6",
+    "music-cover",
+    "music-3.0-free",
+    "music-2.6-free",
+    "music-cover-free",
+)
+DEFAULT_MODEL = "music-3.0"
+
+
+def resolve_api_base(region: str = "") -> str:
+    """Resolve the API base URL. Explicit region wins, then MINIMAX_API_BASE, then MINIMAX_REGION."""
+    if region:
+        if region not in REGION_BASES:
+            raise SystemExit(
+                f"ERROR: unknown region '{region}'. Choose one of: {', '.join(REGION_BASES)}"
+            )
+        return REGION_BASES[region]
+
+    override = (os.getenv("MINIMAX_API_BASE") or "").strip()
+    if override:
+        return override.rstrip("/")
+
+    env_region = (os.getenv("MINIMAX_REGION") or "").strip()
+    if env_region:
+        if env_region not in REGION_BASES:
+            raise SystemExit(
+                f"ERROR: unknown MINIMAX_REGION '{env_region}'. Choose one of: {', '.join(REGION_BASES)}"
+            )
+        return REGION_BASES[env_region]
+
+    return REGION_BASES[DEFAULT_REGION]
+
+
+# Kept for backwards compatibility with callers that import API_BASE directly.
+API_BASE = resolve_api_base()
 
 
 def generate_music(
     prompt: str = "",
     lyrics: str = "",
-    model: str = "music-2.5+",
+    model: str = DEFAULT_MODEL,
     is_instrumental: bool = False,
     lyrics_optimizer: bool = False,
+    audio_url: str = "",
+    audio_base64: str = "",
+    cover_feature_id: str = "",
+    region: str = "",
     sample_rate: int = 44100,
     bitrate: int = 256000,
     fmt: str = "mp3",
@@ -37,6 +92,30 @@ def generate_music(
     """Synchronous HTTP music generation. Returns dict with audio bytes and metadata."""
     if not API_KEY:
         raise SystemExit("ERROR: MINIMAX_API_KEY is not set.\n  export MINIMAX_API_KEY='your-key'")
+
+    if model not in MUSIC_MODELS:
+        raise SystemExit(f"ERROR: unknown model '{model}'. Choose one of: {', '.join(MUSIC_MODELS)}")
+
+    is_cover = model in COVER_MODELS
+    references = [bool(audio_url), bool(audio_base64), bool(cover_feature_id)]
+
+    if is_cover:
+        if sum(references) != 1:
+            raise SystemExit(
+                "ERROR: cover models need exactly one reference: --audio-url, --audio-file or --cover-feature-id."
+            )
+        if not prompt:
+            raise SystemExit("ERROR: cover models require --prompt describing the target style.")
+        if cover_feature_id and not lyrics:
+            raise SystemExit("ERROR: --cover-feature-id requires lyrics.")
+        if is_instrumental or lyrics_optimizer:
+            raise SystemExit(
+                "ERROR: --instrumental and --auto-lyrics are only supported by the text-to-music models."
+            )
+    elif any(references):
+        raise SystemExit(
+            "ERROR: reference audio and --cover-feature-id are only supported by the cover models."
+        )
 
     payload = {
         "model": model,
@@ -56,9 +135,15 @@ def generate_music(
         payload["is_instrumental"] = True
     if lyrics_optimizer:
         payload["lyrics_optimizer"] = True
+    if audio_url:
+        payload["audio_url"] = audio_url
+    if audio_base64:
+        payload["audio_base64"] = audio_base64
+    if cover_feature_id:
+        payload["cover_feature_id"] = cover_feature_id
 
     resp = requests.post(
-        f"{API_BASE}/music_generation",
+        f"{resolve_api_base(region)}/music_generation",
         headers={
             "Authorization": f"Bearer {API_KEY}",
             "Content-Type": "application/json",
@@ -107,9 +192,23 @@ def main():
     p.add_argument("--prompt", default="", help="Music description: style, mood, scenario (max 2000 chars)")
     p.add_argument("--lyrics", default="", help="Song lyrics with structure tags (max 3500 chars)")
     p.add_argument("--lyrics-file", default="", help="Read lyrics from file instead of --lyrics")
-    p.add_argument("--model", default="music-2.5+", choices=["music-2.5+", "music-2.5"], help="Model (default: music-2.5+)")
-    p.add_argument("--instrumental", action="store_true", help="Generate instrumental only (no vocals)")
-    p.add_argument("--auto-lyrics", action="store_true", help="Auto-generate lyrics from prompt")
+    p.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        choices=list(MUSIC_MODELS),
+        help=f"Model (default: {DEFAULT_MODEL})",
+    )
+    p.add_argument(
+        "--region",
+        default="",
+        choices=list(REGION_BASES),
+        help=f"Regional endpoint (default: MINIMAX_API_BASE / MINIMAX_REGION, else {DEFAULT_REGION})",
+    )
+    p.add_argument("--instrumental", action="store_true", help="Generate instrumental only (no vocals, text-to-music models only)")
+    p.add_argument("--auto-lyrics", action="store_true", help="Auto-generate lyrics from prompt (text-to-music models only)")
+    p.add_argument("--audio-url", default="", help="Reference track URL for the cover models")
+    p.add_argument("--audio-file", default="", help="Local reference track for the cover models (sent as base64)")
+    p.add_argument("--cover-feature-id", default="", help="Reference feature id from the cover preprocess step")
     p.add_argument("--format", default="mp3", dest="fmt", choices=["mp3", "wav", "pcm"], help="Audio format (default: mp3)")
     p.add_argument("--sample-rate", type=int, default=44100, choices=[16000, 24000, 32000, 44100], help="Sample rate (default: 44100)")
     p.add_argument("--bitrate", type=int, default=256000, choices=[32000, 64000, 128000, 256000], help="Bitrate (default: 256000)")
@@ -120,6 +219,11 @@ def main():
         with open(args.lyrics_file, "r") as f:
             lyrics = f.read()
 
+    audio_base64 = ""
+    if args.audio_file:
+        with open(args.audio_file, "rb") as f:
+            audio_base64 = base64.b64encode(f.read()).decode("ascii")
+
     os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
 
     result = generate_music(
@@ -128,6 +232,10 @@ def main():
         model=args.model,
         is_instrumental=args.instrumental,
         lyrics_optimizer=args.auto_lyrics,
+        audio_url=args.audio_url,
+        audio_base64=audio_base64,
+        cover_feature_id=args.cover_feature_id,
+        region=args.region,
         sample_rate=args.sample_rate,
         bitrate=args.bitrate,
         fmt=args.fmt,


### PR DESCRIPTION
Reason: The SkillBridge MiniMax music helper and its docs still pinned retired model ids, had no cover mode, and hard-coded a single regional host.

## Changes

`Plugin/SkillBridge/SKILL/frontend-dev/scripts/minimax_music.py`

- Refresh the `--model` choices to the current music generation set (`music-3.0`, `music-2.6`, `music-cover`, plus the `-free` tiers) and move the default to `music-3.0`.
- Add cover generation: `--audio-url`, `--audio-file` (read locally and sent as `audio_base64`) and `--cover-feature-id` map onto the corresponding request fields.
- Validate mode/model combinations up front instead of round-tripping to the API: cover models need exactly one reference plus a style `prompt`, `--cover-feature-id` needs lyrics, `--instrumental` / `--auto-lyrics` stay on the text-to-music models, and the reference flags are rejected on the text-to-music models.
- Add regional endpoint selection. `REGION_BASES` maps `global_en` and `cn_zh` to their base URLs, and `resolve_api_base()` resolves in the order `--region` / `region=` argument, then `MINIMAX_API_BASE`, then `MINIMAX_REGION`, then `global_en`. `MINIMAX_API_BASE` keeps working exactly as before for gateway setups, and the module-level `API_BASE` is kept so existing importers do not break.

`references/minimax-music-guide.md`, `references/minimax-cli-reference.md`

- Replace the retired model table with the current models, document the cover workflow (including the reference track limits and the two-step preprocessed-reference flow), and document the regional endpoints and their resolution order.

## Checks

- `python3 -m py_compile Plugin/SkillBridge/SKILL/frontend-dev/scripts/minimax_music.py`
- `python3 Plugin/SkillBridge/SKILL/frontend-dev/scripts/minimax_music.py --help`
- Offline behaviour check with `requests.post` stubbed: confirmed the default request targets the `global_en` base URL with `music-3.0`, that `region="cn_zh"` switches the host, that cover requests carry `audio_url` / `cover_feature_id`, that `--region` beats `MINIMAX_API_BASE` which beats `MINIMAX_REGION`, and that all seven invalid mode/model combinations above are rejected.

No repository lint, typecheck or test command covers these skill scripts (`npm test` is a placeholder and CI only runs `npm ci` plus the Docker build), so nothing else was run.
