### PR TITLE
fix(VCPBridgeServer): 补充 GET /v1/models 与 /v1/:profile/models 探活路由，兼容第三方客户端连通性检查

### DIFF
--- a/Plugin/VCPBridgeServer/bridgeserver.js
+++ b/Plugin/VCPBridgeServer/bridgeserver.js
@@ -878,7 +878,13 @@ function resolveUpstreamEndpoint(model, stream) {
 
 async function proxyRequest(req, res, { messages, model, body, downstreamFormat }) {
     // 0. 解析 Profile（请求级动态切换）
+    if (runtimeConfig.debugMode) {
+        console.log(`[VCPBridgeServer] Incoming: path=${req.path} | rawModel=${model} | headerProfile=${req.headers['x-bridge-profile']}`);
+    }
     const profileConfig = resolveProfileForRequest(req, model);
+    if (runtimeConfig.debugMode) {
+        console.log(`[VCPBridgeServer] Matched profile: ${profileConfig ? profileConfig.name : 'NONE (fallback to global)'}`);
+    }
 
     // 如果 profile 通过 model 前缀提取了真实 model，使用它
     const effectiveModel = profileConfig?._extractedModel || model;
@@ -998,6 +1004,27 @@ function startServer() {
             modelMap: runtimeConfig.modelMap,
             configPath: runtimeConfig.configPath
         });
+    });
+
+    // 模型列表探活（支持 OpenAI 根端点与 Profile 前缀端点，兼容客户端连通性检查）
+    app.get(['/v1/models', '/v1/:profile/models'], (req, res, next) => {
+        const profile = req.params?.profile;
+        if (profile && ['chat', 'responses', 'messages', 'beta'].includes(profile)) {
+            return next();
+        }
+        const configuredModels = new Set([
+            runtimeConfig.defaultModel,
+            ...Object.keys(runtimeConfig.modelMap || {}),
+            ...Object.values(runtimeConfig.modelMap || {})
+        ].filter(Boolean));
+        if (configuredModels.size === 0) configuredModels.add('gpt-5.6-sol');
+        const data = Array.from(configuredModels).map(id => ({
+            id,
+            object: 'model',
+            created: 1700000000,
+            owned_by: 'vcp-bridge'
+        }));
+        res.json({ object: 'list', data });
     });
 
     // ─── Profile-prefixed routes ─────────────────────────────────────────


### PR DESCRIPTION
### 改动内容 (What)
1. 在 `Plugin/VCPBridgeServer/bridgeserver.js` 中新增 `GET /v1/models` 与 `GET /v1/:profile/models` 路由，动态提取当前已配置的模型（`defaultModel` 及 `modelMap`），返回符合 OpenAI REST 规范的标准模型列表。
2. 路由内部内置了保留关键字防护（如 `chat`、`responses`、`messages` 等非 profile 路径自动调用 `next()` 交由下游处理）。
3. 将请求入口处的调试探测日志收敛在 `runtimeConfig.debugMode` 门控下，默认运行不污染控制台输出。

### 改动原因 (Why)
许多第三方客户端及 API 管理工具（如 OpenAI Codex 桌面端、CC Switch、ChatBox、NextChat 等）在添加新接口或初次握手时，会默认向 `{base_url}/models` 发起 `GET` 请求进行服务存活性探测（Health Check）与模型列表发现。
在此之前，`VCPBridgeServer` 仅注册了面向补全推理的 POST 路由与独立的 `/health` 端点，导致针对 `/v1/models` 或带有 Profile 路径前缀（如 `/v1/:profile/models`）的探活请求全部返回 404 Not Found，进而被客户端误判为服务离线并拒绝建立连接。补充该标准端点能够显著改善对通用生态客户端的兼容性。

### 测试验证 (How)
- **多端点探活实测**：通过本地脚本向 `http://127.0.0.1:6003/v1/models` 及 `http://127.0.0.1:6003/v1/{profile}/models` 分别发起 GET 请求，均稳定返回 HTTP 200 及结构严整的标准 Model List JSON。
- **第三方客户端联调**：在 CC Switch 与外部客户端中配置网关地址后，连通性测试秒级绿灯通过，会话发起与多 Profile 分流均正常闭环。