### PR TITLE
feat: enhance SemanticGroupEditor with weights and serial commands

### DIFF
--- a/Plugin/SemanticGroupEditor/SemanticGroupEditor.js
+++ b/Plugin/SemanticGroupEditor/SemanticGroupEditor.js
@@ -1,155 +1,223 @@
 const fs = require('fs').promises;
 const path = require('path');
 
-// 目标JSON文件的路径，这里我们直接指向RAGDiaryPlugin中的文件
-const SEMANTIC_GROUPS_PATH = path.join(__dirname, '..', 'RAGDiaryPlugin', 'semantic_groups.edit.json');
+// 目标 JSON 文件路径（编辑暂存文件，由 SemanticGroupManager 自动 merge 到主文件）。
+// 测试环境可通过 SEMANTIC_GROUPS_PATH 指向隔离夹具，避免触碰生产数据。
+const SEMANTIC_GROUPS_PATH = process.env.SEMANTIC_GROUPS_PATH
+    ? path.resolve(process.env.SEMANTIC_GROUPS_PATH)
+    : path.join(__dirname, '..', 'RAGDiaryPlugin', 'semantic_groups.edit.json');
 
-// --- 核心功能 ---
+// ============ 文件 I/O ============
 
-/**
- * 读取语义组文件
- */
 async function readSemanticGroupsFile() {
     try {
         const data = await fs.readFile(SEMANTIC_GROUPS_PATH, 'utf8');
         return JSON.parse(data);
     } catch (error) {
         if (error.code === 'ENOENT') {
-            // 如果文件不存在，返回一个空的结构
             return { config: {}, groups: {} };
         }
         throw new Error(`读取语义组文件失败: ${error.message}`);
     }
 }
 
-/**
- * 写入语义组文件
- * @param {object} data 要写入的完整JSON对象
- */
 async function writeSemanticGroupsFile(data) {
+    const tempPath = `${SEMANTIC_GROUPS_PATH}.${process.pid}.${Date.now()}.tmp`;
     try {
-        await fs.writeFile(SEMANTIC_GROUPS_PATH, JSON.stringify(data, null, 2), 'utf8');
+        await fs.writeFile(tempPath, JSON.stringify(data, null, 2), 'utf8');
+        await fs.rename(tempPath, SEMANTIC_GROUPS_PATH);
     } catch (error) {
+        try {
+            await fs.unlink(tempPath);
+        } catch (cleanupError) {
+            if (cleanupError.code !== 'ENOENT') {
+                console.error(`清理语义组临时文件失败: ${cleanupError.message}`);
+            }
+        }
         throw new Error(`写入语义组文件失败: ${error.message}`);
     }
 }
 
+// ============ 串语法解析器 ============
+
+function parseBatchCommands(request) {
+    const commandEntries = Object.keys(request)
+        .map(key => {
+            const match = key.match(/^command(\d+)$/);
+            return match ? { key, index: Number(match[1]) } : null;
+        })
+        .filter(Boolean)
+        .sort((a, b) => a.index - b.index);
+
+    if (commandEntries.length === 0) {
+        return [request];
+    }
+
+    return commandEntries.map(({ key, index }) => {
+        const cmd = { command: request[key] };
+        for (const paramKey of Object.keys(request)) {
+            const match = paramKey.match(/^(.*?)(\d+)$/);
+            if (!match || Number(match[2]) !== index || paramKey === key) continue;
+            if (match[1]) cmd[match[1]] = request[paramKey];
+        }
+        return cmd;
+    });
+}
+
+// ============ 命令实现 ============
+
 /**
- * 查询所有语义组
+ * QueryGroups - 查询语义组
+ * 可选参数 groupname：逗号分隔的组名列表，不传则返回全部
  */
