### PR TITLE
refactor(FileOperator): add line-ending preservation, encoding detect…

### DIFF
--- a/Plugin/FileOperator/FileOperator.js
+++ b/Plugin/FileOperator/FileOperator.js
@@ -46,16 +46,40 @@ function debugLog(message, data = null) {
 }
 
 /**
- * Get a path-like parameter with AI-friendly fallbacks.
- * Supports canonical names such as filePath/directoryPath/sourcePath/destinationPath/searchPath,
- * while also accepting generic path/Path to tolerate mixed tool-call field naming.
+ * Get a parameter value with AI-friendly fallbacks.
+ * Searches candidate names in order, then falls back to case-insensitive matching.
  */
-function getPathParameter(parameters, canonicalName) {
+function getParameterValue(parameters, ...candidateNames) {
   if (!parameters || typeof parameters !== 'object') {
     return undefined;
   }
 
-  return parameters[canonicalName] ?? parameters.path ?? parameters.Path;
+  for (const name of candidateNames) {
+    if (Object.prototype.hasOwnProperty.call(parameters, name) && parameters[name] !== undefined) {
+      return parameters[name];
+    }
+  }
+
+  const normalizedCandidateNames = candidateNames.map(name => String(name).toLowerCase());
+  for (const [key, value] of Object.entries(parameters)) {
+    if (value !== undefined && normalizedCandidateNames.includes(key.toLowerCase())) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function getPathParameter(parameters, ...legacyNames) {
+  return getParameterValue(parameters, 'path', 'filePath', 'directoryPath', 'searchPath', ...legacyNames);
+}
+
+function getSourcePathParameter(parameters) {
+  return getParameterValue(parameters, 'source', 'sourcePath');
+}
+
+function getDestinationPathParameter(parameters) {
+  return getParameterValue(parameters, 'destination', 'destinationPath');
 }
 
 function isPathAllowed(targetPath, operationType = 'generic') {
@@ -104,82 +128,82 @@ function formatFileSize(bytes) {
  * @returns {Object} Object containing normalization and restoration methods
  */
 function createLineEndingHelper(content) {
-    const crlfCount = (content.match(/\r\n/g) || []).length;
+  const crlfCount = (content.match(/\r\n/g) || []).length;
 
-    // Improved LF counting: [^\r]\n handles most cases, plus check file start
-    let lfCount = (content.match(/[^\r]\n/g) || []).length;
-    if (content.startsWith('\n')) {
-        lfCount += 1;
-    }
+  // Improved LF counting: [^\r]\n handles most cases, plus check file start
+  let lfCount = (content.match(/[^\r]\n/g) || []).length;
+  if (content.startsWith('\n')) {
+    lfCount += 1;
+  }
 
-    const crCount = (content.match(/\r(?!\n)/g) || []).length;
+  const crCount = (content.match(/\r(?!\n)/g) || []).length;
 
-    let lineEnding = '\n';
-    if (crlfCount > lfCount && crlfCount > crCount) {
-        lineEnding = '\r\n';
-    } else if (crCount > lfCount && crCount > crlfCount) {
-        lineEnding = '\r';
-    }
+  let lineEnding = '\n';
+  if (crlfCount > lfCount && crlfCount > crCount) {
+    lineEnding = '\r\n';
+  } else if (crCount > lfCount && crCount > crlfCount) {
+    lineEnding = '\r';
+  }
 
-    const hasCRLF = crlfCount > 0;
+  const hasCRLF = crlfCount > 0;
 
-    if (DEBUG_MODE) {
-        console.error(`[CRLF Detect] CRLF=${crlfCount}, LF=${lfCount}, CR=${crCount}, using=${JSON.stringify(lineEnding)}`);
-    }
+  if (DEBUG_MODE) {
+    console.error(`[CRLF Detect] CRLF=${crlfCount}, LF=${lfCount}, CR=${crCount}, using=${JSON.stringify(lineEnding)}`);
+  }
 
-    return {
-        normalize: (str) => str.replace(/\r\n/g, '\n').replace(/\r/g, '\n'),
+  return {
+    normalize: (str) => str.replace(/\r\n/g, '\n').replace(/\r/g, '\n'),
 
-        denormalize: (str) => {
-            if (lineEnding === '\r\n') {
-                return str.replace(/\n/g, '\r\n');
-            } else if (lineEnding === '\r') {
-                return str.replace(/\n/g, '\r');
-            }
-            return str;
-        },
+    denormalize: (str) => {
+      if (lineEnding === '\r\n') {
+        return str.replace(/\n/g, '\r\n');
+      } else if (lineEnding === '\r') {
+        return str.replace(/\n/g, '\r');
+      }
+      return str;
+    },
 
-        includes: (cnt, search) => {
-            const normContent = cnt.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-            const normSearch = search.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-            return normContent.includes(normSearch);
-        },
+    includes: (cnt, search) => {
+      const normContent = cnt.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+      const normSearch = search.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+      return normContent.includes(normSearch);
+    },
 
-        safeReplace: (originalContent, searchStr, replaceStr) => {
-            const normContent = originalContent.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-            const normSearch = searchStr.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-            const normReplace = replaceStr.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    safeReplace: (originalContent, searchStr, replaceStr) => {
+      const normContent = originalContent.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+      const normSearch = searchStr.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+      const normReplace = replaceStr.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
-            if (!normContent.includes(normSearch)) {
-                return {
-                    success: false,
-                    error: 'Search string not found after CRLF normalization'
-                };
-            }
+      if (!normContent.includes(normSearch)) {
+        return {
+          success: false,
+          error: 'Search string not found after CRLF normalization'
+        };
+      }
 
-            const normResult = normContent.replace(normSearch, normReplace);
+      const normResult = normContent.replace(normSearch, normReplace);
 
-            let result = normResult;
-            if (lineEnding === '\r\n') {
-                result = normResult.replace(/\n/g, '\r\n');
-            } else if (lineEnding === '\r') {
-                result = normResult.replace(/\n/g, '\r');
-            }
+      let result = normResult;
+      if (lineEnding === '\r\n') {
+        result = normResult.replace(/\n/g, '\r\n');
+      } else if (lineEnding === '\r') {
+        result = normResult.replace(/\n/g, '\r');
+      }
 
-            return { success: true, result };
-        },
+      return { success: true, result };
+    },
 
-        getDebugInfo: () => ({
-            crlfCount,
-            lfCount,
-            crCount,
-            chosen: lineEnding === '\r\n' ? 'CRLF' : (lineEnding === '\r' ? 'CR' : 'LF'),
-            totalSize: content.length
-        }),
+    getDebugInfo: () => ({
+      crlfCount,
+      lfCount,
+      crCount,
+      chosen: lineEnding === '\r\n' ? 'CRLF' : (lineEnding === '\r' ? 'CR' : 'LF'),
+      totalSize: content.length
+    }),
 
-        hasCRLF,
-        lineEnding: JSON.stringify(lineEnding)
-    };
+    hasCRLF,
+    lineEnding: JSON.stringify(lineEnding)
+  };
 }
 
 function getUniqueFilePath(filePath) {
@@ -201,6 +225,36 @@ function getUniqueFilePath(filePath) {
     }
     counter++;
   }
+}
+
+/**
+ * Detect file encoding from raw buffer.
+ * Progressive: BOM detection (zero-dep) → chardet (if installed) → fallback utf-8.
+ */
+function detectEncoding(buffer) {
+  // 1. BOM detection (zero dependency)
+  if (buffer.length >= 3 && buffer[0] === 0xEF && buffer[1] === 0xBB && buffer[2] === 0xBF) {
+    return { encoding: 'utf-8', bom: true, confidence: 'bom' };
+  }
+  if (buffer.length >= 2 && buffer[0] === 0xFF && buffer[1] === 0xFE) {
+    return { encoding: 'utf-16le', bom: true, confidence: 'bom' };
+  }
+  if (buffer.length >= 2 && buffer[0] === 0xFE && buffer[1] === 0xFF) {
+    return { encoding: 'utf-16be', bom: true, confidence: 'bom' };
+  }
+
+  // 2. Try chardet if available (progressive upgrade)
+  try {
+    const chardet = require('chardet');
+    const sample = buffer.slice(0, 4096);
+    const detected = chardet.detect(sample);
+    return { encoding: detected || 'utf-8', bom: false, confidence: 'chardet' };
+  } catch (_e) {
+    // chardet not installed — fallback
+  }
+
+  // 3. Fallback: assume utf-8
+  return { encoding: 'utf-8', bom: false, confidence: 'fallback' };
 }
 
 function applyDiffLogic(originalContent, diffContent) {
@@ -547,6 +601,10 @@ async function readFile(filePath, encoding = 'utf8', lines) {
       };
     }
 
+    // Detect encoding for text files (non-extracted, non-binary)
+    const isDataUriCheck = typeof content === 'string' && content.startsWith('data:');
+    const encodingInfo = (!isExtracted && !isDataUriCheck) ? detectEncoding(fileBuffer) : null;
+
     const returnData = {
       size: stats.size,
       sizeFormatted: formatFileSize(stats.size),
@@ -554,7 +612,8 @@ async function readFile(filePath, encoding = 'utf8', lines) {
       encoding: isExtracted ? 'utf8' : encoding,
       isExtracted: isExtracted,
       fileName: path.basename(filePath),
-      lines: lineSelectionMetadata
+      lines: lineSelectionMetadata,
+      detectedEncoding: encodingInfo
     };
 
     const lineInfoText = lineSelectionMetadata && !lineSelectionMetadata.skipped
@@ -573,19 +632,11 @@ async function readFile(filePath, encoding = 'utf8', lines) {
         { type: 'image_url', image_url: { url: content } }
       ];
     } else {
-      // For text-based files
-      let language = extension.slice(1).toLowerCase();
-      const codeLangs = {
-        'js': 'javascript', 'py': 'python', 'md': 'markdown', 'ts': 'typescript',
-        'html': 'html', 'css': 'css', 'json': 'json', 'sh': 'bash', 'yml': 'yaml', 'yaml': 'yaml'
-      };
-      language = codeLangs[language] || language;
-      if (isExtracted) language = '';
-
-      const backticks = content.includes('```') ? '````' : '```';
-
+      // For text-based files — return header and raw content as separate objects
+      // (no code block wrapping, to avoid interfering with ApplyDiff searchString matching)
       returnData.content = [
-        { type: 'text', text: `${headerText}\n${backticks}${language}\n${content}\n${backticks}` }
+        { type: 'text', text: headerText },
+        { type: 'text', text: content }
       ];
     }
 
@@ -693,7 +744,17 @@ async function appendFile(filePath, content, encoding = 'utf8') {
       throw new Error(`File would be too large after append: exceeds limit of ${formatFileSize(MAX_FILE_SIZE)}`);
     }
 
-    await fs.appendFile(filePath, content, encoding);
+    // Preserve original file's line ending style when appending
+    let finalContent = content;
+    try {
+      const existingContent = await fs.readFile(filePath, encoding);
+      const helper = createLineEndingHelper(existingContent);
+      finalContent = helper.denormalize(helper.normalize(content));
+    } catch (_e) {
+      // File doesn't exist yet, keep content as-is (LF from AI)
+    }
+
+    await fs.appendFile(filePath, finalContent, encoding);
     const stats = await fs.stat(filePath);
 
     let result = {
@@ -728,11 +789,14 @@ async function editFile(filePath, content, encoding = 'utf8') {
     }
 
     // Ensure the file exists before attempting to edit it.
+    let originalContent = null;
     try {
       const stats = await fs.stat(filePath);
       if (stats.isDirectory()) {
         throw new Error(`Path points to a directory, not a file. Cannot edit.`);
       }
+      // Read original content to detect line endings
+      originalContent = await fs.readFile(filePath, encoding);
     } catch (e) {
       if (e.code === 'ENOENT') {
         throw new Error(`File not found at '${filePath}'. Use WriteFile to create a new file.`);
@@ -744,7 +808,14 @@ async function editFile(filePath, content, encoding = 'utf8') {
       throw new Error(`Content too large: exceeds limit of ${formatFileSize(MAX_FILE_SIZE)}`);
     }
 
-    await fs.writeFile(filePath, content, encoding);
+    // Preserve original file's line ending style
+    let finalContent = content;
+    if (originalContent) {
+      const helper = createLineEndingHelper(originalContent);
+      finalContent = helper.denormalize(helper.normalize(content));
+    }
+
+    await fs.writeFile(filePath, finalContent, encoding);
     const stats = await fs.stat(filePath);
 
     let result = {
@@ -1598,13 +1669,13 @@ async function processBatchRequest(request) {
           }
           break;
         case 'CopyFile':
-          result = await copyFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+          result = await copyFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
           break;
         case 'MoveFile':
-          result = await moveFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+          result = await moveFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
           break;
         case 'RenameFile':
-          result = await renameFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+          result = await renameFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
           break;
         case 'DeleteFile':
           result = await deleteFile(getPathParameter(parameters, 'filePath'));
@@ -1722,11 +1793,11 @@ async function processRequest(request) {
     case 'FileInfo':
       return await getFileInfo(getPathParameter(parameters, 'filePath'));
     case 'CopyFile':
-      return await copyFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+      return await copyFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
     case 'MoveFile':
-      return await moveFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+      return await moveFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
     case 'RenameFile':
-      return await renameFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+      return await renameFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
     case 'DeleteFile':
       return await deleteFile(getPathParameter(parameters, 'filePath'));
     case 'CreateDirectory':


### PR DESCRIPTION
## 改动摘要

对后端 FileOperator 插件进行重构，解决三类问题：

### 1. 行尾符保持（消灭 git diff 全文件变动）
- editFile / appendFile 写入前检测原文件行尾风格（CRLF/LF/CR）
- 新写入内容自动对齐原文件风格，避免 AI 输出的 LF 与 Windows 文件的 CRLF 冲突
- 利用已有的 createLineEndingHelper 工具

### 2. 编码检测（渐进式）
- 新增 detectEncoding 函数：BOM 零依赖检测 → try-require chardet 自动升级 → fallback utf-8
- ReadFile 返回 metadata 附加 detectedEncoding 字段（只提示不自动转码）
- chardet 为可选依赖，未安装时降级为 BOM-only

### 3. 参数容错增强
- 新增 getParameterValue（大小写不敏感遍历 + 多候选名）
- getPathParameter 改为调用 getParameterValue 的包装
- 新增 getSourcePathParameter / getDestinationPathParameter
- processRequest + processBatchRequest 中的 CopyFile/MoveFile/RenameFile 改用新函数

### 4. ReadFile 输出格式优化
- 去掉文本文件的 ``` 代码块包裹
- 改为 [header, rawText] 两个 content 对象
- 避免 ApplyDiff 的 searchString 匹配被 header 文本干扰

## 测试
- 串语法 CreateDirectory→WriteFile→EditFile→ApplyDiff→ReadFile 链式验证通过
- 原有功能（PDF/DOCX/XLSX 解析、Canvas 创建、UpdateHistory）未受影响
