### PR TITLE
chore(gitignore): ignore MediaRenderer outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,6 +248,10 @@ image/sensegen/
 image/webuigen/
 image/zimagegen/
 
+# MediaRenderer 渲染输出
+image/media-renderer/
+file/media-renderer/
+
 # 网络抓取图片输出
 image/urlfetch/
 


### PR DESCRIPTION
## 改动

在根目录 `.gitignore` 中新增：

- `image/media-renderer/`
- `file/media-renderer/`

## 原因

MediaRenderer 会在运行时将渲染结果写入上述目录：

- PNG、JPG、WebP、GIF → `image/media-renderer/`
- WAV、MP4、WebM → `file/media-renderer/`

产物文件名包含时间戳和随机后缀，属于运行时生成文件，不应进入 Git 工作区。

## 影响

没啥影响，工作树干净些。