### PR TITLE
feat(mobile): 补齐移动端依赖的 admin HTTP 出口

### DIFF
--- a/Plugin/VCPClawMail/VCPClawMail.js
+++ b/Plugin/VCPClawMail/VCPClawMail.js
@@ -1149,7 +1149,7 @@ async function readMail(args = {}) {
   lines.push('- 下载附件：调用 `download_attachment`。');
   lines.push('- 转发/新发：调用 `send_mail`，正文或 `attachments` 可包含 URL / `file://`。');
 
-  return asAiContent(lines.join('\n'), imageContent, {
+  const aiResult = asAiContent(lines.join('\n'), imageContent, {
     command: 'read_mail',
     user,
     mailbox: mailboxInfo.mailbox,
@@ -1158,6 +1158,9 @@ async function readMail(args = {}) {
     imageCount: normalized.imageUrls.length + imageContent.length,
     parsedDocumentCount: parsedDocuments.length
   });
+  // 供 admin API 提取原始 HTML / 纯文本 / 附件元数据（AI 工具路径忽略该字段）
+  aiResult.detail = normalized;
+  return aiResult;
 }
 
 function extractUrlsFromText(text) {
@@ -1518,6 +1521,215 @@ async function downloadAttachment(args = {}) {
     fileUrl,
     size: stat.size
   });
+}
+
+/**
+ * 标记邮件已读/未读（SDK transport.markMessages；admin API 与移动端专用）。
+ * @param {object} args - { mailId | mailId[], read = true, fid?, mailbox/user }
+ */
+async function markMail(args = {}) {
+  const mailboxInfo = resolveMailboxArgs(args);
+  const user = mailboxInfo.user;
+  const mailId = args.mailId || args.id;
+  if (!mailId) throw new Error('mark_mail 需要 mailId。');
+  const read = args.read === undefined ? true : normalizeBoolean(args.read, true);
+  const client = getClient(user);
+  const ids = (Array.isArray(mailId) ? mailId : [mailId]).map(String);
+
+  if (client.transport && typeof client.transport.markMessages === 'function') {
+    await client.transport.markMessages(ids, { read }, args.fid ? String(args.fid) : undefined);
+  } else {
+    await callFirstAvailable(client, [
+      'mail.mark',
+      'mark',
+      'messages.mark',
+      'emails.mark'
+    ], [{ ids, id: ids[0], mailId: ids[0], read, user }]);
+  }
+
+  // 标志位变化后刷新缓存，让列表与占位符尽快一致
+  await pollOnce().catch(() => {});
+
+  return asAiText([
+    '# ClawEmail 标记结果',
+    '',
+    '## 状态',
+    '',
+    `- 结果：已标记为${read ? '已读' : '未读'}`,
+    `- 邮箱：${user}`,
+    `- 邮箱槽位：${mailboxInfo.mailbox}`,
+    `- mailId：\`${ids.join(', ')}\``
+  ].join('\n'), {
+    command: 'mark_mail',
+    user,
+    mailbox: mailboxInfo.mailbox,
+    mailId: ids.join(','),
+    read
+  });
+}
+
+/**
+ * 搜索邮件（SDK transport.searchMessages，支持 fts 全文；admin API 与移动端专用）。
+ * @param {object} args - { keyword/q, from, to, subject, since, before, unreadOnly, fts, limit, fid, mailbox/user }
+ */
+async function searchMails(args = {}) {
+  const mailboxInfo = resolveMailboxArgs(args);
+  const user = mailboxInfo.user;
+  const limit = normalizeInteger(args.limit, DEFAULT_POLL_LIMIT);
+  const client = getClient(user);
+
+  const query = {
+    fid: String(args.fid || args.folderId || 1),
+    from: args.from,
+    to: args.to,
+    subject: args.subject,
+    keyword: args.keyword || args.q,
+    since: args.since,
+    before: args.before,
+    unread: args.unreadOnly !== undefined ? normalizeBoolean(args.unreadOnly, false) : undefined,
+    fts: normalizeBoolean(args.fts, false),
+    limit
+  };
+  Object.keys(query).forEach(key => query[key] === undefined && delete query[key]);
+
+  if (!query.keyword && !query.from && !query.to && !query.subject) {
+    throw new Error('search_mail 需要 keyword/from/to/subject 至少一项。');
+  }
+
+  const result = client.transport && typeof client.transport.searchMessages === 'function'
+    ? await client.transport.searchMessages(query)
+    : await callFirstAvailable(client, [
+      'mail.search',
+      'search',
+      'messages.search',
+      'emails.search'
+    ], [query]);
+
+  const rawList = Array.isArray(result)
+    ? result
+    : Array.isArray(result?.emails)
+      ? result.emails
+      : Array.isArray(result?.mails)
+        ? result.mails
+        : Array.isArray(result?.data)
+          ? result.data
+          : [];
+
+  const emails = rawList.slice(0, limit).map(mail => normalizeMailSummary(mail, user));
+  const lines = [];
+
+  lines.push('# ClawEmail 邮件搜索');
+  lines.push('');
+  lines.push('## 统计');
+  lines.push('');
+  lines.push(`- 查询邮箱：${user}`);
+  lines.push(`- 邮箱槽位：${mailboxInfo.mailbox}`);
+  lines.push(`- 返回数量：${emails.length}`);
+  lines.push(`- 全文搜索（fts）：${mdBool(query.fts === true)}`);
+  lines.push('');
+
+  if (emails.length === 0) {
+    lines.push('## 邮件');
+    lines.push('');
+    lines.push('没有匹配的邮件。');
+  } else {
+    lines.push('## 邮件');
+    lines.push('');
+    lines.push('| # | 状态 | mailId | 发件人 | 主题 | 时间 | 附件 | 预览 |');
+    lines.push('|---:|---|---|---|---|---|---|');
+    emails.forEach((mail, index) => {
+      const status = mail.unread === true ? '未读' : (mail.read === true ? '已读' : '未知');
+      lines.push(`| ${index + 1} | ${status} | \`${mdInline(mail.mailId, '未知')}\` | ${mdInline(formatArrayForMd(mail.from), '未知')} | ${mdInline(mail.subject, '(无主题)')} | ${mdInline(mail.date, '未知')} | ${mdBool(mail.hasAttachments)} | ${mdInline(mail.preview, '')} |`);
+    });
+  }
+
+  const aiResult = asAiText(lines.join('\n'), {
+    command: 'search_mail',
+    user,
+    mailbox: mailboxInfo.mailbox,
+    count: emails.length
+  });
+  aiResult.emails = emails;
+  return aiResult;
+}
+
+/**
+ * 移动邮件到任意文件夹（SDK transport.moveMessages；垃圾箱软删除见 moveToTrash）。
+ * @param {object} args - { mailId | mailId[], target/targetFolderId, fid?（源文件夹）, mailbox/user }
+ */
+async function moveMailToFolder(args = {}) {
+  const mailboxInfo = resolveMailboxArgs(args);
+  const user = mailboxInfo.user;
+  const mailId = args.mailId || args.id;
+  if (!mailId) throw new Error('move_mail 需要 mailId。');
+  const target = args.target || args.targetFolderId || args.targetFid || args.toFid;
+  if (!target) throw new Error('move_mail 需要 target（目标文件夹 id）。');
+  const client = getClient(user);
+  const ids = (Array.isArray(mailId) ? mailId : [mailId]).map(String);
+
+  if (client.transport && typeof client.transport.moveMessages === 'function') {
+    await client.transport.moveMessages(ids, String(target), args.fid ? String(args.fid) : undefined);
+  } else {
+    await callFirstAvailable(client, [
+      'mail.move',
+      'move',
+      'messages.move',
+      'emails.move'
+    ], [{ ids, id: ids[0], mailId: ids[0], target: String(target), user }]);
+  }
+
+  await pollOnce().catch(() => {});
+
+  return asAiText([
+    '# ClawEmail 移动结果',
+    '',
+    '## 状态',
+    '',
+    '- 结果：邮件已移动',
+    `- 邮箱：${user}`,
+    `- 邮箱槽位：${mailboxInfo.mailbox}`,
+    `- mailId：\`${ids.join(', ')}\``,
+    `- 目标文件夹：\`${target}\``
+  ].join('\n'), {
+    command: 'move_mail',
+    user,
+    mailbox: mailboxInfo.mailbox,
+    mailId: ids.join(','),
+    target: String(target)
+  });
+}
+
+/**
+ * 获取附件原始字节（供 admin API 流式回传；与 download_attachment 写磁盘工具不同，
+ * 本函数不落盘，直接返回 Buffer）。
+ * @param {object} args - { mailId, attachmentId/partId, mailbox/user }
+ * @returns {Promise<{user, mailbox, mailId, attachmentId, filename, contentType, size, buffer}>}
+ */
+async function getAttachmentData(args = {}) {
+  const mailboxInfo = resolveMailboxArgs(args);
+  const user = mailboxInfo.user;
+  const mailId = args.mailId || args.id;
+  if (!mailId) throw new Error('get_attachment 需要 mailId。');
+  const attachmentId = args.attachmentId || args.partId;
+  if (!attachmentId) throw new Error('get_attachment 需要 attachmentId 或 partId。');
+
+  const client = getClient(user);
+  const part = String(args.partId || attachmentId);
+  const result = await client.mail.getAttachment({ id: mailId, part });
+  const buffer = await attachmentResponseToBuffer(result);
+  const filename = result?.filename || `${attachmentId}.bin`;
+  const contentType = result?.contentType || mime.lookup(filename) || 'application/octet-stream';
+
+  return {
+    user,
+    mailbox: mailboxInfo.mailbox,
+    mailId,
+    attachmentId,
+    filename,
+    contentType,
+    size: buffer.length,
+    buffer
+  };
 }
 
 async function pollOnce() {
@@ -2118,7 +2330,12 @@ async function adminReadMail(args = {}) {
   return {
     meta: result.meta,
     markdown: extractTextContent(result),
-    content: result.content || []
+    content: result.content || [],
+    // 原始 HTML / 纯文本 / 附件元数据（移动端保真渲染与附件列表用）
+    html: result.detail?.html ?? null,
+    text: result.detail?.text ?? null,
+    attachments: result.detail?.attachments ?? [],
+    imageUrls: result.detail?.imageUrls ?? []
   };
 }
 
@@ -2130,6 +2347,62 @@ async function adminMoveToTrash(args = {}) {
   };
 }
 
+// ===== 以下为 V1.1/V2 补全的 admin 包装（SDK 能力现成，仅补出口） =====
+
+async function adminSendMail(args = {}) {
+  const result = await sendMail(args);
+  return {
+    meta: result.meta,
+    markdown: extractTextContent(result)
+  };
+}
+
+async function adminReplyMail(args = {}) {
+  const result = await replyMail(args);
+  return {
+    meta: result.meta,
+    markdown: extractTextContent(result)
+  };
+}
+
+async function adminListFolders(args = {}) {
+  const result = await listFolders(args);
+  return {
+    meta: { user: result.user, mailbox: result.mailbox },
+    folders: result.folders || []
+  };
+}
+
+async function adminMarkMail(args = {}) {
+  const result = await markMail(args);
+  return {
+    meta: result.meta,
+    markdown: extractTextContent(result)
+  };
+}
+
+async function adminSearchMails(args = {}) {
+  const result = await searchMails(args);
+  return {
+    meta: result.meta,
+    emails: result.emails || [],
+    markdown: extractTextContent(result)
+  };
+}
+
+async function adminMoveMail(args = {}) {
+  const result = await moveMailToFolder(args);
+  return {
+    meta: result.meta,
+    markdown: extractTextContent(result)
+  };
+}
+
+/** 附件原始字节（路由层流式回传；不经 markdown 包装）。 */
+async function adminGetAttachment(args = {}) {
+  return await getAttachmentData(args);
+}
+
 module.exports = {
   initialize,
   processToolCall,
@@ -2139,6 +2412,13 @@ module.exports = {
   adminListEmails,
   adminReadMail,
   adminMoveToTrash,
+  adminSendMail,
+  adminReplyMail,
+  adminListFolders,
+  adminMarkMail,
+  adminSearchMails,
+  adminMoveMail,
+  adminGetAttachment,
   _private: {
     buildPlaceholderText,
     buildSubMailboxPlaceholderText,
@@ -2148,6 +2428,10 @@ module.exports = {
     resolveMailboxArgs,
     listFolders,
     findTrashFolder,
-    moveToTrash
+    moveToTrash,
+    markMail,
+    searchMails,
+    moveMailToFolder,
+    getAttachmentData
   }
 };

--- a/Plugin/VCPClawMail/VCPClawMail.js
+++ b/Plugin/VCPClawMail/VCPClawMail.js
@@ -1158,8 +1158,11 @@ async function readMail(args = {}) {
     imageCount: normalized.imageUrls.length + imageContent.length,
     parsedDocumentCount: parsedDocuments.length
   });
-  // 供 admin API 提取原始 HTML / 纯文本 / 附件元数据（AI 工具路径忽略该字段）
-  aiResult.detail = normalized;
+  // 仅 admin API 调用（includeDetail）时挂归一化详情——避免 AI 工具链路
+  // 因 detail 携带 html/text/markdown 副本而膨胀上下文
+  if (args.includeDetail === true) {
+    aiResult.detail = normalized;
+  }
   return aiResult;
 }
 
@@ -2325,6 +2328,7 @@ async function adminListEmails(args = {}) {
 async function adminReadMail(args = {}) {
   const result = await readMail({
     ...args,
+    includeDetail: true,
     includeAttachmentContent: args.includeAttachmentContent === undefined ? false : args.includeAttachmentContent
   });
   return {

--- a/routes/admin/clawMail.js
+++ b/routes/admin/clawMail.js
@@ -87,5 +87,123 @@ module.exports = function(options) {
         });
     }));
 
+    // ===== V1.1/V2 补全端点（SDK 能力现成，仅补 HTTP 出口） =====
+
+    // 发送新邮件：body { mailbox/user, to, cc?, bcc?, subject, body, html?, attachments? }
+    router.post('/claw-mail/messages', asyncHandler(async (req, res) => {
+        const clawMail = getClawMailModule(pluginManager);
+        const result = await clawMail.adminSendMail(req.body || {});
+        res.json({
+            status: 'success',
+            ...result
+        });
+    }));
+
+    // 回复邮件：body { mailbox/user, body, html?, toAll?, attachments? }
+    router.post('/claw-mail/messages/:mailId/reply', asyncHandler(async (req, res) => {
+        const clawMail = getClawMailModule(pluginManager);
+        const result = await clawMail.adminReplyMail({
+            ...(req.body || {}),
+            mailId: req.params.mailId
+        });
+        res.json({
+            status: 'success',
+            ...result
+        });
+    }));
+
+    // 文件夹列表
+    router.get('/claw-mail/folders', asyncHandler(async (req, res) => {
+        const clawMail = getClawMailModule(pluginManager);
+        const result = await clawMail.adminListFolders({
+            mailbox: req.query.mailbox,
+            user: req.query.user
+        });
+        res.json({
+            status: 'success',
+            ...result
+        });
+    }));
+
+    // 搜索（keyword/from/to/subject/since/before/unreadOnly/fts/limit/fid）
+    router.get('/claw-mail/search', asyncHandler(async (req, res) => {
+        const clawMail = getClawMailModule(pluginManager);
+        const result = await clawMail.adminSearchMails({
+            mailbox: req.query.mailbox,
+            user: req.query.user,
+            keyword: req.query.keyword || req.query.q,
+            from: req.query.from,
+            to: req.query.to,
+            subject: req.query.subject,
+            since: req.query.since,
+            before: req.query.before,
+            unreadOnly: req.query.unreadOnly,
+            fts: req.query.fts,
+            limit: req.query.limit,
+            fid: req.query.fid
+        });
+        res.json({
+            status: 'success',
+            ...result
+        });
+    }));
+
+    // 标记已读/未读：body { read = true, mailbox?, user?, fid? }
+    router.post('/claw-mail/messages/:mailId/read', asyncHandler(async (req, res) => {
+        const clawMail = getClawMailModule(pluginManager);
+        const body = req.body || {};
+        const result = await clawMail.adminMarkMail({
+            mailId: req.params.mailId,
+            read: body.read === undefined ? true : body.read,
+            mailbox: body.mailbox,
+            user: body.user,
+            fid: body.fid
+        });
+        res.json({
+            status: 'success',
+            ...result
+        });
+    }));
+
+    // 移动到任意文件夹：body { target/targetFolderId, fid?, mailbox?, user? }
+    router.post('/claw-mail/messages/:mailId/move', asyncHandler(async (req, res) => {
+        const clawMail = getClawMailModule(pluginManager);
+        const result = await clawMail.adminMoveMail({
+            ...(req.body || {}),
+            mailId: req.params.mailId
+        });
+        res.json({
+            status: 'success',
+            ...result
+        });
+    }));
+
+    // 附件原始字节下载（流式回传，不走 JSON 信封）
+    router.get('/claw-mail/messages/:mailId/attachments/:partId', async (req, res) => {
+        try {
+            const clawMail = getClawMailModule(pluginManager);
+            const data = await clawMail.adminGetAttachment({
+                mailId: req.params.mailId,
+                partId: req.params.partId,
+                mailbox: req.query.mailbox,
+                user: req.query.user
+            });
+            res.setHeader('Content-Type', data.contentType || 'application/octet-stream');
+            res.setHeader('Content-Length', data.size);
+            res.setHeader(
+                'Content-Disposition',
+                `attachment; filename*=UTF-8''${encodeURIComponent(data.filename || 'attachment.bin')}`
+            );
+            res.send(data.buffer);
+        } catch (error) {
+            const statusCode = error.statusCode || 500;
+            console.error('[AdminPanelRoutes][VCPClawMail] attachment download failed:', error);
+            res.status(statusCode).json({
+                status: 'error',
+                error: error.message || '附件下载失败。'
+            });
+        }
+    });
+
     return router;
 };

