### PR TITLE
fix(dailynote): align filenames with explicit time prefixes

### DIFF
--- a/Plugin/DailyNote/dailynote.js
+++ b/Plugin/DailyNote/dailynote.js
@@ -603,8 +603,26 @@ async function processLocalFiles(content) {
 }
 
 // --- 'create' Command Logic ---
-function contentStartsWithAiTimePrefix(content) {
-    return /^\s*\[\d{1,2}:\d{2}(?::\d{2})?\](?=\s|$)/.test(content);
+const DIARY_TIME_PREFIX_RE =
+    /^\s*\[([0-9]{1,2}):([0-9]{2})(?::([0-9]{2}))?\](?=\s|$)/;
+
+function parseLeadingDiaryTimePrefix(content) {
+    if (typeof content !== 'string') {
+        return null;
+    }
+
+    const match = DIARY_TIME_PREFIX_RE.exec(content);
+    if (!match) {
+        return null;
+    }
+
+    // Keep this syntax-based rather than enforcing real-world clock ranges:
+    // diary timestamps may represent fictional or otherwise custom time systems.
+    return {
+        hours: match[1].padStart(2, '0'),
+        minutes: match[2],
+        seconds: match[3] ?? null
+    };
 }
 
 async function handleCreateCommand(args) {
@@ -672,10 +690,14 @@ async function handleCreateCommand(args) {
 
         const datePart = dateString.replace(/[.\\\/\s-]/g, '-').replace(/-+/g, '-');
         const now = new Date();
-        const hours = now.getHours().toString().padStart(2, '0');
-        const minutes = now.getMinutes().toString().padStart(2, '0');
-        const seconds = now.getSeconds().toString().padStart(2, '0');
-        const timeStringForFile = `${hours}_${minutes}_${seconds}`;
+        const runtimeHours = now.getHours().toString().padStart(2, '0');
+        const runtimeMinutes = now.getMinutes().toString().padStart(2, '0');
+        const runtimeSeconds = now.getSeconds().toString().padStart(2, '0');
+        const explicitTime = parseLeadingDiaryTimePrefix(processedContent);
+        const fileHours = explicitTime?.hours ?? runtimeHours;
+        const fileMinutes = explicitTime?.minutes ?? runtimeMinutes;
+        const fileSeconds = explicitTime?.seconds ?? runtimeSeconds;
+        const timeStringForFile = `${fileHours}_${fileMinutes}_${fileSeconds}`;
 
         const dirPath = path.join(dailyNoteRootPath, sanitizedFolderName);
 
@@ -704,8 +726,8 @@ async function handleCreateCommand(args) {
 
         await fs.mkdir(dirPath, { recursive: true });
 
-        const timeStringForContent = `${hours}:${minutes}`;
-        const fileContent = contentStartsWithAiTimePrefix(processedContent)
+        const timeStringForContent = `${runtimeHours}:${runtimeMinutes}`;
+        const fileContent = explicitTime
             ? `[${datePart}] - ${actualMaidName}\n${processedContent}`
             : `[${datePart}] - ${actualMaidName}\n[${timeStringForContent}]\n${processedContent}`;
 


### PR DESCRIPTION
## 背景

DailyNote 创建日记时，文件名的日期来自调用参数 `Date`，时分秒则来自插件临近落盘时的系统时间。

如果 Agent 在午夜前生成日记内容，而 DailyNote 请求在午夜后进入常驻队列并执行，就可能生成类似：

- 正文日期与内容时间：`2026-09-01`、`[23:58]`
- 文件名时间：`2026-09-01-00_01_12`

文件内容与落盘过程均正常，但文件名混合了叙事日期和执行时刻，同一天内的文件排序也会偏离正文声明的时间。

## 改动

将现有的 `contentStartsWithAiTimePrefix()` 布尔检测升级为结构化解析器 `parseLeadingDiaryTimePrefix()`。

新逻辑继续使用原有时间前缀语法：

- `[H:MM]`
- `[HH:MM]`
- `[H:MM:SS]`
- `[HH:MM:SS]`

文件名生成规则：

1. 正文没有显式时间前缀时，时分秒继续全部使用执行时钟；
2. 正文提供 `[HH:MM]` 时，文件名采用显式时分，秒继续采用执行时钟；
3. 正文提供 `[HH:MM:SS]` 时，文件名采用完整的显式时分秒；
4. `Date` 继续控制年月日；
5. 文件系统 mtime 继续记录真实落盘时间。

正文是否需要自动补写 `[HH:MM]` 也复用同一个解析结果，避免检测逻辑与文件名解析逻辑未来发生漂移。

## 兼容性

本次改动没有扩大原正则的接受集合，只把原有布尔识别结果升级为结构化捕获。

解析器继续保持：

- 只识别正文第一个非空白 token；
- 只识别 ASCII 方括号、冒号和数字；
- 小时为 1～2 位，分钟和秒为 2 位；
- 右括号后必须为空白或正文结束；
- 秒字段可选。

时间仅作为日记声明的文本坐标处理，没有增加现实钟表范围校验。因此 `[28:75:91]` 等架空世界时间仍可按既有语法被识别，不会被 JavaScript 日期逻辑归一化。

## 影响范围

仅修改：

`Plugin/DailyNote/dailynote.js`

以下行为保持原样：

- 日记正文格式；
- Tag 处理；
- folder / maid 解析；
- `wx` 原子排他创建和重名后缀；
- DailyNote 常驻 FIFO 队列；
- KnowledgeBaseManager 索引协调；
- update 命令；
- 既有日记文件。

没有新增参数、依赖、数据库迁移或历史文件重命名。

## 验证

使用固定执行时钟 `2026-09-02 00:01:12` 完成验证：

- Node 语法检查：PASS
- Git Diff 空白检查：PASS
- 旧正则与新解析器接受集合对照：21 项 PASS
- 真实 `handleCreateCommand()` 创建场景：11 项 PASS
- 同名同秒原子冲突回退：PASS

关键结果：

- `[23:58]` → `2026-09-01-23_58_12.txt`
- `[23:58:47]` → `2026-09-01-23_58_47.txt`
- `[9:08]` → `2026-09-01-09_08_12.txt`
- `Date: 4372-13-45` + `[28:75:91]` → `4372-13-45-28_75_91.txt`
- 无时间前缀或不符合既有语法的前缀继续回退执行时钟
- 同名同秒的第二篇文件继续正确追加 `(2)`