### PR TITLE
通过 VCPChrome 一键配置 UrlFetch Cookie。

### DIFF
--- a/Plugin/ChromeBridge/ChromeBridge.js
+++ b/Plugin/ChromeBridge/ChromeBridge.js
@@ -3,6 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const dotenv = require('dotenv');
 const pluginManager = require('../../Plugin.js');
 const browserRuntimeManager = require('../../modules/browserRuntimeManager.js');
 
@@ -54,6 +55,17 @@ const connectedChromes = new Map();
 // 存储等待响应的命令
 // key: requestId, value: { resolve, reject, timeout, waitForPageInfo }
 const pendingCommands = new Map();
+let urlfetchConfigWriteQueue = Promise.resolve();
+
+const URLFETCH_COOKIE_SYNC_LIMITS = {
+    maxRequestBytes: 2 * 1024 * 1024,
+    maxCookies: 5000,
+    maxCookieNameLength: 256,
+    maxCookieValueLength: 8192,
+    maxCookieBytes: 1.5 * 1024 * 1024,
+    maxPageUrlLength: 2048,
+    maxSiteKeyLength: 253
+};
 
 const HIGH_PRIVILEGE_COMMANDS = new Set([
     'execute_script',
@@ -119,6 +131,324 @@ function allowUserHighPrivilege() {
 
 function isOpen(ws) {
     return ws && ws.readyState === 1;
+}
+
+function isUuid(value) {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(String(value || ''));
+}
+
+function normalizeSiteKey(value) {
+    return String(value || '').trim().toLowerCase().replace(/^\.+|\.+$/g, '');
+}
+
+function isValidSiteKey(value) {
+    const siteKey = normalizeSiteKey(value);
+    if (!siteKey || siteKey.length > URLFETCH_COOKIE_SYNC_LIMITS.maxSiteKeyLength) return false;
+    if (siteKey.includes(':') || siteKey.includes('/') || siteKey.includes('\\') || siteKey.includes('..')) return false;
+    return siteKey.split('.').every(label =>
+        label.length > 0 &&
+        label.length <= 63 &&
+        /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(label)
+    );
+}
+
+function parseJsonObjectWithoutDuplicateKeys(rawValue) {
+    const parsed = JSON.parse(rawValue);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('FETCH_COOKIES_RAW_MULTI 必须是 JSON 对象');
+    }
+
+    const source = String(rawValue);
+    let index = 0;
+    const skipWhitespace = () => {
+        while (/\s/.test(source[index] || '')) index += 1;
+    };
+    const readString = () => {
+        const start = index;
+        if (source[index] !== '"') throw new Error('FETCH_COOKIES_RAW_MULTI JSON 对象键格式无效');
+        index += 1;
+        let escaped = false;
+        while (index < source.length) {
+            const char = source[index++];
+            if (escaped) {
+                escaped = false;
+            } else if (char === '\\') {
+                escaped = true;
+            } else if (char === '"') {
+                return JSON.parse(source.slice(start, index));
+            }
+        }
+        throw new Error('FETCH_COOKIES_RAW_MULTI JSON 字符串未闭合');
+    };
+    const skipValue = () => {
+        const start = index;
+        let depth = 0;
+        let inString = false;
+        let escaped = false;
+        while (index < source.length) {
+            const char = source[index];
+            if (inString) {
+                index += 1;
+                if (escaped) escaped = false;
+                else if (char === '\\') escaped = true;
+                else if (char === '"') inString = false;
+                continue;
+            }
+            if (char === '"') {
+                inString = true;
+                index += 1;
+                continue;
+            }
+            if (char === '{' || char === '[') depth += 1;
+            if (char === '}' || char === ']') {
+                if (depth === 0) break;
+                depth -= 1;
+            }
+            if (depth === 0 && (char === ',' || char === '}')) break;
+            index += 1;
+        }
+        return source.slice(start, index).trim();
+    };
+
+    skipWhitespace();
+    if (source[index++] !== '{') throw new Error('FETCH_COOKIES_RAW_MULTI 必须是 JSON 对象');
+    const seenKeys = new Set();
+    skipWhitespace();
+    while (source[index] !== '}') {
+        const key = readString();
+        const normalizedKey = normalizeSiteKey(key);
+        if (seenKeys.has(normalizedKey)) {
+            throw new Error('FETCH_COOKIES_RAW_MULTI 存在重复域名配置项');
+        }
+        seenKeys.add(normalizedKey);
+        skipWhitespace();
+        if (source[index++] !== ':') throw new Error('FETCH_COOKIES_RAW_MULTI JSON 对象缺少冒号');
+        const rawEntryValue = skipValue();
+        if (typeof parsed[key] !== 'string') {
+            throw new Error(`FETCH_COOKIES_RAW_MULTI 域名 ${key} 的值必须是字符串`);
+        }
+        if (!rawEntryValue) throw new Error('FETCH_COOKIES_RAW_MULTI JSON 对象值不能为空');
+        skipWhitespace();
+        if (source[index] === ',') {
+            index += 1;
+            skipWhitespace();
+        } else if (source[index] !== '}') {
+            throw new Error('FETCH_COOKIES_RAW_MULTI JSON 对象格式无效');
+        }
+    }
+    return parsed;
+}
+
+function getUrlFetchConfigPath() {
+    const projectBasePath = pluginConfig.PROJECT_BASE_PATH || process.env.PROJECT_BASE_PATH || path.resolve(__dirname, '../..');
+    return path.join(projectBasePath, 'Plugin', 'UrlFetch', 'config.env');
+}
+
+function getEnvAssignmentLines(content, key) {
+    const pattern = new RegExp(`^([ \\t]*)${key}[ \\t]*=[^\\r\\n]*$`, 'gm');
+    return Array.from(String(content || '').matchAll(pattern));
+}
+
+function getInlineEnvComment(line, equalsIndex) {
+    let inDoubleQuote = false;
+    let inSingleQuote = false;
+    let escaped = false;
+    let jsonDepth = 0;
+
+    for (let index = equalsIndex + 1; index < line.length; index += 1) {
+        const char = line[index];
+        if (inDoubleQuote || inSingleQuote) {
+            if (escaped) {
+                escaped = false;
+            } else if (char === '\\') {
+                escaped = true;
+            } else if ((inDoubleQuote && char === '"') || (inSingleQuote && char === "'")) {
+                inDoubleQuote = false;
+                inSingleQuote = false;
+            }
+            continue;
+        }
+        if (char === '"') {
+            inDoubleQuote = true;
+        } else if (char === "'") {
+            inSingleQuote = true;
+        } else if (char === '{' || char === '[') {
+            jsonDepth += 1;
+        } else if (char === '}' || char === ']') {
+            jsonDepth = Math.max(0, jsonDepth - 1);
+        } else if (char === '#' && jsonDepth === 0 && /\s/.test(line[index - 1] || '')) {
+            return line.slice(index).trim();
+        }
+    }
+    return '';
+}
+
+async function updateUrlFetchCookiesConfig(siteKey, cookies) {
+    const configPath = getUrlFetchConfigPath();
+    let content = '';
+    let fileMode = null;
+    try {
+        content = await fs.promises.readFile(configPath, 'utf8');
+        fileMode = (await fs.promises.stat(configPath)).mode;
+    } catch (error) {
+        if (error.code !== 'ENOENT') throw error;
+    }
+
+    const assignments = getEnvAssignmentLines(content, 'FETCH_COOKIES_RAW_MULTI');
+    if (assignments.length > 1) {
+        throw new Error('config.env 中存在重复的 FETCH_COOKIES_RAW_MULTI 配置项');
+    }
+
+    let cookieMap = {};
+    if (assignments.length === 1) {
+        const parsedEnv = dotenv.parse(content);
+        const rawJson = parsedEnv.FETCH_COOKIES_RAW_MULTI;
+        if (rawJson && rawJson.trim()) {
+            cookieMap = parseJsonObjectWithoutDuplicateKeys(rawJson);
+        }
+    }
+
+    const normalizedSiteKey = normalizeSiteKey(siteKey);
+    let existingKey = Object.keys(cookieMap).find(key => normalizeSiteKey(key) === normalizedSiteKey);
+    if (existingKey) {
+        cookieMap[existingKey] = cookies;
+    } else {
+        cookieMap[normalizedSiteKey] = cookies;
+    }
+
+    const serialized = JSON.stringify(cookieMap);
+    let updatedContent;
+    if (assignments.length === 1) {
+        const match = assignments[0];
+        const lineStart = match.index;
+        const lineEnd = lineStart + match[0].length;
+        const equalsIndex = match[0].indexOf('=');
+        const inlineComment = getInlineEnvComment(match[0], equalsIndex);
+        const preservedComment = inlineComment ? ` ${inlineComment}` : '';
+        updatedContent = `${content.slice(0, lineStart)}${match[1]}FETCH_COOKIES_RAW_MULTI=${serialized}${preservedComment}${content.slice(lineEnd)}`;
+    } else {
+        const newline = content.includes('\r\n') ? '\r\n' : '\n';
+        const separator = content.length === 0 || content.endsWith('\n') ? '' : newline;
+        updatedContent = `${content}${separator}FETCH_COOKIES_RAW_MULTI=${serialized}${newline}`;
+    }
+
+    const tempPath = `${configPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    try {
+        await fs.promises.writeFile(tempPath, updatedContent, {
+            encoding: 'utf8',
+            mode: fileMode || 0o600
+        });
+        if (fileMode) await fs.promises.chmod(tempPath, fileMode);
+        await fs.promises.rename(tempPath, configPath);
+    } catch (error) {
+        try {
+            await fs.promises.unlink(tempPath);
+        } catch (_) {
+            // ignore cleanup errors
+        }
+        throw error;
+    }
+}
+
+function enqueueUrlFetchConfigUpdate(task) {
+    const operation = urlfetchConfigWriteQueue.then(task, task);
+    urlfetchConfigWriteQueue = operation.catch(() => {});
+    return operation;
+}
+
+function sendUrlFetchCookieSyncResult(entry, data) {
+    if (!isOpen(entry?.ws)) return;
+    entry.ws.send(JSON.stringify({
+        type: 'urlfetch_cookie_sync_result',
+        data
+    }));
+}
+
+async function handleUrlFetchCookieSync(clientId, data = {}) {
+    const entry = connectedChromes.get(clientId);
+    const requestId = data.requestId;
+    if (!entry || !isOpen(entry.ws)) return;
+
+    const fail = (error, code = 'URLFETCH_COOKIE_SYNC_REJECTED') => {
+        sendUrlFetchCookieSyncResult(entry, {
+            requestId: isUuid(requestId) ? requestId : null,
+            status: 'error',
+            code,
+            error
+        });
+    };
+
+    const serializedRequest = JSON.stringify(data);
+    if (Buffer.byteLength(serializedRequest, 'utf8') > URLFETCH_COOKIE_SYNC_LIMITS.maxRequestBytes) {
+        fail('Cookie 同步请求过大', 'URLFETCH_COOKIE_SYNC_TOO_LARGE');
+        return;
+    }
+    if (!isUuid(requestId)) {
+        fail('requestId 无效', 'INVALID_REQUEST_ID');
+        return;
+    }
+
+    let pageUrl;
+    try {
+        pageUrl = new URL(String(data.pageUrl || ''));
+    } catch (_) {
+        fail('pageUrl 无效', 'INVALID_PAGE_URL');
+        return;
+    }
+    const protocol = pageUrl.protocol.toLowerCase();
+    const pageHost = pageUrl.hostname.toLowerCase().replace(/\.$/, '');
+    const siteKey = normalizeSiteKey(data.siteKey);
+    if (!['http:', 'https:'].includes(protocol) || !pageHost || String(data.pageUrl).length > URLFETCH_COOKIE_SYNC_LIMITS.maxPageUrlLength) {
+        fail('仅支持有效的 HTTP/HTTPS pageUrl', 'INVALID_PAGE_URL');
+        return;
+    }
+    if (!isValidSiteKey(siteKey) || !(pageHost === siteKey || pageHost.endsWith(`.${siteKey}`))) {
+        fail('siteKey 不是当前页面主机名或其合法父域名', 'INVALID_SITE_KEY');
+        return;
+    }
+    if (!Array.isArray(data.cookies) || data.cookies.length === 0 || data.cookies.length > URLFETCH_COOKIE_SYNC_LIMITS.maxCookies) {
+        fail('Cookie 数组数量无效', 'INVALID_COOKIE_ARRAY');
+        return;
+    }
+
+    let cookieBytes = 0;
+    const cookiePairs = [];
+    for (const cookie of data.cookies) {
+        if (!cookie || typeof cookie !== 'object' || Array.isArray(cookie)) {
+            fail('Cookie 项格式无效', 'INVALID_COOKIE');
+            return;
+        }
+        const name = String(cookie.name ?? '');
+        const value = String(cookie.value ?? '');
+        if (!name || name.length > URLFETCH_COOKIE_SYNC_LIMITS.maxCookieNameLength ||
+            value.length > URLFETCH_COOKIE_SYNC_LIMITS.maxCookieValueLength ||
+            /[\r\n;]/.test(name)) {
+            fail('Cookie 名称或值长度/格式无效', 'INVALID_COOKIE');
+            return;
+        }
+        const pair = `${name}=${value}`;
+        cookieBytes += Buffer.byteLength(pair, 'utf8') + 2;
+        if (cookieBytes > URLFETCH_COOKIE_SYNC_LIMITS.maxCookieBytes) {
+            fail('Cookie 内容过大', 'URLFETCH_COOKIE_SYNC_TOO_LARGE');
+            return;
+        }
+        cookiePairs.push(pair);
+    }
+
+    const cookieString = cookiePairs.join('; ');
+    try {
+        await enqueueUrlFetchConfigUpdate(() => updateUrlFetchCookiesConfig(siteKey, cookieString));
+        sendUrlFetchCookieSyncResult(entry, {
+            requestId,
+            status: 'success',
+            siteKey,
+            cookieCount: data.cookies.length,
+            updatedAt: nowIso()
+        });
+    } catch (error) {
+        console.error(`[ChromeBridge] UrlFetch Cookie 配置写入失败 (${error.code || 'CONFIG_WRITE_ERROR'}): ${error.message}`);
+        fail(error.message || 'UrlFetch Cookie 配置写入失败', 'URLFETCH_CONFIG_WRITE_FAILED');
+    }
 }
 
 function getConnection(clientIdOrEntry) {
@@ -245,6 +575,13 @@ function handleClientMessage(clientId, message) {
     const entry = connectedChromes.get(clientId);
     if (entry) {
         entry.lastSeenAt = nowIso();
+    }
+
+    if (message?.type === 'urlfetch_cookie_sync') {
+        // WebSocketServer 已在连接建立时完成 VCP_Key 鉴权；此处只接受已登记且仍打开的连接。
+        if (!entry || !isOpen(entry.ws)) return;
+        void handleUrlFetchCookieSync(clientId, message.data || {});
+        return;
     }
 
     if (message.type === 'clientHello') {

--- a/Plugin/ChromeBridge/VCPChrome/background.js
+++ b/Plugin/ChromeBridge/VCPChrome/background.js
@@ -17,6 +17,7 @@ if (
 console.log('[VCP Background] 🚀 VCPChrome background.js loaded.');
 let ws = null;
 let isConnected = false;
+const pendingUrlFetchCookieSync = new Map();
 let isMonitoringEnabled = false; // 页面监控开关
 let redactSensitiveDom = true; // 浏览器内隐私开关：默认开启，用户可在 Popup 显式关闭
 let heartbeatIntervalId = null;
@@ -331,6 +332,17 @@ function connect(options = {}) {
             if (message.type === 'heartbeat_ack') {
                 console.log('Received heartbeat acknowledgment.');
                 // 可以选择更新一个时间戳来跟踪连接活跃度
+            } else if (message.type === 'urlfetch_cookie_sync_result') {
+                const requestId = message.data?.requestId;
+                const pending = pendingUrlFetchCookieSync.get(requestId);
+                if (!pending) return;
+                pendingUrlFetchCookieSync.delete(requestId);
+                clearTimeout(pending.timeoutId);
+                pending.sendResponse(message.data || {
+                    requestId,
+                    status: 'error',
+                    error: '服务端返回了无效的 Cookie 同步响应'
+                });
             } else if (message.type === 'command') {
                 const commandData = message.data;
                 console.log('Received commandData:', commandData);
@@ -447,6 +459,7 @@ function connect(options = {}) {
             console.log('WebSocket connection closed.');
             isConnected = false;
             ws = null;
+            rejectPendingUrlFetchCookieSync('VCP WebSocket 已断开');
             updateIcon();
             broadcastStatusUpdate(); // 广播最新状态
             if (heartbeatIntervalId) {
@@ -462,6 +475,7 @@ function connect(options = {}) {
             console.error('WebSocket error:', error);
             isConnected = false;
             ws = null;
+            rejectPendingUrlFetchCookieSync('VCP WebSocket 发生错误');
             updateIcon();
             broadcastStatusUpdate(); // 广播最新状态
             if (heartbeatIntervalId) {
@@ -644,6 +658,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         }
         // 不再立即返回状态，而是等待广播
         // sendResponse({ isConnected: !isConnected });
+    } else if (request.type === 'SYNC_URLFETCH_COOKIES') {
+        requestUrlFetchCookieSync(sendResponse);
+        return true;
     } else if (request.type === 'PAGE_INFO_UPDATE') {
         const senderTabId = sender.tab?.id;
         
@@ -1717,6 +1734,133 @@ function sendResponseToWs(message) {
     if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify(message));
     }
+}
+
+function rejectPendingUrlFetchCookieSync(errorMessage) {
+    pendingUrlFetchCookieSync.forEach((pending, requestId) => {
+        clearTimeout(pending.timeoutId);
+        pending.sendResponse({
+            status: 'error',
+            code: 'VCP_NOT_CONNECTED',
+            error: errorMessage
+        });
+        pendingUrlFetchCookieSync.delete(requestId);
+    });
+}
+
+function createRequestId() {
+    if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+    return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2)}-${Math.random().toString(16).slice(2)}`;
+}
+
+function requestUrlFetchCookieSync(sendResponse) {
+    if (!isConnected || !ws || ws.readyState !== WebSocket.OPEN) {
+        sendResponse({ status: 'error', code: 'VCP_NOT_CONNECTED', error: 'VCP WebSocket 尚未连接' });
+        return;
+    }
+
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        if (chrome.runtime.lastError) {
+            sendResponse({
+                status: 'error',
+                code: 'ACTIVE_TAB_QUERY_FAILED',
+                error: `无法获取当前活动标签页：${chrome.runtime.lastError.message}`
+            });
+            return;
+        }
+
+        const tab = tabs?.[0];
+        const pageUrl = String(tab?.url || '');
+        let url;
+        try {
+            url = new URL(pageUrl);
+        } catch (_) {
+            sendResponse({ status: 'error', code: 'INVALID_PAGE_URL', error: '当前标签页不是有效网页' });
+            return;
+        }
+
+        if (!['http:', 'https:'].includes(url.protocol)) {
+            sendResponse({
+                status: 'error',
+                code: 'UNSUPPORTED_PAGE',
+                error: '当前标签页不是 HTTP/HTTPS 页面，无法读取 Cookie'
+            });
+            return;
+        }
+
+        const siteKey = url.hostname.toLowerCase().replace(/\.$/, '');
+        const validSiteKey = siteKey.length > 0 &&
+            siteKey.length <= 253 &&
+            !siteKey.includes(':') &&
+            siteKey.split('.').every(label =>
+                label.length > 0 &&
+                label.length <= 63 &&
+                /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(label)
+            );
+        if (!validSiteKey) {
+            sendResponse({
+                status: 'error',
+                code: 'INVALID_PAGE_URL',
+                error: '当前页面主机名格式不受支持'
+            });
+            return;
+        }
+
+        chrome.cookies.getAll({ url: pageUrl }, (cookies) => {
+            if (chrome.runtime.lastError) {
+                sendResponse({
+                    status: 'error',
+                    code: 'COOKIE_QUERY_FAILED',
+                    error: `读取当前站点 Cookie 失败：${chrome.runtime.lastError.message}`
+                });
+                return;
+            }
+            if (!Array.isArray(cookies) || cookies.length === 0) {
+                sendResponse({
+                    status: 'error',
+                    code: 'NO_COOKIES',
+                    error: '当前页面没有可用 Cookie'
+                });
+                return;
+            }
+
+            const requestId = createRequestId();
+            const timeoutId = setTimeout(() => {
+                const pending = pendingUrlFetchCookieSync.get(requestId);
+                if (!pending) return;
+                pendingUrlFetchCookieSync.delete(requestId);
+                pending.sendResponse({
+                    status: 'error',
+                    code: 'URLFETCH_COOKIE_SYNC_TIMEOUT',
+                    error: '服务端写入 UrlFetch Cookie 超时'
+                });
+            }, 30000);
+
+            pendingUrlFetchCookieSync.set(requestId, { sendResponse, timeoutId });
+            try {
+                ws.send(JSON.stringify({
+                    type: 'urlfetch_cookie_sync',
+                    data: {
+                        requestId,
+                        siteKey,
+                        pageUrl,
+                        cookies: cookies.map(cookie => ({
+                            name: cookie.name,
+                            value: cookie.value
+                        }))
+                    }
+                }));
+            } catch (error) {
+                clearTimeout(timeoutId);
+                pendingUrlFetchCookieSync.delete(requestId);
+                sendResponse({
+                    status: 'error',
+                    code: 'COOKIE_SYNC_SEND_FAILED',
+                    error: `发送 Cookie 到 VCP 服务端失败：${error.message || error}`
+                });
+            }
+        });
+    });
 }
 
 function parseNumberParam(value, defaultValue, minValue, maxValue) {

--- a/Plugin/ChromeBridge/VCPChrome/manifest.json
+++ b/Plugin/ChromeBridge/VCPChrome/manifest.json
@@ -1,14 +1,15 @@
 {
     "manifest_version": 3,
     "name": "VCP Chrome Control",
-    "version": "1.0.2",
-    "description": "连接到VCP服务器，允许AI代理与您的浏览器交互。1.0.2 加固 execute_script 异步结果透传并支持 MAIN/ISOLATED 执行世界。",
+    "version": "1.0.3",
+    "description": "连接到VCP服务器，允许AI代理与您的浏览器交互。1.0.3 增加当前站点 UrlFetch Cookie 一键配置。",
     "permissions": [
         "storage",
         "activeTab",
         "scripting",
         "debugger",
-        "alarms"
+        "alarms",
+        "cookies"
     ],
     "host_permissions": [
         "<all_urls>",

--- a/Plugin/ChromeBridge/VCPChrome/popup.html
+++ b/Plugin/ChromeBridge/VCPChrome/popup.html
@@ -97,6 +97,24 @@
             font-size: 11px;
             text-align: left;
         }
+        .urlfetch-cookie-button {
+            width: 100%;
+            border-color: #c2410c;
+            background: #fff7ed;
+            color: #9a3412;
+            font-weight: 600;
+        }
+        .urlfetch-cookie-button:hover {
+            background: #ffedd5;
+        }
+        #urlfetch-cookie-status {
+            min-height: 16px;
+            margin-top: 5px;
+            color: #6b7280;
+            font-size: 11px;
+            line-height: 1.35;
+            text-align: left;
+        }
         #settings {
             margin-top: 15px;
             padding-top: 10px;
@@ -210,6 +228,11 @@
         <button id="copyGroundedMarkdown" class="copy-button">📋 复制当前页面 MD 操作图全文</button>
     </div>
     <div id="copy-status" aria-live="polite"></div>
+
+    <div class="button-group">
+        <button id="syncUrlFetchCookies" class="urlfetch-cookie-button">🍪 配置当前站点 UrlFetch Cookie</button>
+    </div>
+    <div id="urlfetch-cookie-status" aria-live="polite"></div>
 
     <!-- 显示最新页面信息 -->
     <div id="page-info">

--- a/Plugin/ChromeBridge/VCPChrome/popup.js
+++ b/Plugin/ChromeBridge/VCPChrome/popup.js
@@ -21,6 +21,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const refreshButton = document.getElementById('refreshPage');
     const copyGroundedMarkdownButton = document.getElementById('copyGroundedMarkdown');
     const copyStatusDiv = document.getElementById('copy-status');
+    const syncUrlFetchCookiesButton = document.getElementById('syncUrlFetchCookies');
+    const urlFetchCookieStatusDiv = document.getElementById('urlfetch-cookie-status');
     const settingsToggle = document.getElementById('settings-toggle');
     const settingsDiv = document.getElementById('settings');
     const serverUrlInput = document.getElementById('serverUrl');
@@ -127,6 +129,33 @@ document.addEventListener('DOMContentLoaded', () => {
     function setCopyStatus(message, isError = false) {
         copyStatusDiv.textContent = message;
         copyStatusDiv.style.color = isError ? '#b42318' : '#6d5a8f';
+    }
+
+    function setUrlFetchCookieStatus(message, isError = false) {
+        urlFetchCookieStatusDiv.textContent = message;
+        urlFetchCookieStatusDiv.style.color = isError ? '#b42318' : '#6b7280';
+    }
+
+    function getUrlFetchCookieRiskConfirmation() {
+        return new Promise(resolve => {
+            chrome.storage.local.get(['urlfetchCookieRiskConfirmed'], result => {
+                resolve(result.urlfetchCookieRiskConfirmed === true);
+            });
+        });
+    }
+
+    async function confirmUrlFetchCookieRiskIfNeeded() {
+        if (await getUrlFetchCookieRiskConfirmation()) return true;
+
+        const confirmed = window.confirm(
+            '此操作会读取当前网页可用的全部 Cookie，包括 HttpOnly Cookie，并通过已鉴权的 VCP WebSocket 上传到服务端，保存到 Plugin/UrlFetch/config.env。Cookie 可用于访问你的登录会话，请确认你信任当前 VCP 服务端。是否继续？'
+        );
+        if (!confirmed) return false;
+
+        await new Promise(resolve => {
+            chrome.storage.local.set({ urlfetchCookieRiskConfirmed: true }, resolve);
+        });
+        return true;
     }
 
     async function requestCurrentGroundedMarkdown() {
@@ -327,6 +356,52 @@ document.addEventListener('DOMContentLoaded', () => {
                 copyGroundedMarkdownButton.textContent = originalText;
                 copyGroundedMarkdownButton.disabled = false;
             }, 1800);
+        }
+    });
+
+    syncUrlFetchCookiesButton.addEventListener('click', async () => {
+        const originalText = syncUrlFetchCookiesButton.textContent;
+        syncUrlFetchCookiesButton.disabled = true;
+        setUrlFetchCookieStatus('正在读取当前站点 Cookie…');
+        try {
+            const confirmed = await confirmUrlFetchCookieRiskIfNeeded();
+            if (!confirmed) {
+                setUrlFetchCookieStatus('已取消 Cookie 配置。');
+                return;
+            }
+
+            setUrlFetchCookieStatus('正在读取并发送 Cookie…');
+            const response = await new Promise(resolve => {
+                chrome.runtime.sendMessage({ type: 'SYNC_URLFETCH_COOKIES' }, result => {
+                    if (chrome.runtime.lastError) {
+                        resolve({
+                            status: 'error',
+                            code: 'POPUP_MESSAGE_FAILED',
+                            error: chrome.runtime.lastError.message
+                        });
+                        return;
+                    }
+                    resolve(result || {
+                        status: 'error',
+                        code: 'EMPTY_RESPONSE',
+                        error: '扩展后台未返回结果'
+                    });
+                });
+            });
+
+            if (response.status !== 'success') {
+                throw new Error(response.error || 'UrlFetch Cookie 配置失败');
+            }
+
+            const updatedAt = response.updatedAt ? new Date(response.updatedAt).toLocaleString() : '刚刚';
+            setUrlFetchCookieStatus(
+                `已配置 ${response.siteKey}，共 ${response.cookieCount} 个 Cookie。更新时间：${updatedAt}`
+            );
+        } catch (error) {
+            setUrlFetchCookieStatus(error.message || String(error), true);
+        } finally {
+            syncUrlFetchCookiesButton.textContent = originalText;
+            syncUrlFetchCookiesButton.disabled = false;
         }
     });
 

--- a/Plugin/FileOperator/FileOperator.js
+++ b/Plugin/FileOperator/FileOperator.js
@@ -46,16 +46,40 @@ function debugLog(message, data = null) {
 }
 
 /**
- * Get a path-like parameter with AI-friendly fallbacks.
- * Supports canonical names such as filePath/directoryPath/sourcePath/destinationPath/searchPath,
- * while also accepting generic path/Path to tolerate mixed tool-call field naming.
+ * Get a parameter value with AI-friendly fallbacks.
+ * Searches candidate names in order, then falls back to case-insensitive matching.
  */
-function getPathParameter(parameters, canonicalName) {
+function getParameterValue(parameters, ...candidateNames) {
   if (!parameters || typeof parameters !== 'object') {
     return undefined;
   }
 
-  return parameters[canonicalName] ?? parameters.path ?? parameters.Path;
+  for (const name of candidateNames) {
+    if (Object.prototype.hasOwnProperty.call(parameters, name) && parameters[name] !== undefined) {
+      return parameters[name];
+    }
+  }
+
+  const normalizedCandidateNames = candidateNames.map(name => String(name).toLowerCase());
+  for (const [key, value] of Object.entries(parameters)) {
+    if (value !== undefined && normalizedCandidateNames.includes(key.toLowerCase())) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function getPathParameter(parameters, ...legacyNames) {
+  return getParameterValue(parameters, 'path', 'filePath', 'directoryPath', 'searchPath', ...legacyNames);
+}
+
+function getSourcePathParameter(parameters) {
+  return getParameterValue(parameters, 'source', 'sourcePath');
+}
+
+function getDestinationPathParameter(parameters) {
+  return getParameterValue(parameters, 'destination', 'destinationPath');
 }
 
 function isPathAllowed(targetPath, operationType = 'generic') {
@@ -104,82 +128,82 @@ function formatFileSize(bytes) {
  * @returns {Object} Object containing normalization and restoration methods
  */
 function createLineEndingHelper(content) {
-    const crlfCount = (content.match(/\r\n/g) || []).length;
+  const crlfCount = (content.match(/\r\n/g) || []).length;
 
-    // Improved LF counting: [^\r]\n handles most cases, plus check file start
-    let lfCount = (content.match(/[^\r]\n/g) || []).length;
-    if (content.startsWith('\n')) {
-        lfCount += 1;
-    }
+  // Improved LF counting: [^\r]\n handles most cases, plus check file start
+  let lfCount = (content.match(/[^\r]\n/g) || []).length;
+  if (content.startsWith('\n')) {
+    lfCount += 1;
+  }
 
-    const crCount = (content.match(/\r(?!\n)/g) || []).length;
+  const crCount = (content.match(/\r(?!\n)/g) || []).length;
 
-    let lineEnding = '\n';
-    if (crlfCount > lfCount && crlfCount > crCount) {
-        lineEnding = '\r\n';
-    } else if (crCount > lfCount && crCount > crlfCount) {
-        lineEnding = '\r';
-    }
+  let lineEnding = '\n';
+  if (crlfCount > lfCount && crlfCount > crCount) {
+    lineEnding = '\r\n';
+  } else if (crCount > lfCount && crCount > crlfCount) {
+    lineEnding = '\r';
+  }
 
-    const hasCRLF = crlfCount > 0;
+  const hasCRLF = crlfCount > 0;
 
-    if (DEBUG_MODE) {
-        console.error(`[CRLF Detect] CRLF=${crlfCount}, LF=${lfCount}, CR=${crCount}, using=${JSON.stringify(lineEnding)}`);
-    }
+  if (DEBUG_MODE) {
+    console.error(`[CRLF Detect] CRLF=${crlfCount}, LF=${lfCount}, CR=${crCount}, using=${JSON.stringify(lineEnding)}`);
+  }
 
-    return {
-        normalize: (str) => str.replace(/\r\n/g, '\n').replace(/\r/g, '\n'),
+  return {
+    normalize: (str) => str.replace(/\r\n/g, '\n').replace(/\r/g, '\n'),
 
-        denormalize: (str) => {
-            if (lineEnding === '\r\n') {
-                return str.replace(/\n/g, '\r\n');
-            } else if (lineEnding === '\r') {
-                return str.replace(/\n/g, '\r');
-            }
-            return str;
-        },
+    denormalize: (str) => {
+      if (lineEnding === '\r\n') {
+        return str.replace(/\n/g, '\r\n');
+      } else if (lineEnding === '\r') {
+        return str.replace(/\n/g, '\r');
+      }
+      return str;
+    },
 
-        includes: (cnt, search) => {
-            const normContent = cnt.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-            const normSearch = search.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-            return normContent.includes(normSearch);
-        },
+    includes: (cnt, search) => {
+      const normContent = cnt.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+      const normSearch = search.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+      return normContent.includes(normSearch);
+    },
 
-        safeReplace: (originalContent, searchStr, replaceStr) => {
-            const normContent = originalContent.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-            const normSearch = searchStr.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-            const normReplace = replaceStr.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    safeReplace: (originalContent, searchStr, replaceStr) => {
+      const normContent = originalContent.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+      const normSearch = searchStr.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+      const normReplace = replaceStr.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
-            if (!normContent.includes(normSearch)) {
-                return {
-                    success: false,
-                    error: 'Search string not found after CRLF normalization'
-                };
-            }
+      if (!normContent.includes(normSearch)) {
+        return {
+          success: false,
+          error: 'Search string not found after CRLF normalization'
+        };
+      }
 
-            const normResult = normContent.replace(normSearch, normReplace);
+      const normResult = normContent.replace(normSearch, normReplace);
 
-            let result = normResult;
-            if (lineEnding === '\r\n') {
-                result = normResult.replace(/\n/g, '\r\n');
-            } else if (lineEnding === '\r') {
-                result = normResult.replace(/\n/g, '\r');
-            }
+      let result = normResult;
+      if (lineEnding === '\r\n') {
+        result = normResult.replace(/\n/g, '\r\n');
+      } else if (lineEnding === '\r') {
+        result = normResult.replace(/\n/g, '\r');
+      }
 
-            return { success: true, result };
-        },
+      return { success: true, result };
+    },
 
-        getDebugInfo: () => ({
-            crlfCount,
-            lfCount,
-            crCount,
-            chosen: lineEnding === '\r\n' ? 'CRLF' : (lineEnding === '\r' ? 'CR' : 'LF'),
-            totalSize: content.length
-        }),
+    getDebugInfo: () => ({
+      crlfCount,
+      lfCount,
+      crCount,
+      chosen: lineEnding === '\r\n' ? 'CRLF' : (lineEnding === '\r' ? 'CR' : 'LF'),
+      totalSize: content.length
+    }),
 
-        hasCRLF,
-        lineEnding: JSON.stringify(lineEnding)
-    };
+    hasCRLF,
+    lineEnding: JSON.stringify(lineEnding)
+  };
 }
 
 function getUniqueFilePath(filePath) {
@@ -201,6 +225,36 @@ function getUniqueFilePath(filePath) {
     }
     counter++;
   }
+}
+
+/**
+ * Detect file encoding from raw buffer.
+ * Progressive: BOM detection (zero-dep) → chardet (if installed) → fallback utf-8.
+ */
+function detectEncoding(buffer) {
+  // 1. BOM detection (zero dependency)
+  if (buffer.length >= 3 && buffer[0] === 0xEF && buffer[1] === 0xBB && buffer[2] === 0xBF) {
+    return { encoding: 'utf-8', bom: true, confidence: 'bom' };
+  }
+  if (buffer.length >= 2 && buffer[0] === 0xFF && buffer[1] === 0xFE) {
+    return { encoding: 'utf-16le', bom: true, confidence: 'bom' };
+  }
+  if (buffer.length >= 2 && buffer[0] === 0xFE && buffer[1] === 0xFF) {
+    return { encoding: 'utf-16be', bom: true, confidence: 'bom' };
+  }
+
+  // 2. Try chardet if available (progressive upgrade)
+  try {
+    const chardet = require('chardet');
+    const sample = buffer.slice(0, 4096);
+    const detected = chardet.detect(sample);
+    return { encoding: detected || 'utf-8', bom: false, confidence: 'chardet' };
+  } catch (_e) {
+    // chardet not installed — fallback
+  }
+
+  // 3. Fallback: assume utf-8
+  return { encoding: 'utf-8', bom: false, confidence: 'fallback' };
 }
 
 function applyDiffLogic(originalContent, diffContent) {
@@ -547,6 +601,10 @@ async function readFile(filePath, encoding = 'utf8', lines) {
       };
     }
 
+    // Detect encoding for text files (non-extracted, non-binary)
+    const isDataUriCheck = typeof content === 'string' && content.startsWith('data:');
+    const encodingInfo = (!isExtracted && !isDataUriCheck) ? detectEncoding(fileBuffer) : null;
+
     const returnData = {
       size: stats.size,
       sizeFormatted: formatFileSize(stats.size),
@@ -554,7 +612,8 @@ async function readFile(filePath, encoding = 'utf8', lines) {
       encoding: isExtracted ? 'utf8' : encoding,
       isExtracted: isExtracted,
       fileName: path.basename(filePath),
-      lines: lineSelectionMetadata
+      lines: lineSelectionMetadata,
+      detectedEncoding: encodingInfo
     };
 
     const lineInfoText = lineSelectionMetadata && !lineSelectionMetadata.skipped
@@ -573,19 +632,11 @@ async function readFile(filePath, encoding = 'utf8', lines) {
         { type: 'image_url', image_url: { url: content } }
       ];
     } else {
-      // For text-based files
-      let language = extension.slice(1).toLowerCase();
-      const codeLangs = {
-        'js': 'javascript', 'py': 'python', 'md': 'markdown', 'ts': 'typescript',
-        'html': 'html', 'css': 'css', 'json': 'json', 'sh': 'bash', 'yml': 'yaml', 'yaml': 'yaml'
-      };
-      language = codeLangs[language] || language;
-      if (isExtracted) language = '';
-
-      const backticks = content.includes('```') ? '````' : '```';
-
+      // For text-based files — return header and raw content as separate objects
+      // (no code block wrapping, to avoid interfering with ApplyDiff searchString matching)
       returnData.content = [
-        { type: 'text', text: `${headerText}\n${backticks}${language}\n${content}\n${backticks}` }
+        { type: 'text', text: headerText },
+        { type: 'text', text: content }
       ];
     }
 
@@ -693,7 +744,17 @@ async function appendFile(filePath, content, encoding = 'utf8') {
       throw new Error(`File would be too large after append: exceeds limit of ${formatFileSize(MAX_FILE_SIZE)}`);
     }
 
-    await fs.appendFile(filePath, content, encoding);
+    // Preserve original file's line ending style when appending
+    let finalContent = content;
+    try {
+      const existingContent = await fs.readFile(filePath, encoding);
+      const helper = createLineEndingHelper(existingContent);
+      finalContent = helper.denormalize(helper.normalize(content));
+    } catch (_e) {
+      // File doesn't exist yet, keep content as-is (LF from AI)
+    }
+
+    await fs.appendFile(filePath, finalContent, encoding);
     const stats = await fs.stat(filePath);
 
     let result = {
@@ -728,11 +789,14 @@ async function editFile(filePath, content, encoding = 'utf8') {
     }
 
     // Ensure the file exists before attempting to edit it.
+    let originalContent = null;
     try {
       const stats = await fs.stat(filePath);
       if (stats.isDirectory()) {
         throw new Error(`Path points to a directory, not a file. Cannot edit.`);
       }
+      // Read original content to detect line endings
+      originalContent = await fs.readFile(filePath, encoding);
     } catch (e) {
       if (e.code === 'ENOENT') {
         throw new Error(`File not found at '${filePath}'. Use WriteFile to create a new file.`);
@@ -744,7 +808,14 @@ async function editFile(filePath, content, encoding = 'utf8') {
       throw new Error(`Content too large: exceeds limit of ${formatFileSize(MAX_FILE_SIZE)}`);
     }
 
-    await fs.writeFile(filePath, content, encoding);
+    // Preserve original file's line ending style
+    let finalContent = content;
+    if (originalContent) {
+      const helper = createLineEndingHelper(originalContent);
+      finalContent = helper.denormalize(helper.normalize(content));
+    }
+
+    await fs.writeFile(filePath, finalContent, encoding);
     const stats = await fs.stat(filePath);
 
     let result = {
@@ -1598,13 +1669,13 @@ async function processBatchRequest(request) {
           }
           break;
         case 'CopyFile':
-          result = await copyFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+          result = await copyFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
           break;
         case 'MoveFile':
-          result = await moveFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+          result = await moveFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
           break;
         case 'RenameFile':
-          result = await renameFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+          result = await renameFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
           break;
         case 'DeleteFile':
           result = await deleteFile(getPathParameter(parameters, 'filePath'));
@@ -1722,11 +1793,11 @@ async function processRequest(request) {
     case 'FileInfo':
       return await getFileInfo(getPathParameter(parameters, 'filePath'));
     case 'CopyFile':
-      return await copyFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+      return await copyFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
     case 'MoveFile':
-      return await moveFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+      return await moveFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
     case 'RenameFile':
-      return await renameFile(getPathParameter(parameters, 'sourcePath'), getPathParameter(parameters, 'destinationPath'));
+      return await renameFile(getSourcePathParameter(parameters), getDestinationPathParameter(parameters));
     case 'DeleteFile':
       return await deleteFile(getPathParameter(parameters, 'filePath'));
     case 'CreateDirectory':

--- a/Plugin/UrlFetch/README.md
+++ b/Plugin/UrlFetch/README.md
@@ -30,7 +30,17 @@ FETCH_PROXY_PORT=7890
 #### Cookies 配置（三选一）
 
 ##### 方式一：FETCH_COOKIES_RAW_MULTI（推荐，支持多网站）
-JSON 对象格式，key 是域名关键词，value 是 cookie 字符串。会根据访问的 URL 自动匹配对应的 cookies。
+JSON 对象格式，key 是域名，value 是 cookie 字符串。访问 URL 时仅匹配主机名完全相等或其合法子域名；多个匹配项会优先使用最长、最具体的域名配置。
+
+**VCPChrome 一键配置**：
+1. 在 VCPChrome Popup 中打开已登录的 HTTP/HTTPS 页面
+2. 首次点击“配置当前站点 UrlFetch Cookie”时确认风险
+3. 扩展读取当前 URL 可用的全部 Cookie（包括 HttpOnly），通过已鉴权的 VCP WebSocket 发送到服务端
+4. 服务端只更新 `Plugin/UrlFetch/config.env` 中的 `FETCH_COOKIES_RAW_MULTI`，同一站点重复配置只替换该站点，其他站点和手工配置保持不变
+
+成功后 Popup 只显示站点、Cookie 数量和更新时间，不显示 Cookie 名称或值。该操作不会新增 HTTP 接口，也不需要重启 VCP 服务。
+
+**格式限制**：一键配置使用现有的 `name=value` 原始 Cookie 字符串格式，因此不会保留 Cookie 的 `path`、`SameSite`、`HttpOnly`、`secure` 等属性。这是 `FETCH_COOKIES_RAW_MULTI` 语义本身的限制。
 
 **获取步骤**：
 1. 在浏览器中打开第一个网站并登录（如 B站）
@@ -268,3 +278,4 @@ A: 当直接访问某些网站失败时，会自动尝试通过配置的代理�
 
 - **v0.1.0**: 初始版本，支持文本和快照模式
 - **v0.1.1**: 新增 Cookies 配置支持
+- **未定版本**: VCPChrome 支持当前站点 UrlFetch Cookie 一键配置；更新 `FETCH_COOKIES_RAW_MULTI` 时保留其他站点、注释和环境变量。

--- a/Plugin/UrlFetch/UrlFetch.js
+++ b/Plugin/UrlFetch/UrlFetch.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 const path = require('path');
 require('dotenv').config({ path: path.resolve(__dirname, 'config.env') });
+const dotenv = require('dotenv');
+const fsSync = require('fs');
 const puppeteer = require('puppeteer-extra');
 const StealthPlugin = require('puppeteer-extra-plugin-stealth');
 const AnonymizeUAPlugin = require('puppeteer-extra-plugin-anonymize-ua');
@@ -319,6 +321,21 @@ function isPdfUrl(url) {
         return new URL(url).pathname.toLowerCase().endsWith('.pdf');
     } catch {
         return false;
+    }
+}
+
+function getCurrentUrlFetchCookieEnv() {
+    try {
+        const configPath = path.resolve(__dirname, 'config.env');
+        return {
+            ...process.env,
+            ...dotenv.parse(fsSync.readFileSync(configPath, 'utf8'))
+        };
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            console.error(`读取 UrlFetch config.env 失败: ${error.message}`);
+        }
+        return process.env;
     }
 }
 
@@ -922,16 +939,26 @@ async function fetchWithPuppeteer(url, mode = 'text', proxyPort = null) {
         };
 
         // 方式1：多站点原始格式 (FETCH_COOKIES_RAW_MULTI) - 优先级最高
-        const fetchCookiesRawMulti = process.env.FETCH_COOKIES_RAW_MULTI;
+        const currentCookieEnv = getCurrentUrlFetchCookieEnv();
+        const fetchCookiesRawMulti = currentCookieEnv.FETCH_COOKIES_RAW_MULTI;
         if (fetchCookiesRawMulti && fetchCookiesRawMulti.trim()) {
             try {
                 const cookiesMap = JSON.parse(fetchCookiesRawMulti);
-                // 遍历所有域名配置，找到匹配当前访问 URL 的
-                for (const [domain, cookieString] of Object.entries(cookiesMap)) {
-                    if (urlObj.hostname.includes(domain)) {
-                        cookiesToSet = parseRawCookies(cookieString, urlObj);
-                        break;
-                    }
+                const matchingEntry = Object.entries(cookiesMap)
+                    .filter(([domain, cookieString]) => {
+                        if (typeof cookieString !== 'string') return false;
+                        const normalizedDomain = String(domain || '').trim().toLowerCase().replace(/^\.+|\.+$/g, '');
+                        return normalizedDomain &&
+                            (urlObj.hostname.toLowerCase() === normalizedDomain ||
+                                urlObj.hostname.toLowerCase().endsWith(`.${normalizedDomain}`));
+                    })
+                    .sort((left, right) => {
+                        const leftDomain = String(left[0]).trim().replace(/^\.+|\.+$/g, '');
+                        const rightDomain = String(right[0]).trim().replace(/^\.+|\.+$/g, '');
+                        return rightDomain.length - leftDomain.length;
+                    })[0];
+                if (matchingEntry) {
+                    cookiesToSet = parseRawCookies(matchingEntry[1], urlObj);
                 }
             } catch (multiCookieError) {
                 console.error('解析多站点 Cookies 失败:', multiCookieError.message);

--- a/Plugin/UrlFetch/config.env.example
+++ b/Plugin/UrlFetch/config.env.example
@@ -74,6 +74,10 @@ FETCH_COOKIES_RAW=
 # JSON 对象格式，key 是域名关键词，value 是 cookie 字符串
 # 会根据访问的 URL 自动匹配对应的 cookies
 # 示例：{"bilibili.com":"SESSDATA=abc123; bili_jct=xyz","twitter.com":"auth_token=xxx; ct0=yyy"}
+# VCPChrome Popup 的“配置当前站点 UrlFetch Cookie”按钮会自动更新此配置项：
+# - 首次写入时追加 FETCH_COOKIES_RAW_MULTI
+# - 重复配置只替换当前站点，保留其他站点、注释和其他环境变量
+# - 只保存 name=value 原始 Cookie 字符串，不保存 path、SameSite、HttpOnly 等属性
 FETCH_COOKIES_RAW_MULTI=
 
 # 方式3：JSON 数组格式（高级用户，支持最多参数）


### PR DESCRIPTION
主要改动：
- VCPChrome 扩展版本升级至 1.0.3，新增 cookies 权限。
- Popup 新增“配置当前站点 UrlFetch Cookie”按钮和状态区域。
- 首次点击显示风险确认，并持久化确认状态。
- Background 使用 chrome.cookies.getAll({ url }) 读取当前 HTTP/HTTPS 页面全部 Cookie，包括 HttpOnly。
- Cookie 通过现有已鉴权 WebSocket 通道发送，不新增 HTTP 接口。
- 服务端新增 urlfetch_cookie_sync 处理：
  - 校验 UUID、URL、域名归属、Cookie 数量和大小。
  - 拒绝非法 JSON、重复域名配置项和重复环境变量配置。
  - 原子更新 Plugin/UrlFetch/config.env。
  - 保留其他站点、注释、换行格式和环境变量。
  - 并发请求串行写入，避免互相覆盖。
  - 响应、Popup 和扩展日志不输出 Cookie 明文。
- UrlFetch.js：
  - 每次 Puppeteer 执行前重新读取 config.env。
  - 域名匹配改为完全匹配或合法子域匹配。
  - 多个匹配项使用最长、最具体的域名配置。
- 更新了 Plugin/UrlFetch/config.env.example 和 README.md。