--- a/routes/forumApi.js
+++ b/routes/forumApi.js
@@ -303,12 +303,13 @@ router.get('/posts', async (req, res) => {
                     return null;
                 }
 
-                // 轻量模式：不读正文，lastReply 字段缺省
+                // 轻量模式：不读正文，lastReply/replyCount 字段缺省
                 if (lightMode) {
                     return {
                         ...postMeta,
                         lastReplyBy: null,
                         lastReplyAt: null,
+                        replyCount: null,
                         modifiedAt: stats.mtime.toISOString(),
                         mtimeMs: stats.mtimeMs
                     };
@@ -321,7 +322,7 @@ router.get('/posts', async (req, res) => {
                 let lastReplyBy = null;
                 let lastReplyAt = null;
                 let match;
-                
+
                 // 限制匹配次数防止 ReDoS
                 let matchCount = 0;
                 while ((match = replyPattern.exec(content)) !== null && matchCount < FORUM_CONFIG.MAX_FLOORS_PER_POST) {
@@ -334,6 +335,8 @@ router.get('/posts', async (req, res) => {
                     ...postMeta,
                     lastReplyBy,
                     lastReplyAt,
+                    // 楼层总数（复用上面的匹配计数；客户端列表展示回复数徽标用）
+                    replyCount: matchCount,
                     modifiedAt: stats.mtime.toISOString(),
                     mtimeMs: stats.mtimeMs
                 };

--- a/routes/forumApi.js
+++ b/routes/forumApi.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const fs = require('fs').promises;
 const fsSync = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 const FORUM_DIR = process.env.KNOWLEDGEBASE_ROOT_PATH ? path.join(process.env.KNOWLEDGEBASE_ROOT_PATH, 'VCP论坛') : path.join(__dirname, '..', 'dailynote', 'VCP论坛');
 
@@ -230,6 +231,25 @@ async function withFileLock(filePath, operation) {
 }
 
 /**
+ * 文件名安全清洗（与 Plugin/VCPForum/VCPForum.js 的 sanitizeFilename 保持一致，
+ * 保证 REST 发帖与 Agent 工具发帖产生完全相同的文件名格式）。
+ */
+function sanitizeFilename(name) {
+    return String(name).replace(/[\\/:\*\?"<>\|]/g, '_').slice(0, 50);
+}
+
+/**
+ * 本地时区 ISO 时间戳（与 VCPForum.js 的 getLocalISOTimestamp 一致）；
+ * 写入文件名时调用方需再把冒号替换为 `-`（Windows 兼容）。
+ */
+function getLocalISOTimestamp() {
+    const now = new Date();
+    const offset = now.getTimezoneOffset();
+    const localDate = new Date(now.getTime() - offset * 60 * 1000);
+    return localDate.toISOString().replace(/Z$/, '');
+}
+
+/**
  * 安全的楼层解析 - 使用限制性正则
  */
 function parseFloors(content) {
@@ -256,7 +276,10 @@ function parseFloors(content) {
 // ========== API 路由 ==========
 
 // GET /posts - 列出所有帖子
+// ?light=true 时跳过正文读取（不返回 lastReplyBy/lastReplyAt），
+// 列表刷新场景下把 O(N×文件大小) 的扫描降为纯元数据操作。
 router.get('/posts', async (req, res) => {
+    const lightMode = req.query.light === 'true';
     try {
         await fs.mkdir(FORUM_DIR, { recursive: true });
         const files = await fs.readdir(FORUM_DIR);
@@ -278,6 +301,17 @@ router.get('/posts', async (req, res) => {
                 if (stats.size > FORUM_CONFIG.MAX_FILE_SIZE) {
                     console.warn(`[Forum API] File too large, skipping: ${file}`);
                     return null;
+                }
+
+                // 轻量模式：不读正文，lastReply 字段缺省
+                if (lightMode) {
+                    return {
+                        ...postMeta,
+                        lastReplyBy: null,
+                        lastReplyAt: null,
+                        modifiedAt: stats.mtime.toISOString(),
+                        mtimeMs: stats.mtimeMs
+                    };
                 }
                 
                 const content = await fs.readFile(fullPath, 'utf-8');
@@ -321,6 +355,73 @@ router.get('/posts', async (req, res) => {
     } catch (error) {
         console.error('[Forum API] Error getting posts:', error);
         res.status(500).json({ success: false, error: 'Failed to retrieve forum posts.' });
+    }
+});
+
+// POST /posts - REST 发帖端点（此前发帖只能走 /v1/human/tool 模拟 Agent 工具调用）
+// 文件格式与 VCPForum.js createPost 完全一致（同一文件名模板与正文模板），
+// 不处理 file:// 本地图发布（REST 客户端应直接提交可访问的图片 URL）。
+router.post('/posts', async (req, res) => {
+    let { maid, board, title, content } = req.body || {};
+
+    // ===== 输入验证 =====
+    if (!maid || !board || !title || !content) {
+        return res.status(400).json({ success: false, error: 'maid, board, title and content are required.' });
+    }
+
+    maid = sanitizeInput(maid, FORUM_CONFIG.MAX_MAID_LENGTH).trim();
+    board = sanitizeInput(board, 50).trim();
+    title = sanitizeInput(title, FORUM_CONFIG.MAX_TITLE_LENGTH).trim();
+    content = sanitizeInput(content, FORUM_CONFIG.MAX_CONTENT_LENGTH);
+
+    if (!maid || !board || !title || !content.trim()) {
+        return res.status(400).json({ success: false, error: 'Invalid maid, board, title or content after sanitization.' });
+    }
+
+    try {
+        const timestamp = getLocalISOTimestamp();
+        const sanitizedTimestamp = timestamp.replace(/:/g, '-');
+        const uid = `${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
+
+        const filename = `[${sanitizeFilename(board)}][${sanitizeFilename(title)}][${sanitizeFilename(maid)}][${sanitizedTimestamp}][${uid}].md`;
+        const relativePath = `../../dailynote/VCP论坛/${filename}`;
+        const fullPath = path.join(FORUM_DIR, filename);
+
+        if (!isPathSafe(fullPath, FORUM_DIR)) {
+            return res.status(403).json({ success: false, error: 'Path traversal detected' });
+        }
+
+        const fileContent = `
+# ${title}
+
+**作者:** ${maid}
+**UID:** ${uid}
+**时间戳:** ${timestamp}
+**路径:** ${relativePath}
+
+---
+
+${content}
+
+---
+
+## 评论区
+---
+`.trim();
+
+        await fs.mkdir(FORUM_DIR, { recursive: true });
+        // 新文件路径无竞争，但走统一的锁/写流程保持一致性
+        await withFileLock(fullPath, async () => {
+            await fs.writeFile(fullPath, fileContent, 'utf-8');
+        });
+
+        res.json({ success: true, message: 'Post created successfully.', uid, filename });
+    } catch (error) {
+        console.error('[Forum API] Error creating post:', error);
+        if (error.message === 'Lock acquisition timeout') {
+            return res.status(503).json({ success: false, error: 'Server busy, please try again.' });
+        }
+        res.status(500).json({ success: false, error: 'Failed to create post.' });
     }
 });
 


### PR DESCRIPTION
本 PR 汇总 VCPMobile「更多」功能（论坛 / clawEmail 邮箱）需要的上游补丁：

- 论坛：新增 POST /posts REST 发帖端点 + GET /posts?light=true 轻量模式；帖子列表返回 replyCount 楼层总数。
- clawEmail：管理后台 admin/clawMail.js 补全 searchMails / moveMailToFolder / markMail / listFolders / reply / send HTTP 出口，以及附件流式下载；readMail 的 detail 仅在 adminReadMail 显式开启时挂载，避免 AI 工具结果膨胀。

所有改动已在 VCPMobile 真机流程中验证通过。