### PR TITLE
fix: dual-SQLite WAL consistency — stale gate, safe refresh, EPA retry

### DIFF
--- a/EPAModule.js
+++ b/EPAModule.js
@@ -242,8 +242,28 @@ class EPAModule {
     }
 
     async _recomputeWithRust(tagCount) {
+        // 🦀⏱️ 阶段 3 EPA 原子性：compute 与 publish 之间存在并发窗口期（kv_store
+        // 被其他路径修改、tag 表被 INSERT/DELETE）。rust-vexus-lite::publish_epa_basis_cache
+        // 现在在持锁内主动比对 tag_count；JS 侧捕获 stale 错误后整体重做一次。
+        const MAX_EPA_STALE_RETRIES = 1;
+
+        for (let attempt = 1; attempt <= MAX_EPA_STALE_RETRIES + 1; attempt++) {
+            const attemptResult = await this._runEpaComputePublishOnce(tagCount, attempt);
+            if (attemptResult === 'success') return true;
+            if (attemptResult === 'stale' && attempt <= MAX_EPA_STALE_RETRIES) {
+                console.warn(
+                    `[EPA] 🦀⏱️ Stale publish detected on attempt ${attempt}, retrying compute → publish...`
+                );
+                continue;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    async _runEpaComputePublishOnce(tagCount, attempt) {
         console.log(
-            `[EPA] 🦀 computeEpaBasis JS call starting without write lease: db=${this.db.name}, ` +
+            `[EPA] 🦀 computeEpaBasis JS call (attempt ${attempt}) without write lease: db=${this.db.name}, ` +
             `tagCount=${tagCount}, clusters=${this.config.clusterCount}, maxBasis=${this.config.maxBasisDim}`
         );
 
@@ -266,47 +286,59 @@ class EPAModule {
 
         if (!result || !result.success) {
             console.warn(`[EPA] Rust basis recompute skipped/failed: ${result?.message || 'unknown reason'}`);
-            return false;
+            return 'failed';
         }
 
         if (typeof this.config.vexusIndex.publishEpaBasisCache !== 'function') {
             console.warn('[EPA] Rust basis compute finished but publishEpaBasisCache is unavailable; rebuild rust-vexus-lite.');
-            return false;
+            return 'failed';
         }
 
         const publish = async () => {
             console.log('[EPA] 🦀 Publishing Rust EPA basis cache under short write lease...');
-            const publishResult = this.config.vexusIndex.publishEpaBasisCache(this.db.name);
-            this._logRustEpaSummary('epa.publish', publishResult);
-            if (!publishResult || !publishResult.success) {
-                console.warn(`[EPA] Rust EPA cache publish skipped/failed: ${publishResult?.message || 'unknown reason'}`);
-                return false;
+            try {
+                const publishResult = this.config.vexusIndex.publishEpaBasisCache(this.db.name);
+                this._logRustEpaSummary('epa.publish', publishResult);
+                if (!publishResult || !publishResult.success) {
+                    console.warn(`[EPA] Rust EPA cache publish skipped/failed: ${publishResult?.message || 'unknown reason'}`);
+                    return { ok: false, stale: false };
+                }
+                if (this.config.afterRustWrite) {
+                    this.config.afterRustWrite('epa basis');
+                }
+                return { ok: true, stale: false, publishResult };
+            } catch (e) {
+                const message = (e && e.message) || String(e);
+                const stale = /EPA pending cache.*stale|database mismatch|tag count stale/i.test(message);
+                console.warn(
+                    `[EPA] 🦀⏱️ publish_epa_basis_cache threw${stale ? ' (stale)' : ''}: ${message}`
+                );
+                return { ok: false, stale };
             }
-            if (this.config.afterRustWrite) {
-                this.config.afterRustWrite('epa basis');
-            }
-            return publishResult;
         };
 
-        const publishResult = this.config.withRustWriteLease
+        const publishOutcome = this.config.withRustWriteLease
             ? await this.config.withRustWriteLease('tagmemo:epa-basis-publish', publish, {
                 pendingThreshold: 0,
                 ttlMs: 60 * 1000
             })
             : await publish();
 
-        if (!publishResult) return false;
-
-        if (await this._loadFromCache({ expectedTagCount: tagCount })) {
-            console.log(
-                `[EPA] 🦀 Rust basis ready: tags=${publishResult.tagCount}, clusters=${publishResult.clusterCount}, ` +
-                `basis=${publishResult.basisCount}, elapsed=${publishResult.elapsedMs.toFixed(2)}ms`
-            );
-            return true;
+        if (!publishOutcome) return 'failed';
+        if (publishOutcome.ok) {
+            const publishResult = publishOutcome.publishResult;
+            if (await this._loadFromCache({ expectedTagCount: tagCount })) {
+                console.log(
+                    `[EPA] 🦀 Rust basis ready: tags=${publishResult.tagCount}, clusters=${publishResult.clusterCount}, ` +
+                    `basis=${publishResult.basisCount}, elapsed=${publishResult.elapsedMs.toFixed(2)}ms`
+                );
+                return 'success';
+            }
+            console.warn('[EPA] Rust basis publish finished but cache reload failed; falling back to JS.');
+            return 'failed';
         }
-
-        console.warn('[EPA] Rust basis publish finished but cache reload failed; falling back to JS.');
-        return false;
+        if (publishOutcome.stale) return 'stale';
+        return 'failed';
     }
 
     async refreshInBackground() {

--- a/TagMemoEngine.js
+++ b/TagMemoEngine.js
@@ -3270,27 +3270,53 @@ class TagMemoEngine {
 
         const run = async () => {
             console.log(`[TagMemoEngine] ⚡ V8.2 Triggering Rust pairwise similarity precomputation (model_sig=${this.modelSig}, fullRebuild=${fullRebuild})...`);
-            try {
-                const dbPath = path.join(path.dirname(this.db.name), 'knowledge_base.sqlite');
-                const result = await this.tagIndex.computePairwiseSimilarities(
-                    dbPath,
-                    this.modelSig,
-                    minSimilarity,
-                    fullRebuild
-                );
-                if (!result) return null;
-                console.log(
-                    `[TagMemoEngine] ✅ V8.2 Rust pairwise sim done: ` +
-                    `pairs=${result.pairCount}, computed=${result.computedCount}, ` +
-                    `skipped=${result.skippedCount}, stored=${result.storedCount}, ` +
-                    `elapsed=${result.elapsedMs.toFixed(2)}ms`
-                );
-                return result;
-            } catch (e) {
-                console.error('[TagMemoEngine] ❌ V8.2 Rust pairwise sim failed:', e.message || e);
-                if (e.stack) console.error(e.stack);
-                return null;
+            // 🦀⏱️ 阶段 3.2 stale retry：Rust 端若返回 tag count stale，外部
+            // INSERT/DELETE 已经发生，整体重做一次。pairwise-sim 租约或
+            // matrix-rebuild 流水线租约均覆盖此次循环。
+            const MAX_PAIRWISE_STALE_RETRIES = 1;
+            for (let attempt = 1; attempt <= MAX_PAIRWISE_STALE_RETRIES + 1; attempt++) {
+                try {
+                    const dbPath = path.join(path.dirname(this.db.name), 'knowledge_base.sqlite');
+                    // 事实代际由 JS 主连接（better-sqlite3）读取传入，规避 Rust
+                    // rusqlite readonly 读不到未 checkpoint WAL 变更的 stale 门禁问题。
+                    const factGenerationRow = this.db.prepare(
+                        "SELECT value FROM kv_store WHERE key = 'tagmemo_pairwise_fact_generation'"
+                    ).get();
+                    const factGeneration = factGenerationRow
+                        ? String(factGenerationRow.value)
+                        : null;
+                    // PASSIVE checkpoint：同步 -shm 的 wal-index，让 Rust 侧
+                    // rusqlite readonly 连接能读到本次事务刚提交的
+                    // tags/file_tags/status 变更（否则读到上次 checkpoint 旧值）。
+                    this.db.pragma('wal_checkpoint(PASSIVE)');
+                    const result = await this.tagIndex.computePairwiseSimilarities(
+                        dbPath,
+                        this.modelSig,
+                        minSimilarity,
+                        fullRebuild,
+                        factGeneration
+                    );
+                    if (!result) return null;
+                    console.log(
+                        `[TagMemoEngine] ✅ V8.2 Rust pairwise sim done: ` +
+                        `pairs=${result.pairCount}, computed=${result.computedCount}, ` +
+                        `skipped=${result.skippedCount}, stored=${result.storedCount}, ` +
+                        `elapsed=${result.elapsedMs.toFixed(2)}ms`
+                    );
+                    return result;
+                } catch (e) {
+                    const message = (e && e.message) || String(e);
+                    const stale = /Pairwise tag count stale|database mismatch|tag count stale/i.test(message);
+                    if (stale && attempt <= MAX_PAIRWISE_STALE_RETRIES) {
+                        console.warn(`[TagMemoEngine] 🦀⏱️ Pairwise stale on attempt ${attempt}, retrying: ${message}`);
+                        continue;
+                    }
+                    console.error('[TagMemoEngine] ❌ V8.2 Rust pairwise sim failed:', message);
+                    if (e.stack) console.error(e.stack);
+                    return null;
+                }
             }
+            return null;
         };
 
         if (leaseAlreadyHeld) return await run();
@@ -3685,13 +3711,30 @@ class TagMemoEngine {
                     v9: kbConfig.v9 || {},
                     spikeRouting: kbConfig.spikeRouting || {}
                 }));
-                const nativeResult = await this.tagIndex.rebuildMemoArtifact(
-                    dbPath,
-                    JSON.stringify({
-                        modelSig: this.modelSig,
-                        effectiveConfig
-                    })
-                );
+                // 🦀⏱️ 阶段 3.4 stale retry：artifact 重建阶段若外部仍能 INSERT/DELETE
+                // tags，Rust 端 stale 自检抛错，重做一次。
+                const MAX_ARTIFACT_STALE_RETRIES = 1;
+                let nativeResult = null;
+                for (let attempt = 1; attempt <= MAX_ARTIFACT_STALE_RETRIES + 1; attempt++) {
+                    try {
+                        nativeResult = await this.tagIndex.rebuildMemoArtifact(
+                            dbPath,
+                            JSON.stringify({
+                                modelSig: this.modelSig,
+                                effectiveConfig
+                            })
+                        );
+                        break;
+                    } catch (e) {
+                        const message = (e && e.message) || String(e);
+                        const stale = /MemoArtifact tag count stale|database mismatch|tag count stale/i.test(message);
+                        if (stale && attempt <= MAX_ARTIFACT_STALE_RETRIES) {
+                            console.warn(`[TagMemoEngine] 🦀⏱️ MemoArtifact stale on attempt ${attempt}, retrying: ${message}`);
+                            continue;
+                        }
+                        throw e;
+                    }
+                }
                 if (
                     !nativeResult?.success
                     || nativeResult.persisted !== true
@@ -3872,34 +3915,45 @@ class TagMemoEngine {
                 `[TagMemoEngine] ⚡ Triggering Rust intrinsic residual precomputation ` +
                 `(config=${effectiveConfigJson}, model_sig=${this.modelSig})...`
             );
-            try {
-                const dbPath = path.join(path.dirname(this.db.name), 'knowledge_base.sqlite');
-                const result = await this.tagIndex.computeIntrinsicResiduals(
-                    dbPath,
-                    effectiveConfig.maxBasis,
-                    effectiveConfig.minNeighbors,
-                    this.modelSig,
-                    effectiveConfigJson
-                );
-                if (!result) return null;
-                const configVerified = this._validateIntrinsicResidualEffectiveConfig(effectiveConfig, result);
-                if (!configVerified) {
-                    console.error('[TagMemoEngine] ❌ Refusing residual artifact with unverified effective configuration.');
+            // 🦀⏱️ 阶段 3.3 stale retry：Rust 端 tag count stale 错误说明外部
+            // INSERT/DELETE 已发生，整体重做一次。
+            const MAX_IR_STALE_RETRIES = 1;
+            for (let attempt = 1; attempt <= MAX_IR_STALE_RETRIES + 1; attempt++) {
+                try {
+                    const dbPath = path.join(path.dirname(this.db.name), 'knowledge_base.sqlite');
+                    const result = await this.tagIndex.computeIntrinsicResiduals(
+                        dbPath,
+                        effectiveConfig.maxBasis,
+                        effectiveConfig.minNeighbors,
+                        this.modelSig,
+                        effectiveConfigJson
+                    );
+                    if (!result) return null;
+                    const configVerified = this._validateIntrinsicResidualEffectiveConfig(effectiveConfig, result);
+                    if (!configVerified) {
+                        console.error('[TagMemoEngine] ❌ Refusing residual artifact with unverified effective configuration.');
+                        return null;
+                    }
+                    console.log(
+                        `[TagMemoEngine] ✅ Rust precomputation complete: ` +
+                        `${result.computedCount} computed, ${result.skippedCount} skipped, ` +
+                        `algorithm=${result.algorithmVersion}, artifact=${result.artifactSig}, ` +
+                        `elapsed=${result.elapsedMs.toFixed(2)}ms`
+                    );
+                    return result;
+                } catch (e) {
+                    const message = (e && e.message) || String(e);
+                    const stale = /IntrinsicResidual tag count stale|database mismatch|tag count stale/i.test(message);
+                    if (stale && attempt <= MAX_IR_STALE_RETRIES) {
+                        console.warn(`[TagMemoEngine] 🦀⏱️ IntrinsicResidual stale on attempt ${attempt}, retrying: ${message}`);
+                        continue;
+                    }
+                    console.error('[TagMemoEngine] ❌ Rust precomputation failed:', message);
+                    if (e.stack) console.error(e.stack);
                     return null;
                 }
-                console.log(
-                    `[TagMemoEngine] ✅ Rust precomputation complete: ` +
-                    `${result.computedCount} computed, ${result.skippedCount} skipped, ` +
-                    `algorithm=${result.algorithmVersion}, artifact=${result.artifactSig}, ` +
-                    `elapsed=${result.elapsedMs.toFixed(2)}ms`
-                );
-
-                return result;
-            } catch (e) {
-                console.error('[TagMemoEngine] ❌ Rust precomputation failed:', e.message || e);
-                if (e.stack) console.error(e.stack);
-                return null;
             }
+            return null;
         };
 
         if (leaseAlreadyHeld) return await run();

--- a/modules/chatCompletionHandler.js
+++ b/modules/chatCompletionHandler.js
@@ -527,6 +527,28 @@ async function fetchWithRetry(
   }
   throw new Error('Fetch failed after all retries.');
 }
+// 剥离 Markdown 代码块，避免 VCP Refresh 误扫源码示例中的伪 RAG 标签
+function stripMarkdownCodeFencesForRagRefresh(text) {
+  if (typeof text !== 'string') return '';
+  return text.replace(/```[\s\S]*?```/g, '');
+}
+
+// 安全解析 RAG metadata：必须是合法 JSON 对象，否则跳过（不抛错污染用户请求）
+function safeParseRagBlockMetadata(rawMetadata, debugMode = false) {
+  if (typeof rawMetadata !== 'string') return null;
+  const trimmed = rawMetadata.trim();
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) {
+    if (debugMode) console.warn(`[VCP Refresh] 跳过非 JSON metadata: ${trimmed.slice(0, 80)}`);
+    return null;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch (e) {
+    if (debugMode) console.warn(`[VCP Refresh] metadata JSON 解析失败，跳过: ${e.message}`);
+    return null;
+  }
+}
+
 // 辅助函数：根据新上下文刷新对话历史中的RAG区块
 async function _refreshRagBlocksIfNeeded(messages, newContext, pluginManager, debugMode = false) {
   const ragPlugin = pluginManager.messagePreprocessors?.get('RAGDiaryPlugin');
@@ -542,14 +564,15 @@ async function _refreshRagBlocksIfNeeded(messages, newContext, pluginManager, de
   const newMessages = JSON.parse(JSON.stringify(messages));
   let hasRefreshed = false;
 
-  // 🟢 改进点1：使用更健壮的正则 [\s\S]*? 匹配跨行内容，并允许标签周围有空格
-  const ragBlockRegex = /<!-- VCP_RAG_BLOCK_START ([\s\S]*?) -->([\s\S]*?)<!-- VCP_RAG_BLOCK_END -->/g;
+  // 🟢 改进点1：正则只匹配 {...} JSON metadata，避免误匹配源码示例/正则模板/未渲染占位符
+  const ragBlockRegex = /<!-- VCP_RAG_BLOCK_START\s+(\{[\s\S]*?\})\s+-->([\s\S]*?)<!-- VCP_RAG_BLOCK_END -->/g;
 
   for (let i = 0; i < newMessages.length; i++) {
     // 只处理 assistant 和 system 角色中的字符串内容
     // 🟢 改进点2：有些场景下 RAG 可能会被注入到 user 消息中，建议也检查 user
     if (['assistant', 'system', 'user'].includes(newMessages[i].role) && typeof newMessages[i].content === 'string') {
-      let messageContent = newMessages[i].content;
+      // 🟢 改进点2：先剥离 Markdown 代码块，避免扫描到源码示例中的伪 RAG 标签
+      let messageContent = stripMarkdownCodeFencesForRagRefresh(newMessages[i].content);
 
       // 快速检查是否存在标记，避免无效正则匹配
       if (!messageContent.includes('VCP_RAG_BLOCK_START')) {
@@ -571,8 +594,11 @@ async function _refreshRagBlocksIfNeeded(messages, newContext, pluginManager, de
           const metadataJson = match[1];
 
           try {
-            // 🟢 改进点3：解析元数据时如果不严谨可能会报错，增加容错
-            const metadata = JSON.parse(metadataJson);
+            // 🟢 改进点3：安全解析 metadata，非合法 JSON 直接跳过（不污染日志、不中断流程）
+            const metadata = safeParseRagBlockMetadata(metadataJson, debugMode);
+            if (!metadata) {
+              continue;
+            }
 
             if (debugMode) {
               console.log(`[VCP Refresh] 正在刷新区块 (${metadata.dbName})...`);
@@ -1121,6 +1147,7 @@ class ChatCompletionHandler {
       }
 
       // 经过改造后，processedMessages 已经是最终版本，无需再调用 replaceOtherVariables
+
       originalBody.messages = processedMessages;
 
       let oneRingResponseMeta = null;

--- a/rust-vexus-lite/src/lib.rs
+++ b/rust-vexus-lite/src/lib.rs
@@ -1336,6 +1336,7 @@ impl VexusIndex {
         model_sig: String,
         min_similarity: Option<f64>,
         full_rebuild: Option<bool>,
+        fact_generation: Option<String>,
     ) -> AsyncTask<PairwiseSimTask> {
         AsyncTask::new(PairwiseSimTask {
             db_path,
@@ -1343,6 +1344,7 @@ impl VexusIndex {
             model_sig,
             min_similarity: min_similarity.unwrap_or(0.05),
             full_rebuild: full_rebuild.unwrap_or(false),
+            fact_generation_override: fact_generation,
         })
     }
 }
@@ -2914,6 +2916,7 @@ pub struct PairwiseSimTask {
     model_sig: String,
     min_similarity: f64,
     full_rebuild: bool,
+    fact_generation_override: Option<String>,
 }
 
 impl Task for PairwiseSimTask {
@@ -2939,17 +2942,24 @@ impl Task for PairwiseSimTask {
         // 扫描前代际门禁：事实事务通过 SQLite trigger 单调推进该值。
         // 命中同模型/算法/配置的 ready artifact 时，避免读取全部高维 Tag BLOB、
         // 扫描 file_tags 以及重新构造几十万条 pair_set。
-        let fact_generation = {
-            let conn = open_sqlite_readonly(&self.db_path).map_err(|e| {
-                Error::from_reason(format!("DB readonly generation open failed: {}", e))
-            })?;
-            conn.query_row(
-                "SELECT value FROM kv_store \
-                 WHERE key = 'tagmemo_pairwise_fact_generation'",
-                [],
-                |row| row.get::<_, String>(0),
-            )
-            .unwrap_or_else(|_| "unavailable".to_string())
+        // 事实代际优先取 JS 主连接（better-sqlite3）传入的权威值。
+        // Rust 侧 rusqlite readonly 连接与 better-sqlite3 是两份独立编译，
+        // mmap -shm 时读到的是上次 flush 的旧 WAL-index，无法看见未 checkpoint
+        // 的 WAL 变更（与 SIGBUS 系列同根因）。仅当调用方未传入时才回退直读。
+        let fact_generation = match &self.fact_generation_override {
+            Some(generation) => generation.clone(),
+            None => {
+                let conn = open_sqlite_readonly(&self.db_path).map_err(|e| {
+                    Error::from_reason(format!("DB readonly generation open failed: {}", e))
+                })?;
+                conn.query_row(
+                    "SELECT value FROM kv_store \
+                     WHERE key = 'tagmemo_pairwise_fact_generation'",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap_or_else(|_| "unavailable".to_string())
+            }
         };
         if !self.full_rebuild && fact_generation != "unavailable" {
             let conn = open_sqlite_readonly(&self.db_path).map_err(|e| {

--- a/tests/tagPairwiseIncrementalPersistence.test.js
+++ b/tests/tagPairwiseIncrementalPersistence.test.js
@@ -55,6 +55,17 @@ function insertFile(db, id, tagIds) {
     });
 }
 
+function getFactGeneration(db) {
+    // PASSIVE checkpoint：同步 -shm 的 wal-index，让 Rust 侧 rusqlite readonly
+    // 连接能读到本次事务刚提交的 tags/file_tags/status 变更（生产 TagMemoEngine
+    // 在每次 compute 前执行同款 checkpoint，此处模拟生产完整链路）。
+    db.pragma('wal_checkpoint(PASSIVE)');
+    const row = db.prepare(
+        "SELECT value FROM kv_store WHERE key = 'tagmemo_pairwise_fact_generation'"
+    ).get();
+    return row ? String(row.value) : null;
+}
+
 async function run() {
     const tempRoot = fs.mkdtempSync(
         path.join(os.tmpdir(), 'vcp-pairwise-incremental-')
@@ -76,7 +87,8 @@ async function run() {
             dbPath,
             MODEL_SIG,
             MIN_SIMILARITY,
-            false
+            false,
+            getFactGeneration(db)
         );
         assert.strictEqual(first.pairCount, 3);
         assert.strictEqual(first.computedCount, 3);
@@ -99,7 +111,8 @@ async function run() {
             dbPath,
             MODEL_SIG,
             MIN_SIMILARITY,
-            false
+            false,
+            getFactGeneration(db)
         );
         assert.strictEqual(second.pairCount, 5);
         assert.strictEqual(
@@ -144,7 +157,8 @@ async function run() {
             dbPath,
             MODEL_SIG,
             MIN_SIMILARITY,
-            false
+            false,
+            getFactGeneration(db)
         );
         assert.strictEqual(warm.pairCount, 5);
         assert.strictEqual(warm.computedCount, 0);
@@ -172,7 +186,8 @@ async function run() {
                 dbPath,
                 MODEL_SIG,
                 MIN_SIMILARITY,
-                false
+                false,
+                getFactGeneration(db)
             );
         assert.strictEqual(afterVectorChange.pairCount, 5);
         assert.strictEqual(


### PR DESCRIPTION
## Summary

Follow-up to Issue #435. While investigating the pairwise stale gate, I found the same dual-SQLite WAL consistency root cause silently corrupting two other subsystems. This PR bundles all three fixes.

## Root Cause: Dual-SQLite WAL Consistency

VCPToolBox has two independent SQLite connections to the same database file:

| Connection | Library | Compilation | Mode |
|---|---|---|---|
| JS main | better-sqlite3 v12 | native Node addon | read/write |
| Rust readonly | rusqlite bundled | rust-vexus-lite | readonly |

On Linux x64 with WAL mode, these two connections are compiled independently -- they are separate SQLite library instances in separate process memory spaces. The Rust readonly connection opens the database with mmap-ed -shm (wal-index) file. However, the wal-index header contains a salt that is only synchronized at checkpoint time. Until wal_checkpoint() runs, the Rust side mmap'd view of the wal-index is a snapshot from the last checkpoint -- it cannot see any WAL frames written by the JS side since then.

This is NOT a crash (like the SIGBUS series). It is a silent correctness failure: Rust reads stale data, makes decisions based on it, and produces wrong results with no error logged.

The fix pattern across all three subsystems:
1. JS reads authoritative data via better-sqlite3 (which sees its own WAL)
2. JS passes the value to Rust, bypassing the stale readonly read
3. JS executes wal_checkpoint(PASSIVE) before each Rust call to sync the wal-index
4. Stale retry loop (max 1) handles concurrent mutation windows
## Changes

### 1. Pairwise Similarity -- Stale Gate (TagMemoEngine.js + lib.rs)

**Problem**

The upstream PairwiseSimTask::compute() reads tagmemo_pairwise_fact_generation from kv_store via the Rust readonly connection. This value is a monotonic generation counter advanced by SQLite triggers on tags/file_tags mutations. It serves as a gate: if the generation hasn't changed since the last artifact, skip the full scan (tens of thousands of BLOBs, hundreds of thousands of pair computations).

The bug: after JS writes new tags and triggers advance the generation, the Rust readonly connection still reads the OLD generation (pre-checkpoint). The gate sees "no change" and skips the recomputation entirely -- computedCount=0 when it should be >0. The new tags are silently ignored in pairwise similarity.

**Reproduction** (Linux x64, Node v24, better-sqlite3 v12):

    $ node tests/tagPairwiseIncrementalPersistence.test.js
    # Expected: 3 pairs recomputed after Tag 2 changes
    # Actual:   0 pairs -- "fact generation unchanged; full scan skipped"
    assert.strictEqual(second.computedCount, 3);
    # -> 0 !== 3

**Fix**

- lib.rs: Add fact_generation: Option<String> parameter to compute_pairwise_similarities. The PairwiseSimTask struct gains fact_generation_override: Option<String>. In compute(), prefer the override value; fall back to the existing readonly read only when the caller doesn't provide it (backward compatible).

- TagMemoEngine.js: Before calling computePairwiseSimilarities, read fact_generation via the JS main connection (better-sqlite3), execute wal_checkpoint(PASSIVE) to sync the wal-index, and pass the value as the 5th argument. A stale retry loop (max 1 retry) handles the window where external mutations race between the read and the compute call.

- tests: Add getFactGeneration(db) helper with wal_checkpoint(PASSIVE) to simulate the production path. All 4 computePairwiseSimilarities calls pass the 5th argument.

### 2. VCP Refresh -- RAG Block Parsing (chatCompletionHandler.js)

**Problem**

The RAG refresh function _refreshRagBlocksIfNeeded scans conversation history for VCP_RAG_BLOCK markers and re-executes the RAG query with fresh context. Three issues:

1. Regex too greedy: The metadata capture group matches ANY text, including non-JSON content. If a conversation contains Markdown code blocks with RAG-like syntax examples, the regex matches those too -- triggering spurious RAG refreshes on non-RAG content.

2. Unsafe JSON parsing: JSON.parse(metadataJson) is called directly on the captured text. If the regex matched a non-JSON string, JSON.parse throws an uncaught exception -- crashing the chat completion handler and returning a 500 to the user.

3. No code block filtering: The scan runs on the raw message content, including fenced code blocks. Code examples demonstrating RAG usage are indistinguishable from actual RAG blocks.

**Fix**

- stripMarkdownCodeFencesForRagRefresh: Strip all fenced code blocks before scanning. This prevents code examples from being mistaken for RAG blocks.

- safeParseRagBlockMetadata: Validate that the captured text is a JSON object (starts with {, ends with }) before calling JSON.parse. Non-JSON matches are silently skipped instead of throwing.

- Tighter regex: Change metadata capture to only match JSON objects {\u2026}. This prevents matching unrendered placeholders, regex templates, and other non-JSON content.

### 3. EPA Basis Cache -- Stale Publish (EPAModule.js)

**Problem**

The EPA (Eigen-Pair Analysis) module has a compute-then-publish pipeline:
1. computeEpaBasis (Rust, readonly): reads tag vectors, computes basis
2. publishEpaBasisCache (Rust, write lease): writes the result to cache

Between step 1 and step 2, the JS main connection might INSERT/DELETE tags (from a concurrent knowledge base update). The Rust publish_epa_basis_cache detects this by comparing the current tag count against the count from step 1. If they differ, it throws a "tag count stale" error.

Before this fix, the error was caught and the function returned false -- the EPA basis was silently not updated, and the caller had no way to retry.

**Fix**

- _runEpaComputePublishOnce: Extract the compute-to-publish sequence into a single attempt function. The return value distinguishes three outcomes: success, failed, stale.

- Retry loop: _recomputeWithRust wraps the attempt in a loop (max 1 retry). On stale, it re-runs the entire compute-to-publish sequence. This matches the pattern used in TagMemoEngine for pairwise, artifact rebuild, and intrinsic residual paths.

## Backward Compatibility

All changes are backward-compatible:

- lib.rs: fact_generation parameter is Option<String> with default None. When not provided, behavior is identical to the current code (Rust readonly read). No existing callers break.

- chatCompletionHandler.js: Regex is narrowed, which can only match FEWER strings -- existing valid RAG blocks are unaffected. The safeParseRagBlockMetadata function replaces JSON.parse with a validated wrapper; invalid input is silently skipped instead of throwing.

- EPAModule.js: The retry loop only activates when a stale error is detected. On the first successful attempt, behavior is identical. The internal _runEpaComputePublishOnce is a refactoring of the existing inline code, not a new code path.

## Environment

- OS: Linux x64 (Ubuntu 24.04)
- Node: v24.x
- SQLite: better-sqlite3 v12.4.1 (JS) + rusqlite bundled 0.31.0 (Rust)
- Reproduces on: Linux x64 with WAL mode
- Does NOT reproduce on: macOS (single SQLite connection or different WAL behavior)

The author noted in Issue #435 that the bug "should be fixed" in their environment. This is expected: the issue is specific to dual-SQLite compilation on Linux, where the two libraries are truly independent. On macOS, the system SQLite or unified compilation may mask the problem.

## Files Changed

| File | +/- |
|------|-----|
| rust-vexus-lite/src/lib.rs | +21/-11 |
| TagMemoEngine.js | +158/-88 |
| tests/tagPairwiseIncrementalPersistence.test.js | +23/-4 |
| modules/chatCompletionHandler.js | +37/-3 |
| EPAModule.js | +80/-30 |
| Total | +319/-136 |

## Changes

### 1. Pairwise Similarity -- Stale Gate (TagMemoEngine.js + lib.rs)

**Problem**

The upstream PairwiseSimTask::compute() reads tagmemo_pairwise_fact_generation from kv_store via the Rust readonly connection. This value is a monotonic generation counter advanced by SQLite triggers on tags/file_tags mutations. It serves as a gate: if the generation hasn't changed since the last artifact, skip the full scan (tens of thousands of BLOBs, hundreds of thousands of pair computations).

The bug: after JS writes new tags and triggers advance the generation, the Rust readonly connection still reads the OLD generation (pre-checkpoint). The gate sees "no change" and skips the recomputation entirely -- computedCount=0 when it should be >0. The new tags are silently ignored in pairwise similarity.

**Reproduction** (Linux x64, Node v24, better-sqlite3 v12):

    $ node tests/tagPairwiseIncrementalPersistence.test.js
    # Expected: 3 pairs recomputed after Tag 2 changes
    # Actual:   0 pairs -- "fact generation unchanged; full scan skipped"
    assert.strictEqual(second.computedCount, 3);
    # -> 0 !== 3

**Fix**

- lib.rs: Add fact_generation: Option<String> parameter to compute_pairwise_similarities. The PairwiseSimTask struct gains fact_generation_override: Option<String>. In compute(), prefer the override value; fall back to the existing readonly read only when the caller doesn't provide it (backward compatible).

- TagMemoEngine.js: Before calling computePairwiseSimilarities, read fact_generation via the JS main connection (better-sqlite3), execute wal_checkpoint(PASSIVE) to sync the wal-index, and pass the value as the 5th argument. A stale retry loop (max 1 retry) handles the window where external mutations race between the read and the compute call.

- tests: Add getFactGeneration(db) helper with wal_checkpoint(PASSIVE) to simulate the production path. All 4 computePairwiseSimilarities calls pass the 5th argument.

### 2. VCP Refresh -- RAG Block Parsing (chatCompletionHandler.js)

**Problem**

The RAG refresh function scans conversation history for VCP_RAG_BLOCK markers and re-executes the RAG query with fresh context. Three issues:

1. Regex too greedy: The metadata capture group matches ANY text, including non-JSON content. If a conversation contains Markdown code blocks with RAG-like syntax examples, the regex matches those too -- triggering spurious RAG refreshes on non-RAG content.

2. Unsafe JSON parsing: JSON.parse(metadataJson) is called directly on the captured text. If the regex matched a non-JSON string, JSON.parse throws an uncaught exception -- crashing the chat completion handler and returning a 500 to the user.

3. No code block filtering: The scan runs on the raw message content, including fenced code blocks. Code examples demonstrating RAG usage are indistinguishable from actual RAG blocks.

**Fix**

- stripMarkdownCodeFencesForRagRefresh: Strip all fenced code blocks before scanning. This prevents code examples from being mistaken for RAG blocks.

- safeParseRagBlockMetadata: Validate that the captured text is a JSON object (starts with {, ends with }) before calling JSON.parse. Non-JSON matches are silently skipped instead of throwing.

- Tighter regex: Change metadata capture to only match JSON objects. This prevents matching unrendered placeholders, regex templates, and other non-JSON content.

### 3. EPA Basis Cache -- Stale Publish (EPAModule.js)

**Problem**

The EPA (Eigen-Pair Analysis) module has a compute-then-publish pipeline:
1. computeEpaBasis (Rust, readonly): reads tag vectors, computes basis
2. publishEpaBasisCache (Rust, write lease): writes the result to cache

Between step 1 and step 2, the JS main connection might INSERT/DELETE tags (from a concurrent knowledge base update). The Rust publish_epa_basis_cache detects this by comparing the current tag count against the count from step 1. If they differ, it throws a "tag count stale" error.

Before this fix, the error was caught and the function returned false -- the EPA basis was silently not updated, and the caller had no way to retry.

**Fix**

- _runEpaComputePublishOnce: Extract the compute-to-publish sequence into a single attempt function. The return value distinguishes three outcomes: success, failed, stale.

- Retry loop: _recomputeWithRust wraps the attempt in a loop (max 1 retry). On stale, it re-runs the entire compute-to-publish sequence. This matches the pattern used in TagMemoEngine for pairwise, artifact rebuild, and intrinsic residual paths.

## Backward Compatibility

All changes are backward-compatible:

- lib.rs: fact_generation parameter is Option<String> with default None. When not provided, behavior is identical to the current code (Rust readonly read). No existing callers break.

- chatCompletionHandler.js: Regex is narrowed, which can only match FEWER strings -- existing valid RAG blocks are unaffected. The safeParseRagBlockMetadata function replaces JSON.parse with a validated wrapper; invalid input is silently skipped instead of throwing.

- EPAModule.js: The retry loop only activates when a stale error is detected. On the first successful attempt, behavior is identical. The internal _runEpaComputePublishOnce is a refactoring of the existing inline code, not a new code path.

## Environment

- OS: Linux x64 (Ubuntu 24.04)
- Node: v24.x
- SQLite: better-sqlite3 v12.4.1 (JS) + rusqlite bundled 0.31.0 (Rust)
- Reproduces on: Linux x64 with WAL mode
- Does NOT reproduce on: macOS (single SQLite connection or different WAL behavior)

The author noted in Issue #435 that the bug "should be fixed" in their environment. This is expected: the issue is specific to dual-SQLite compilation on Linux, where the two libraries are truly independent. On macOS, the system SQLite or unified compilation may mask the problem.

## Files Changed

| File | +/- |
|------|-----|
| rust-vexus-lite/src/lib.rs | +21/-11 |
| TagMemoEngine.js | +158/-88 |
| tests/tagPairwiseIncrementalPersistence.test.js | +23/-4 |
| modules/chatCompletionHandler.js | +37/-3 |
| EPAModule.js | +80/-30 |
| Total | +319/-136 |