### PR TITLE
统一日记正文与 Tag 的空行格式（日记写入、Tag 补充、批量打标）

### DIFF
--- a/Plugin/DailyNote/dailynote.js
+++ b/Plugin/DailyNote/dailynote.js
@@ -288,7 +288,10 @@ async function resolveDiaryFolderName(folderName, options = {}) {
 // --- Tag Processing Functions (for 'create' command) ---
 
 function detectTagLine(content) {
-    const lines = content.split('\n');
+    const lines = content.split(/\r?\n/);
+    while (lines.length > 1 && lines[lines.length - 1].trim() === '') {
+        lines.pop();
+    }
     if (lines.length === 0) {
         return { hasTag: false, lastLine: '', contentWithoutLastLine: content };
     }
@@ -462,7 +465,7 @@ async function processTags(contentText, externalTag) {
         }
         const fixedTag = fixTagFormat(externalTag);
         const contentBody = detection.hasTag ? detection.contentWithoutLastLine : contentText;
-        return contentBody.trimEnd() + '\n' + fixedTag;
+        return contentBody.trimEnd() + '\n\n' + fixedTag;
     }
 
     // Fallback to detecting tag in content
@@ -471,7 +474,7 @@ async function processTags(contentText, externalTag) {
         debugLog('Tag detected in content, fixing format...');
         const fixedTag = fixTagFormat(detection.lastLine);
         // Ensure there's exactly one newline before the tag.
-        return detection.contentWithoutLastLine.trimEnd() + '\n' + fixedTag;
+        return detection.contentWithoutLastLine.trimEnd() + '\n\n' + fixedTag;
     }
 
     if (TAG_MASTER_ENABLED) {
@@ -480,7 +483,7 @@ async function processTags(contentText, externalTag) {
         if (generatedTag) {
             const fixedTag = fixTagFormat(generatedTag);
             debugLog('Generated and appended tag:', fixedTag);
-            return contentText.trimEnd() + '\n' + fixedTag;
+            return contentText.trimEnd() + '\n\n' + fixedTag;
         }
 
         console.warn('[DailyNote] TagMaster enabled but failed to generate tags. Falling back to missing-tag error.');

--- a/Plugin/DailyNoteManager/daily-note-manager.js
+++ b/Plugin/DailyNoteManager/daily-note-manager.js
@@ -89,7 +89,10 @@ function parseDateToNum(dateStr) {
 
 // --- Helper: Tag Processing (aligned with DailyNote plugin) ---
 function detectTagLine(content) {
-    const lines = content.split('\n');
+    const lines = content.split(/\r?\n/);
+    while (lines.length > 1 && lines[lines.length - 1].trim() === '') {
+        lines.pop();
+    }
     if (lines.length === 0) {
         return { hasTag: false, lastLine: '', contentWithoutLastLine: content };
     }
@@ -126,12 +129,12 @@ function processTags(contentText, externalTag) {
     if (externalTag && typeof externalTag === 'string' && externalTag.trim() !== '') {
         const fixedTag = fixTagFormat(externalTag);
         const contentBody = detection.hasTag ? detection.contentWithoutLastLine : contentText;
-        return contentBody.trimEnd() + '\n' + fixedTag;
+        return contentBody.trimEnd() + '\n\n' + fixedTag;
     }
 
     if (detection.hasTag) {
         const fixedTag = fixTagFormat(detection.lastLine);
-        return detection.contentWithoutLastLine.trimEnd() + '\n' + fixedTag;
+        return detection.contentWithoutLastLine.trimEnd() + '\n\n' + fixedTag;
     }
 
     throw new Error("Tag is missing. Please provide a 'Tag' argument or add a 'Tag:' line at the end of the 'Content'.");

--- a/scripts/diary-tag-batch-processor.js
+++ b/scripts/diary-tag-batch-processor.js
@@ -54,7 +54,10 @@ function error(message, ...args) {
  * 检查最后一行是否为Tag行
  */
 function detectTagLine(content) {
-    const lines = content.split('\n');
+    const lines = content.split(/\r?\n/);
+    while (lines.length > 1 && lines[lines.length - 1].trim() === '') {
+        lines.pop();
+    }
     if (lines.length === 0) {
         return { hasTag: false, lastLine: '', contentWithoutLastLine: content };
     }
@@ -302,13 +305,15 @@ async function processFile(filePath) {
         let finalContent = content;
         
         if (detection.hasTag) {
-            if (isTagFormatValid(detection.lastLine)) {
+            const fixedTag = fixTagFormat(detection.lastLine);
+            const canonicalContent = detection.contentWithoutLastLine.trimEnd() + '\n\n' + fixedTag;
+
+            if (isTagFormatValid(detection.lastLine) && canonicalContent === content) {
                 log(`  ✓ Tag format is valid`);
                 stats.skipped++;
             } else {
-                log(`  ⚠ Tag format needs fixing`);
-                const fixedTag = fixTagFormat(detection.lastLine);
-                finalContent = detection.contentWithoutLastLine + '\n' + fixedTag;
+                log(`  ⚠ Tag format or body/tag spacing needs fixing`);
+                finalContent = canonicalContent;
                 modified = true;
                 stats.fixed++;
                 log(`  ✓ Fixed tag: ${fixedTag}`);
@@ -320,7 +325,7 @@ async function processFile(filePath) {
             
             if (generatedTag) {
                 const fixedTag = fixTagFormat(generatedTag);
-                finalContent = content + '\n' + fixedTag;
+                finalContent = content.trimEnd() + '\n\n' + fixedTag;
                 modified = true;
                 stats.generated++;
                 log(`  ✓ Generated tag: ${fixedTag}`);


### PR DESCRIPTION
不管是日记写入，还是 Tag 审查后的补充，或者批量打标，保证日记正文和 Tag 行之间有且只有一个空行。