### PR TITLE
fix(VSearch): suppress dotenv v17 stdout banner that breaks stdio JSON protocol

### DIFF
--- a/Plugin/VSearch/VSearch.js
+++ b/Plugin/VSearch/VSearch.js
@@ -10,7 +10,7 @@ const configPath = path.resolve(__dirname, './config.env');
 const rootConfigPath = path.resolve(__dirname, '../../config.env');
 const manifestPath = path.resolve(__dirname, './plugin-manifest.json');
 
-dotenv.config({ path: configPath });
+dotenv.config({ path: configPath, quiet: true });
 
 const {
     VSearchKey: API_KEY,


### PR DESCRIPTION
## 问题 / Problem

`Plugin/VSearch/package.json` 声明 `dotenv: ^17.4.2`。dotenv v17 在 `config()` 时会向 **stdout** 打印横幅：

```
◇ injected env (11) from config.env // tip: ...
```

VSearch 与 PluginManager 走 stdio 协议、stdout 必须是纯 JSON，横幅排在 JSON 响应之前，导致每次调用都失败：

```
[PluginManager executePlugin Internal] Failed to parse final stdout JSON from plugin "VSearch".
Error: Unexpected token ◇, "◇ injected"... is not valid JSON
```

VSearch.js 自身的日志已经全部走 stderr（设计意图正确），唯一污染源就是 dotenv 的横幅。主仓库 `package.json` 用的是 `^16.5.0`（无横幅），所以只有 VSearch 受影响。

## 修复 / Fix

一行改动：`dotenv.config({ path: configPath, quiet: true })`，恢复 v16 的静默行为。

在 Linux (node v22) 实测：修复前 stdout 首行为横幅，修复后 stdout 为纯 JSON。