-async function queryGroups() {
+async function queryGroups(params) {
     const data = await readSemanticGroupsFile();
     const groups = data.groups || {};
-    let resultText = "当前系统中的语义词元组如下：\n\n";
 
-    if (Object.keys(groups).length === 0) {
-        resultText = "当前系统中没有任何语义词元组。";
+    let targetNames = null;
+    if (params.groupname) {
+        targetNames = params.groupname.split(',').map(n => n.trim()).filter(Boolean);
+    }
+
+    let resultText = '';
+    const notFound = [];
+
+    if (targetNames) {
+        for (const name of targetNames) {
+            if (groups[name]) {
+                const g = groups[name];
+                const words = g.words || [];
+                const autoLearned = g.auto_learned || [];
+                resultText += `【${name}】\n`;
+                resultText += `  权重: ${g.weight ?? 1}\n`;
+                resultText += `  词元 (${words.length}): ${words.join(', ')}\n`;
+                if (autoLearned.length > 0) {
+                    resultText += `  自动学习 (${autoLearned.length}): ${autoLearned.join(', ')}\n`;
+                }
+                resultText += `\n`;
+            } else {
+                notFound.push(name);
+            }
+        }
+        if (notFound.length > 0) {
+            resultText += `⚠️ 未找到的组名: ${notFound.join(', ')}\n`;
+        }
+        if (resultText === '' && notFound.length === 0) {
+            resultText = '当前系统中没有任何语义词元组。';
+        }
     } else {
-        for (const groupName in groups) {
-            const words = groups[groupName].words || [];
-            resultText += `组名: ${groupName}\n`;
-            resultText += `词元: ${words.join(', ')}\n\n`;
+        // 全量列举
+        const groupNames = Object.keys(groups);
+        if (groupNames.length === 0) {
+            resultText = '当前系统中没有任何语义词元组。';
+        } else {
+            resultText = `共 ${groupNames.length} 个语义组：\n\n`;
+            for (const [name, g] of Object.entries(groups)) {
+                const words = g.words || [];
+                const autoLearned = g.auto_learned || [];
+                resultText += `【${name}】 权重:${g.weight ?? 1} | 词元(${words.length}): ${words.join(', ')}`;
+                if (autoLearned.length > 0) {
+                    resultText += ` | 自学(${autoLearned.length}): ${autoLearned.join(', ')}`;
+                }
+                resultText += `\n`;
+            }
         }
     }
+
     return { success: true, result: resultText.trim() };
 }
 
 /**
- * 更新一个或多个语义组
- * @param {object} params - 输入的参数对象
+ * UpdateGroups - 更新或创建语义组的词元
  */
 async function updateGroups(params) {
+    const { groupname, groupwords } = params;
+    if (!groupname || !groupwords) {
+        return { success: false, error: "缺少必需参数。请提供 'groupname' 和 'groupwords'。" };
+    }
+
     const data = await readSemanticGroupsFile();
     const groups = data.groups || {};
-    let updatesCount = 0;
-    let newGroupsCount = 0;
-    const updatedGroupNames = [];
 
-    // 检查是单个更新还是批量更新
-    if (params.groupname && params.groupwords) {
-        // 单个更新
-        const { groupname, groupwords } = params;
-        const wordsArray = groupwords.split(',').map(w => w.trim()).filter(Boolean);
+    const wordsArray = groupwords.split(',').map(w => w.trim()).filter(Boolean);
+    const isNew = !groups[groupname];
 
-        if (groups[groupname]) {
-            updatesCount++;
-        } else {
-            newGroupsCount++;
-        }
-        
-        // 创建或覆盖组
-        if (groups[groupname]) {
-            // 组已存在，只更新词元
-            groups[groupname].words = wordsArray;
-        } else {
-            // 组不存在，创建新组并设置默认值
-            groups[groupname] = {
-                words: wordsArray,
-                auto_learned: [],
-                weight: 1,
-                vector: null,
-                last_activated: null,
-                activation_count: 0,
-                vector_id: null
-            };
-        }
-        updatedGroupNames.push(groupname);
-
+    if (isNew) {
+        groups[groupname] = {
+            words: wordsArray,
+            auto_learned: [],
+            weight: 1
+        };
     } else {
-        // 批量更新
-        let i = 1;
-        while (params[`groupname${i}`] && params[`groupwords${i}`]) {
-            const groupname = params[`groupname${i}`];
-            const groupwords = params[`groupwords${i}`];
-            const wordsArray = groupwords.split(',').map(w => w.trim()).filter(Boolean);
-
-            if (groups[groupname]) {
-                updatesCount++;
-            } else {
-                newGroupsCount++;
-            }
-
-            if (groups[groupname]) {
-                // 组已存在，只更新词元
-                groups[groupname].words = wordsArray;
-            } else {
-                // 组不存在，创建新组并设置默认值
-                groups[groupname] = {
-                    words: wordsArray,
-                    auto_learned: [],
-                    weight: 1,
-                    vector: null,
-                    last_activated: null,
-                    activation_count: 0,
-                    vector_id: null
-                };
-            }
-            updatedGroupNames.push(groupname);
-            i++;
-        }
-    }
-    
-    if (updatedGroupNames.length === 0) {
-        return { success: false, error: "没有提供有效的更新参数。请提供 'groupname' 和 'groupwords'。" };
+        groups[groupname].words = wordsArray;
     }
 
     data.groups = groups;
     await writeSemanticGroupsFile(data);
 
-    let resultText = `操作成功！\n`;
-    if (newGroupsCount > 0) {
-        resultText += `- 新建了 ${newGroupsCount} 个词元组。\n`;
-    }
-    if (updatesCount > 0) {
-        resultText += `- 更新了 ${updatesCount} 个词元组。\n`;
-    }
-    resultText += `涉及的组名: ${updatedGroupNames.join(', ')}`;
-
-    return { success: true, result: resultText };
+    const action = isNew ? '新建' : '更新';
+    return { success: true, result: `已${action}组「${groupname}」，词元数: ${wordsArray.length}。` };
 }
 
+/**
+ * SetWeight - 设置组权重
+ * 参数：groupname（必需，逗号分隔支持多组）、weight（必需，大于 0 的有限数字）
+ */
+async function setWeight(params) {
+    const { groupname, weight } = params;
+    if (!groupname) return { success: false, error: '缺少 groupname 参数。' };
+    if (weight === undefined || weight === null || weight === '') {
+        return { success: false, error: '缺少 weight 参数。' };
+    }
 
-// --- 主逻辑 ---
+    const w = Number(weight);
+    if (!Number.isFinite(w) || w <= 0) {
+        return { success: false, error: `weight 必须是大于 0 的有限数字，收到: "${weight}"` };
+    }
+
+    const data = await readSemanticGroupsFile();
+    const groups = data.groups || {};
+
+    const names = groupname.split(',').map(n => n.trim()).filter(Boolean);
+    const updated = [];
+    const notFound = [];
+
+    for (const name of names) {
+        if (groups[name]) {
+            groups[name].weight = w;
+            updated.push(name);
+        } else {
+            notFound.push(name);
+        }
+    }
+
+    if (updated.length === 0) {
+        return { success: false, error: `所有指定组名均不存在: ${notFound.join(', ')}` };
+    }
+
+    data.groups = groups;
+    await writeSemanticGroupsFile(data);
+
+    let result = `已将 [${updated.join(', ')}] 的权重设为 ${w}。`;
+    if (notFound.length > 0) {
+        result += `\n⚠️ 未找到: ${notFound.join(', ')}`;
+    }
+    result += `\n提示: 权重变更将在 VCP 后端下次启动时由 SemanticGroupManager 自动 merge 生效。`;
+    return { success: true, result };
+}
+
+// ============ 命令路由 ============
+
+function dispatch(command, params) {
+    switch (command) {
+        case 'QueryGroups': return queryGroups(params);
+        case 'UpdateGroups': return updateGroups(params);
+        case 'SetWeight': return setWeight(params);
+        default: return Promise.resolve({ success: false, error: `未知指令: ${command}` });
+    }
+}
+
+// ============ 主逻辑 ============
 
 async function main() {
     let input = '';
@@ -161,30 +229,34 @@ async function main() {
 
     try {
         const request = JSON.parse(input);
-        // 兼容批量和单个指令
-        const command = request.command || request.command1; 
-        let response;
+        const commands = parseBatchCommands(request);
+        const results = [];
 
-        switch (command) {
-            case 'QueryGroups':
-                response = await queryGroups();
-                break;
-            case 'UpdateGroups':
-                response = await updateGroups(request);
-                break;
-            default:
-                // 检查是否存在批量更新指令
-                if (request.command1 || request.groupname1) {
-                     response = await updateGroups(request);
-                } else {
-                    throw new Error(`未知的指令: ${command}`);
-                }
+        for (const cmd of commands) {
+            const response = await dispatch(cmd.command, cmd, request);
+            results.push(response);
         }
 
-        if (response.success) {
-            console.log(JSON.stringify({ status: "success", result: response.result }));
+        // 聚合输出
+        const allSuccess = results.every(r => r.success);
+        const combinedResult = results.map((r, i) => {
+            if (commands.length > 1) {
+                const prefix = `[步骤${i + 1}/${commands.length} ${commands[i].command}]`;
+                return r.success ? `${prefix} ✅\n${r.result}` : `${prefix} ❌\n${r.error}`;
+            }
+            return r.success ? r.result : r.error;
+        }).join('\n\n');
+
+        if (allSuccess) {
+            console.log(JSON.stringify({ status: "success", result: combinedResult }));
         } else {
-            throw new Error(response.error);
+            // 部分失败时仍返回 success 状态以展示结果，通过内容区分
+            const hasAnySuccess = results.some(r => r.success);
+            console.log(JSON.stringify({
+                status: hasAnySuccess ? "success" : "error",
+                result: hasAnySuccess ? combinedResult : undefined,
+                error: hasAnySuccess ? undefined : combinedResult
+            }));
         }
     } catch (e) {
         console.log(JSON.stringify({ status: "error", error: e.message }));

--- a/Plugin/SemanticGroupEditor/plugin-manifest.json
+++ b/Plugin/SemanticGroupEditor/plugin-manifest.json
@@ -1,10 +1,10 @@
 {
   "manifestVersion": "1.0.0",
   "name": "SemanticGroupEditor",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "displayName": "语义组编辑器",
-  "description": "一个用于查询和更新RAG知识库中语义词元组的插件。",
-  "author": "Roo",
+  "description": "用于查询、更新和设置 RAG 知识库中语义词元组权重的插件。所有命令支持串语法批量操作。",
+  "author": "lionsky & infinite-vector",
   "pluginType": "synchronous",
   "entryPoint": {
     "type": "nodejs",
@@ -18,13 +18,18 @@
     "invocationCommands": [
       {
         "commandIdentifier": "QueryGroups",
-        "description": "查询当前系统中所有的语义词元组，返回组名和对应的词元列表。\n调用格式:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand:「始」QueryGroups「末」\n<<<[END_TOOL_REQUEST]>>>",
-        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand:「始」QueryGroups「末」\n<<<[END_TOOL_REQUEST]>>>"
+        "description": "查询语义词元组。不传 groupname 则返回全部组的概览；传入 groupname 则只返回指定组的详细信息。\n参数:\n- groupname (字符串, 可选): 要查询的组名，多个组用英文逗号分隔。不存在的组名会被明确提示。\n\n全量查询:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand:「始」QueryGroups「末」\n<<<[END_TOOL_REQUEST]>>>\n\n按名查询:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand:「始」QueryGroups「末」,\ngroupname:「始」绘画与视觉创作,代码实现与工程「末」\n<<<[END_TOOL_REQUEST]>>>",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand:「始」QueryGroups「末」,\ngroupname:「始」绘画与视觉创作「末」\n<<<[END_TOOL_REQUEST]>>>"
       },
       {
         "commandIdentifier": "UpdateGroups",
-        "description": "更新或创建语义词元组。如果组名已存在，则覆盖更新；如果不存在，则新建。支持批量操作。\n参数:\n- groupname (字符串, 必需): 要更新或创建的组名。\n- groupwords (字符串, 必需): 词元列表，用英文逗号分隔。\n\n单次更新调用格式:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand:「始」UpdateGroups「末」,\ngroupname:「始」新的组名「末」,\ngroupwords:「始」词1,词2,词3「末」\n<<<[END_TOOL_REQUEST]>>>\n\n批量更新调用格式 (使用数字后缀):\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand1:「始」UpdateGroups「末」,\ngroupname1:「始」组名A「末」,\ngroupwords1:「始」词A1,词A2「末」,\ncommand2:「始」UpdateGroups「末」,\ngroupname2:「始」组名B「末」,\ngroupwords2:「始」词B1,词B2「末」\n<<<[END_TOOL_REQUEST]>>>",
+        "description": "更新或创建语义词元组的词元列表。组名已存在则覆盖词元；不存在则新建（默认权重1）。\n参数:\n- groupname (字符串, 必需): 组名。\n- groupwords (字符串, 必需): 词元列表，用英文逗号分隔。\n\n单次:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand:「始」UpdateGroups「末」,\ngroupname:「始」科幻概念「末」,\ngroupwords:「始」戴森球,曲率引擎,赛博朋克「末」\n<<<[END_TOOL_REQUEST]>>>\n\n批量 (串语法):\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand1:「始」UpdateGroups「末」,\ngroupname1:「始」组名A「末」,\ngroupwords1:「始」词A1,词A2「末」,\ncommand2:「始」UpdateGroups「末」,\ngroupname2:「始」组名B「末」,\ngroupwords2:「始」词B1,词B2「末」\n<<<[END_TOOL_REQUEST]>>>",
         "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand:「始」UpdateGroups「末」,\ngroupname:「始」科幻概念「末」,\ngroupwords:「始」戴森球,曲率引擎,赛博朋克「末」\n<<<[END_TOOL_REQUEST]>>>"
+      },
+      {
+        "commandIdentifier": "SetWeight",
+        "description": "设置语义组的权重值。权重影响 RAG 检索时该组向量对查询增强的贡献（groupWeight = weight × activationStrength）。\n参数:\n- groupname (字符串, 必需): 组名，多个组用英文逗号分隔可批量设置同一权重。\n- weight (数字, 必需): 大于 0 的有限数字。1 = 默认，0 到 1 之间 = 减弱，>1 = 增强。当前 RAG 管线使用回退表达式，因此不接受 0。\n\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand:「始」SetWeight「末」,\ngroupname:「始」绘画与视觉创作「末」,\nweight:「始」1.5「末」\n<<<[END_TOOL_REQUEST]>>>\n\n串语法批量:\n<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand1:「始」SetWeight「末」,\ngroupname1:「始」绘画与视觉创作「末」,\nweight1:「始」1.5「末」,\ncommand2:「始」SetWeight「末」,\ngroupname2:「始」代码实现与工程「末」,\nweight2:「始」0.8「末」\n<<<[END_TOOL_REQUEST]>>>",
+        "example": "<<<[TOOL_REQUEST]>>>\ntool_name:「始」SemanticGroupEditor「末」,\ncommand:「始」SetWeight「末」,\ngroupname:「始」绘画与视觉创作「末」,\nweight:「始」1.5「末」\n<<<[END_TOOL_REQUEST]>>>"
       }
     ]
   }


### PR DESCRIPTION
## 改动概述将 SemanticGroupEditor 升级至 v2.0，补齐按组查询、组权重编辑和统一串语法支持。
主要改动
1. QueryGroups 支持定向查询

不传 groupname 时继续列举全部语义组
传入 groupname 时只查询指定组
多个组名使用英文逗号分隔
查询结果同时显示组权重、词元数量和自动学习词元
不存在的组名会在回执中明确列出

2. 新增 SetWeight

支持设置单个语义组的权重
支持多个组设置同一权重
只接受大于 0 的有限数字
拒绝 0、负数、Infinity、NaN、尾随字符和空值
权重会由 SemanticGroupManager 同步，并参与groupWeight = weight × activationStrength 的查询向量增强逻辑

3. 所有命令统一支持串语法

支持 command1 / command2 / ... 数字后缀
支持 QueryGroups、UpdateGroups、SetWeight 混合编排
按数字编号顺序执行
支持稀疏编号和两位数编号
避免 command1 与 command11 的参数串线
聚合返回每一步的成功或失败结果

4. 写入与兼容性

更新既有组时保留 weight、auto_learned、vector_id 等元数据
新建组默认 weight=1
写入采用临时文件加 rename，避免生成半截 JSON
支持通过 SEMANTIC_GROUPS_PATH 指向隔离测试夹具
未增加管理员权限声明
删除语义组仍交由管理面板处理

测试
隔离单元测试 17/17 通过，覆盖：

全量与定向查询权重
单组与多组设置权重
非法权重拒绝
更新词元时保留元数据
新建组默认值
稀疏编号与两位数串语法
command1 / command11 参数隔离
混合成功和失败步骤回执
manifest 与实现命令一致
测试前后生产 semantic_groups.edit.json SHA-256 不变

